### PR TITLE
Change subtree fetch request to allow faster queries with many content states

### DIFF
--- a/kernel/classes/ezcontentobjecttreenode.php
+++ b/kernel/classes/ezcontentobjecttreenode.php
@@ -1557,7 +1557,7 @@ class eZContentObjectTreeNode extends eZPersistentObject
         $sqlPermissionTempTables = array();
         $groupPermTempTable = false;
         $createdStateAliases = array();
-        $stateLimit=false;
+        $stateLimit = false;
 
         if ( is_array( $limitationList ) && count( $limitationList ) > 0 )
         {
@@ -1642,8 +1642,8 @@ class eZContentObjectTreeNode extends eZPersistentObject
                             if ( strncmp( $ident, 'StateGroup_', 11 ) === 0 )
                             {
                                 $stateIdentifier = substr( $ident, 11 );
-                                $sqlPartPartSuffix='';
-                                $stateLimit=true;
+                                $sqlPartPartSuffix = '';
+                                $stateLimit = true;
 
                                 $sqlPartPartSuffix = "AND ezcobj_state.id = ezcobj_state_link.contentobject_state_id " .
                                                                "AND ezcobj_state.group_id = ezcobj_state_group.id " .
@@ -1651,11 +1651,11 @@ class eZContentObjectTreeNode extends eZPersistentObject
 
                                 if ( count( $limitationArray[$ident] ) > 1 )
                                 {
-                                    $sqlPartPart[] = $db->generateSQLINStatement( $limitationArray[$ident], "ezcobj_state.id" ).' '.$sqlPartPartSuffix;
+                                    $sqlPartPart[] = $db->generateSQLINStatement( $limitationArray[$ident], "ezcobj_state.id" ) . ' ' . $sqlPartPartSuffix;
                                 }
                                 else
                                 {
-                                    $sqlPartPart[] = "ezcobj_state.id = " . $limitationArray[$ident][0].' '.$sqlPartPartSuffix;
+                                    $sqlPartPart[] = "ezcobj_state.id = " . $limitationArray[$ident][0] . ' ' . $sqlPartPartSuffix;
                                 }
                             }
                         }
@@ -1673,7 +1673,7 @@ class eZContentObjectTreeNode extends eZPersistentObject
             }
             $sqlPermissionCheckingWhere .= ' AND ((' . implode( ") OR (", $sqlParts ) . ')) ';
         }
-        if ($stateLimit)
+        if ( $stateLimit )
         {
             $sqlPermissionCheckingWhere .= "AND ezcobj_state_link.contentobject_id = ezcontentobject.id".$sqlPermissionCheckingWhere; 
             $sqlPermissionCheckingFrom .= ", ezcobj_state_link ";


### PR DESCRIPTION
http://issues.ez.no/IssueView.php?Id=17881 : 

To many states and policies lead to slow fetch node sql request

behavior found : 
- very slow access to content
- the main fetch node sql query is very slow (about 50 seconds on my server)

Cause : 
the mainfetch node sql query uses 3 table aliases for each state, which leads to very slow sql requests.

Resolved : 
ezcontentobjecttreenode.php attached and git pull request comming

could you please update the stable-4.4 branch to the real 4.4 sources ?

It seems like there's a lot of old code in that branch.
