### PR TITLE
Refactoring of the method eZContentObjectTreeNode::urlAlias(). 

### DIFF
--- a/kernel/classes/ezcontentobjecttreenode.php
+++ b/kernel/classes/ezcontentobjecttreenode.php
@@ -5649,6 +5649,7 @@ class eZContentObjectTreeNode extends eZPersistentObject
     function urlAlias()
     {
         $useURLAlias =& $GLOBALS['eZContentObjectTreeNodeUseURLAlias'];
+        $ini = eZINI::instance();
         if ( !isset( $useURLAlias ) )
         {
             $useURLAlias = $ini->variable( 'URLTranslator', 'Translation' ) == 'enabled';
@@ -5656,7 +5657,6 @@ class eZContentObjectTreeNode extends eZPersistentObject
         if ( $useURLAlias )
         {
             $URL = $this->pathWithNames();
-            $ini = eZINI::instance();
             if ( $ini->hasVariable( 'SiteAccessSettings', 'PathPrefix' ) &&
                  $ini->variable( 'SiteAccessSettings', 'PathPrefix' ) != '' )
             {


### PR DESCRIPTION
Hi!

I made a little refactoring on the method eZContentObjectTreeNode::urlAlias().
The result does not change.
I just tried to avoid duplicate lines.

Best regards,
Thomas.
