### PR TITLE
Fixed #018353: Node view override keys parent_node_remote_id and parent_o

### DIFF
--- a/kernel/common/eztemplateautoload.php
+++ b/kernel/common/eztemplateautoload.php
@@ -251,7 +251,9 @@ if ( !function_exists( 'eZObjectForwardInit' ) )
                                                                      'url_alias' => array( 'url_alias' ),
                                                                      'remote_id' => array( 'object', 'remote_id' ),
                                                                      'node_remote_id' => array( 'remote_id' ),
-                                                                     'parent_class_identifier' => array( 'parent', 'class_identifier' ) ),
+                                                                     'parent_class_identifier' => array( 'parent', 'class_identifier' ),
+                                                                     'parent_node_remote_id' => array( 'parent', 'remote_id'),
+                                                                     'parent_object_remote_id' => array( 'parent', 'object', 'remote_id') ),
                                           'attribute_access' => array(),
                                           'use_views' => 'view' ),
 


### PR DESCRIPTION
Fixed #018353: Node view override keys parent_node_remote_id and parent_object_remote_id don't work with node_view_gui

Code should be self explanatory. I missed that when implementing those 2 override keys.
