### PR TITLE
Fixed #017703: Fatal error when deleting main node having ezfind enabled

### DIFF
--- a/kernel/content/ezcontentoperationcollection.php
+++ b/kernel/content/ezcontentoperationcollection.php
@@ -936,6 +936,14 @@ class eZContentOperationCollection
             if ( !isset( $objectIdList[$objectId] ) )
                 $objectIdList[$objectId] = eZContentObject::fetch( $objectId );
         }
+        
+        foreach ( array_keys( $mainNodeChanged ) as $objectId )
+        {
+            $allNodes = $objectIdList[$objectId]->assignedNodes();
+            // Registering node that will be promoted as 'main'
+            $mainNodeChanged[$objectId] = $allNodes[0];
+            eZContentObjectTreeNode::updateMainNodeID( $allNodes[0]->attribute( 'node_id' ), $objectId, false, $allNodes[0]->attribute( 'parent_node_id' ) );
+        }
 
         // Give other search engines that the default one a chance to reindex
         // when removing locations.
@@ -945,15 +953,7 @@ class eZContentOperationCollection
                 eZContentOperationCollection::registerSearchObject( $objectId, $object->attribute( 'current_version' ) );
         }
 
-        eZNodeAssignment::purgeByID( array_keys( $nodeAssignmentIdList ) );
-
-        foreach ( array_keys( $mainNodeChanged ) as $objectId )
-        {
-            $allNodes = $objectIdList[$objectId]->assignedNodes();
-            // Registering node that will be promoted as 'main'
-            $mainNodeChanged[$objectId] = $allNodes[0];
-            eZContentObjectTreeNode::updateMainNodeID( $allNodes[0]->attribute( 'node_id' ), $objectId, false, $allNodes[0]->attribute( 'parent_node_id' ) );
-        }
+        eZNodeAssignment::purgeByID( array_keys( $nodeAssignmentIdList ) );        
 
         $db->commit();
 


### PR DESCRIPTION
when you start deleting main node, removeNodes operation do it and execute  registerSearchObject operation. 
But addObject from ezsolr relies on mainNode and in that moment there is no mainNode at all. Main Node is updated after de registerSearchObject op. 
This fix makes the update main node op before calling the registerSearchObject.
