### PR TITLE
Issue #01842: eZFile::create() - ezfile-tmp* files remain when rename fails

### DIFF
--- a/lib/ezfile/classes/ezfile.php
+++ b/lib/ezfile/classes/ezfile.php
@@ -75,7 +75,11 @@ class eZFile
 
             if ( $atomic )
             {
-                eZFile::rename( $filepath, $realpath );
+                if ( !eZFile::rename( $filepath, $realpath ) )
+                {
+                    // If the renaming process fails, delete the temporary file
+                    unlink( $filepath );
+                }
             }
             return true;
         }


### PR DESCRIPTION
When the renaming process during file creation fails (for whatever reason, probably because another process is trying to do a similar rename), the previously created ezfile-tmp\* file remains in the file system.

With this patch, the ezfile-tmp\* file is deleted, if eZFile::rename() returns _false_.
