### PR TITLE
Depth uri in the HostUriMatchMapItems

### DIFF
--- a/kernel/classes/ezsiteaccess.php
+++ b/kernel/classes/ezsiteaccess.php
@@ -277,7 +277,7 @@ class eZSiteAccess
                     $type = eZSiteAccess::TYPE_HTTP_HOST_URI;
                     if ( $ini->hasVariable( 'SiteAccessSettings', 'HostUriMatchMapItems' ) )
                     {
-                        $match_item = $uri->element( 0 );
+                        $uirString = $uri->elements();
                         $matchMapItems = $ini->variableArray( 'SiteAccessSettings', 'HostUriMatchMapItems' );
                         $defaultHostMatchMethod = $ini->variable( 'SiteAccessSettings', 'HostUriMatchMethodDefault' );
 
@@ -288,7 +288,7 @@ class eZSiteAccess
                             $matchAccess     = $matchMapItem[2];
                             $matchHostMethod = isset( $matchMapItem[3] ) ? $matchMapItem[3] : $defaultHostMatchMethod;
 
-                            if ( $matchURI !== '' && $matchURI !== $match_item )
+                            if ( $matchURI !== '' && strpos($uriString, $matchURI) !== 0 )
                                 continue;
 
                             switch( $matchHostMethod )
@@ -320,9 +320,10 @@ class eZSiteAccess
                             {
                                 if ( $matchURI !== '' )
                                 {
-                                    $uri->increase( 1 );
+                                    $matchURIFolders = explode( '/', $matchURI );
+                                    $uri->increase( count( $matchURIFolders ) );
                                     $uri->dropBase();
-                                    $access['uri_part'] = array( $matchURI );
+                                    $access['uri_part'] = $matchURIFolders;
                                 }
                                 $access['name'] = $matchAccess;
                                 $access['type'] = $type;


### PR DESCRIPTION
Hi !

I made one commit to allow you to use depth uri in the "HostUriMatchMapItems" of your settings.
So you can has different siteaccess following uris like that : "paris/fr", "paris/en", "london/fr", "london/en".

Best regards,
Thomas.
