### PR TITLE
Stable 4.4

### DIFF
--- a/kernel/classes/ezcontentobjecttreenode.php
+++ b/kernel/classes/ezcontentobjecttreenode.php
@@ -1561,12 +1561,12 @@ class eZContentObjectTreeNode extends eZPersistentObject
         if ( is_array( $limitationList ) && count( $limitationList ) > 0 )
         {
             $sqlParts = array();
+            $stateLimit=false;
             foreach( $limitationList as $limitationArray )
             {
                 $sqlPartPart = array();
                 $sqlPartPartPart = array();
                 $sqlPlacementPart = array();
-
                 foreach ( array_keys( $limitationArray ) as $ident )
                 {
                     switch( $ident )
@@ -1642,7 +1642,7 @@ class eZContentObjectTreeNode extends eZPersistentObject
                             if ( strncmp( $ident, 'StateGroup_', 11 ) === 0 )
                             {
                                 $stateIdentifier = substr( $ident, 11 );
-
+                                $sqlPartPartSuffix='';
                                 if ( !isset( $createdStateAliases[$stateIdentifier] ) )
                                 {
                                     $stateIndex = count( $createdStateAliases );
@@ -1655,28 +1655,21 @@ class eZContentObjectTreeNode extends eZPersistentObject
 
                                 if ( !isset( $createdStateAliases[$stateIdentifier] ) )
                                 {
+                                    $stateLimit=true;
                                     $createdStateAliases[$stateIdentifier] = $stateIndex;
-                                    $stateLinkTable =  "ezcobj_state_lnk_{$stateIndex}_perm";
-                                    $stateGroupTable = "ezcobj_state_grp_{$stateIndex}_perm";
-                                    $stateAliasTables[$stateIdentifier] = $stateTable;
 
-                                    $sqlPermissionCheckingFrom .= ", ezcobj_state_link $stateLinkTable ";
-                                    $sqlPermissionCheckingFrom .= ", ezcobj_state_group $stateGroupTable ";
-                                    $sqlPermissionCheckingFrom .= ", ezcobj_state $stateTable ";
-
-                                    $sqlPermissionCheckingWhere .= "AND $stateLinkTable.contentobject_id = ezcontentobject.id " .
-                                                                   "AND $stateTable.id = $stateLinkTable.contentobject_state_id " .
-                                                                   "AND $stateTable.group_id = $stateGroupTable.id " .
-                                                                   "AND $stateGroupTable.identifier='" . $db->escapeString( $stateIdentifier ) . "' ";
+                                    $sqlPartPartSuffix = "AND ezcobj_state.id = ezcobj_state_link.contentobject_state_id " .
+                                                                   "AND ezcobj_state.group_id = ezcobj_state_group.id " .
+                                                                   "AND ezcobj_state_group.identifier='" . $db->escapeString( $stateIdentifier ) . "' ";
                                 }
 
                                 if ( count( $limitationArray[$ident] ) > 1 )
                                 {
-                                    $sqlPartPart[] = $db->generateSQLINStatement( $limitationArray[$ident], "$stateTable.id" );
+                                    $sqlPartPart[] = $db->generateSQLINStatement( $limitationArray[$ident], "ezcobj_state.id" ).' '.$sqlPartPartSuffix;
                                 }
                                 else
                                 {
-                                    $sqlPartPart[] = "$stateTable.id = " . $limitationArray[$ident][0];
+                                    $sqlPartPart[] = "ezcobj_state.id = " . $limitationArray[$ident][0].' '.$sqlPartPartSuffix;
                                 }
                             }
                         }
@@ -1693,6 +1686,13 @@ class eZContentObjectTreeNode extends eZPersistentObject
                 $sqlParts[] = implode( ' AND ', $sqlPartPart );
             }
             $sqlPermissionCheckingWhere .= ' AND ((' . implode( ") OR (", $sqlParts ) . ')) ';
+        }
+        if ($stateLimit)
+        {
+            $sqlPermissionCheckingWhere .= "AND ezcobj_state_link.contentobject_id = ezcontentobject.id".$sqlPermissionCheckingWhere; 
+            $sqlPermissionCheckingFrom .= ", ezcobj_state_link ";
+            $sqlPermissionCheckingFrom .= ", ezcobj_state_group ";
+            $sqlPermissionCheckingFrom .= ", ezcobj_state ";                    
         }
 
         $sqlPermissionChecking = array( 'from' => $sqlPermissionCheckingFrom,


### PR DESCRIPTION
http://issues.ez.no/IssueView.php?Id=17881&activeItem=6
#017881: To many states and policies lead to slow fetch node sql request

Description:
To many states and policies lead to slow fetch node sql request

behavior found : 
- very slow access to content
- the main fetch node sql query is very slow (about 50 seconds on my server)

Cause : 
the main fetch node sql query uses 3 table aliases for each state, which leads to very slow sql requests.

Patch : see commit log
