### PR TITLE
Allow ezuser datatype fromString to be used for updates

### DIFF
--- a/kernel/classes/datatypes/ezuser/ezusertype.php
+++ b/kernel/classes/datatypes/ezuser/ezusertype.php
@@ -444,8 +444,16 @@ class eZUserType extends eZDataType
         $login = $userData[0];
         $email = $userData[1];
 
-        if ( eZUser::fetchByName( $login ) || ( eZUser::requireUniqueEmail() && eZUser::fetchByEmail( $email ) ) )
+        $userByUsername = eZUser::fetchByName( $login );
+        if( $userByUsername && $userByUsername->attribute( 'contentobject_id' ) != $contentObjectAttribute->attribute( 'contentobject_id' ) )
             return false;
+
+        if( eZUser::requireUniqueEmail() )
+        {
+            $userByEmail = eZUser::fetchByEmail( $email );
+            if( $userByEmail && $userByEmail->attribute( 'contentobject_id' ) != $contentObjectAttribute->attribute( 'contentobject_id' ) )
+                return false;
+        }
 
         $user = eZUser::create( $contentObjectAttribute->attribute( 'contentobject_id' ) );
 


### PR DESCRIPTION
When creating a user, it's important to make sure there isn't an existing user with the same username or e-mail address (when RequireUniqueEmail is enforced).  However, when updating a user, this limitation should be lifted if the match is on the user that you're trying to update.
