### PR TITLE
#18423 Fallbacks for eZSys::hostname() and eZSys::serverPort()

### DIFF
--- a/lib/ezutils/classes/ezsys.php
+++ b/lib/ezutils/classes/ezsys.php
@@ -597,7 +597,7 @@ class eZSys
         if ( !$hostName )
         {
             $ini = eZINI::instance();
-            $siteUrl = $ini->variable( 'SiteSettings', 'SiteURL' );
+            $siteUrl = 'http://' . $ini->variable( 'SiteSettings', 'SiteURL' );
             $hostName = parse_url( $siteUrl, PHP_URL_HOST );
         }
 


### PR DESCRIPTION
This change is related to the issue http://issues.ez.no/IssueView.php?Id=18423.

During shell execution (or when other errors occur while accessing those variables), the variables $_SERVER['HTTP_HOST'] and $_SERVER['SERVER_PORT'] are not set.

This change introduces fallbacks:
- SiteURL from site.ini for $_SERVER['HTTP_HOST']
- 80 for $_SERVER['SERVER_PORT']

As the original poster pointed out, it would perhaps be a good idea to add Fallback-Variables in the site.ini ('FallbackHostname', 'FallbackPort'), but as this would require changes in ini files that would have to be adapted by the users, I would prefer my change here as an immediate fix, and after a discussion about the subject, the other changes in another pull request.

Best
- Jérôme
