### PR TITLE
#018442: XML-Text in ezoption datatype is not encoded

### DIFF
--- a/kernel/classes/datatypes/ezoption/ezoption.php
+++ b/kernel/classes/datatypes/ezoption/ezoption.php
@@ -166,8 +166,8 @@ class eZOption
 
         foreach ( $this->Options as $option )
         {
-            unset( $optionNode );
             $optionNode = $doc->createElement( "option", $option["value"] );
+            $optionNode->appendChild( $doc->createCDATASection( $option["value"] ) );
             $optionNode->setAttribute( "id", $option['id'] );
             $optionNode->setAttribute( 'additional_price', $option['additional_price'] );
             $options->appendChild( $optionNode );


### PR DESCRIPTION
If you use html special chars like the ampersand in an ezoption input, the special chars get stripped out instead of encoded.

See: http://issues.ez.no/IssueView.php?Id=18442
