### PR TITLE
The text part of the URL datatype ("_ezurl_text_") shouldn't be required

### DIFF
--- a/kernel/classes/datatypes/ezurl/ezurltype.php
+++ b/kernel/classes/datatypes/ezurl/ezurltype.php
@@ -69,7 +69,7 @@ class eZURLType extends eZDataType
             $url = $http->PostVariable( $base . "_ezurl_url_" . $contentObjectAttribute->attribute( "id" ) );
             $text = $http->PostVariable( $base . "_ezurl_text_" . $contentObjectAttribute->attribute( "id" ) );
             if ( $contentObjectAttribute->validateIsRequired() )
-                if ( ( $url == "" ) or ( $text == "" ) )
+                if ( $url == "" )
                 {
                     $contentObjectAttribute->setValidationError( ezpI18n::tr( 'kernel/classes/datatypes',
                                                                          'Input required.' ) );


### PR DESCRIPTION
The text part of the URL datatype ("_ezurl_text_") shouldn't be required since only URL part is esential in this datatype.
