### PR TITLE
Spanish translation

### DIFF
--- a/share/translations/esl-ES/translation.ts
+++ b/share/translations/esl-ES/translation.ts
@@ -27373,7 +27373,7 @@ si has elegido la opción &quot;%3&quot; desde &quot;%4&quot; </translation>
     </message>
     <message>
         <source>Content object limits</source>
-        <translation>Limites de objeto de contenido</translation>
+        <translation>Límites de objeto de contenido</translation>
     </message>
     <message>
         <source>Content object export</source>


### PR DESCRIPTION
Some spanish translation. Main one is related to the word menu. in spanish it should say 'menú' 
http://es.wikipedia.org/wiki/Men%C3%BA_(inform%C3%A1tica)
Also some other minor typos fixed. 

p.s. probably log message should says something about spanish... is there any way to change it? 
