### PR TITLE
Heliopsis

### DIFF
--- a/kernel/classes/ezcontentobject.php
+++ b/kernel/classes/ezcontentobject.php
@@ -2881,7 +2881,8 @@ class eZContentObject extends eZPersistentObject
         $db = eZDB::instance();
         $sortingString = '';
         $sortingInfo = array( 'attributeFromSQL' => '',
-                              'attributeWhereSQL' => '' );
+                              'attributeWhereSQL' => '',
+                              'attributeTargetSQL' => '' );
 
         $showInvisibleNodesCond = '';
         // process params (only SortBy and IgnoreVisibility currently supported):
@@ -2979,6 +2980,7 @@ class eZContentObject extends eZPersistentObject
                         ezcontentclass.identifier as contentclass_identifier,
                         ezcontentclass.is_container as is_container,
                         ezcontentobject.* $versionNameTargets
+                        $sortingInfo[attributeTargetSQL]
                      FROM
                         ezcontentclass,
                         ezcontentobject,


### PR DESCRIPTION
Hi,
I fixed a bug I found in the query building of eZContentObject::relatedObjects.
The bug was revealed while trying to sort results by class_name : though generated by eZContentObjectTreeNode::createSortingSQLStrings() target fields string was not added to the SQL query resulting in an SQL error.

I guess you should check if it has been forgeted in other fetch functions...
