### PR TITLE
Correction of the bug #012922 and #018378

### DIFF
--- a/kernel/classes/ezsearch.php
+++ b/kernel/classes/ezsearch.php
@@ -99,10 +99,20 @@ class eZSearch
     static function search( $searchText, $params, $searchTypes = array() )
     {
         $searchEngine = eZSearch::getEngine();
-
+        $ini = eZINI::instance();
+        $logSearchStats = $ini->variable( 'SearchSettings', 'LogSearchStats' ) == 'enabled';
         if ( $searchEngine instanceof ezpSearchEngine )
         {
-            return $searchEngine->search( $searchText, $params, $searchTypes );
+            $result = $searchEngine->search( $searchText, $params, $searchTypes );
+            if ( $logSearchStats and
+                    trim( $searchText ) != "" and
+                     is_array( $result ) and
+                     array_key_exists( 'SearchCount', $result ) and
+                     is_numeric( $result['SearchCount'] ) )
+            {
+                eZSearchLog::addPhrase( $searchText, $result["SearchCount"] );
+            }
+            return $result;
         }
     }
 

--- a/kernel/classes/ezsearchlog.php
+++ b/kernel/classes/ezsearchlog.php
@@ -28,7 +28,11 @@ class eZSearchLog
         $phrase = $trans->transformByGroup( trim( $phrase ), 'lowercase' );
 
         $phrase = $db->escapeString( $phrase );
-
+        // 250 is the numbers of characters accepted by the DB table, so shorten to fit
+        if ( strlen( $phrase ) > 250 )
+        {
+            $phrase = substr( $phrase , 0 , 247 ) . "...";
+        }
         // find or store the phrase
         $phraseRes = $db->arrayQuery( "SELECT id FROM ezsearch_search_phrase WHERE phrase='$phrase'" );
 
@@ -42,12 +46,6 @@ class eZSearchLog
         }
         else
         {
-            // 250 is the numbers of characters accepted by the DB table, so shorten to fit
-            if ( strlen( $phrase ) > 250 )
-            {
-                $phrase = substr( $phrase , 0 , 247 ) . "...";
-            }
-
             $db->query( "INSERT INTO
                               ezsearch_search_phrase ( phrase, phrase_count, result_count )
                          VALUES ( '$phrase', 1, $returnCount )" );

--- a/kernel/content/search.php
+++ b/kernel/content/search.php
@@ -199,13 +199,4 @@ else
     $searchData = $searchResult;
 }
 
-if ( $logSearchStats and
-     trim( $searchText ) != "" and
-     is_array( $searchData ) and
-     array_key_exists( 'SearchCount', $searchData ) and
-     is_numeric( $searchData['SearchCount'] ) )
-{
-    eZSearchLog::addPhrase( $searchText, $searchData["SearchCount"] );
-}
-
 ?>


### PR DESCRIPTION
Correction of the bug #012922: Database transaction error when search phrase longer than 250 characters
the message had to be shorten if it is long for the table in the EZ database.
and 
Correction of the bug #18378 : add phrase for all search not only content/search.
