### PR TITLE
Fixed bug in eZSection

### DIFF
--- a/kernel/classes/ezsection.php
+++ b/kernel/classes/ezsection.php
@@ -100,6 +100,11 @@ class eZSection extends eZPersistentObject
                                                        null,
                                                        array( "identifier" => $sectionIdentifier ),
                                                        $asObject );
+            if( !$sectionFetched )
+            {
+                return null;
+            }
+
             if( $asObject )
             {
                 // the section identifier index refers to the id index object


### PR DESCRIPTION
ezSection::fetchByIdentifier() now returns null if no section is found.

Method attribute() was called even if no matching section was found.
