### PR TITLE
Autoload improvments

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -98,7 +98,7 @@ class ezpAutoloader
             $ezpTestClasses = require 'var/autoload/ezp_tests.php';
         }
 
-        if ( defined( 'EZP_AUTOLOAD_ALLOW_KERNEL_OVERRIDE' ) and EZP_AUTOLOAD_ALLOW_KERNEL_OVERRIDE )
+        if ( defined( 'EZP_AUTOLOAD_ALLOW_KERNEL_OVERRIDE' ) && EZP_AUTOLOAD_ALLOW_KERNEL_OVERRIDE )
         {
             if ( file_exists( 'var/autoload/ezp_override.php' ) )
             {
@@ -106,7 +106,7 @@ class ezpAutoloader
             }
         }
 
-        return array_merge( $ezpClasses, $ezpExtensionClasses, $ezpTestClasses, $ezpKernelOverrideClasses );
+        return $ezpKernelOverrideClasses + $ezpTestClasses + $ezpExtensionClasses + $ezpClasses;
     }
 
     /**
@@ -153,8 +153,8 @@ class ezpAutoloader
      */
     protected static function registerEzc()
     {
-        $useBundledComponents = defined( 'EZP_USE_BUNDLED_COMPONENTS' ) ? EZP_USE_BUNDLED_COMPONENTS === true : file_exists( 'lib/ezc' );
-        if ( $useBundledComponents )
+        $useBundled = defined( 'EZP_USE_BUNDLED_COMPONENTS' ) ? EZP_USE_BUNDLED_COMPONENTS : file_exists( 'lib/ezc' );
+        if ( $useBundled )
         {
             set_include_path( '.' . PATH_SEPARATOR . './lib/ezc' . PATH_SEPARATOR . get_include_path() );
             require 'Base/src/base.php';


### PR DESCRIPTION
- Cache all autload files into one cache file to remove any file_exist calls against non existing files during execution
- Lazy load ezcBase so that cached pages that does not use it don't get the overhead (also file_exist calls against non existing files)

Further possible improvement, add support for fallback to simple autoload convention loading if class name starts with "ezp\":

```
diff --git a/autoload.php b/autoload.php
index 245dba3..aefb498 100644
--- a/autoload.php
+++ b/autoload.php
@@ -73,6 +73,12 @@ class ezpAutoloader
         {
             return require( self::$ezpClasses[$className] );
         }
+
+        // Fallback to loading class by convention if it starts with ezp\ namespace
+        if ( strncmp( $className, 'ezp\\', 4 ) === 0 )
+        {
+            return require( str_replace( array('\\', '_'), DIRECTORY_SEPARATOR, $className ) . '.php' );
+        }
     }

     /**
```
