### PR TITLE
Desactivate template debug in specific views

### DIFF
--- a/lib/eztemplate/classes/eztemplate.php
+++ b/lib/eztemplate/classes/eztemplate.php
@@ -2383,7 +2383,7 @@ class eZTemplate
             $instance = self::instance();
 
             $ini = eZINI::instance();
-            if ( $ini->variable( 'TemplateSettings', 'Debug' ) == 'enabled' )
+            if (!isset($GLOBALS['eZTemplateDebugInternalsEnabled']) && $ini->variable( 'TemplateSettings', 'Debug' ) == 'enabled' )
                 eZTemplate::setIsDebugEnabled( true );
 
             $compatAutoLoadPath = $ini->variableArray( 'TemplateSettings', 'AutoloadPath' );


### PR DESCRIPTION
Hi !

We already can desactivate debug output in specific view, for example in XML or JSON views :
`eZDebug::updateSettings(array( "debug-enabled" => false, "debug-by-ip" => false ));`

Unless I am mistaken, it's not easy to desactivate the template debug in the same views.
It's now possible by using the existing setter :
`eZTemplate::setIsDebugEnabled( false );`

Best regards,
Thomas.
