### PR TITLE
Fix for #18642 - user/selfedit policy does not work without at least one content/edit and content/create policy

### DIFF
--- a/kernel/classes/ezcontentobject.php
+++ b/kernel/classes/ezcontentobject.php
@@ -4649,7 +4649,7 @@ class eZContentObject extends eZPersistentObject
                  $user = eZUser::currentUser();
                  if ( $user->attribute( 'contentobject_id' ) === $this->attribute( 'id' ) )
                  {
-                     $access = $user->hasAccessTo( 'user', 'selfedit' );
+                     $access = $user->hasAccessTo( 'content', 'selfedit' );
                      if ( $access['accessWord'] == 'yes' )
                      {
                          $canEdit = 1;
@@ -4675,7 +4675,7 @@ class eZContentObject extends eZPersistentObject
                  $user = eZUser::currentUser();
                  if ( $user->id() == $this->attribute( 'id' ) )
                  {
-                     $access = $user->hasAccessTo( 'user', 'selfedit' );
+                     $access = $user->hasAccessTo( 'content', 'selfedit' );
                      if ( $access['accessWord'] == 'yes' )
                      {
                          $this->Permissions["can_translate"] = 1;

--- a/kernel/classes/ezcontentobjecttreenode.php
+++ b/kernel/classes/ezcontentobjecttreenode.php
@@ -321,7 +321,7 @@ class eZContentObjectTreeNode extends eZPersistentObject
                  $user = eZUser::currentUser();
                  if ( $user->id() == $this->ContentObject->attribute( 'id' ) )
                  {
-                     $access = $user->hasAccessTo( 'user', 'selfedit' );
+                     $access = $user->hasAccessTo( 'content', 'selfedit' );
                      if ( $access['accessWord'] == 'yes' )
                      {
                          $this->Permissions["can_edit"] = 1;

--- a/kernel/content/module.php
+++ b/kernel/content/module.php
@@ -11,7 +11,7 @@ $Module = array( 'name' => 'eZContentObject',
 
 $ViewList = array();
 $ViewList['edit'] = array(
-    'functions' => array( 'edit or create' ),
+    'functions' => array( 'edit or create or selfedit' ),
     'default_navigation_part' => 'ezcontentnavigationpart',
     'ui_context' => 'edit',
     'single_post_actions' => array( 'PreviewButton' => 'Preview',
@@ -695,5 +695,6 @@ $FunctionList['restore'] = array();
 $FunctionList['cleantrash'] = array();
 $FunctionList['tipafriend'] = array();
 $FunctionList['dashboard'] = array();
+$FunctionList['selfedit'] = array();
 
 ?>

--- a/kernel/user/module.php
+++ b/kernel/user/module.php
@@ -121,6 +121,5 @@ $FunctionList['login'] = array( 'SiteAccess' => $SiteAccess );
 $FunctionList['password'] = array();
 $FunctionList['preferences'] = array();
 $FunctionList['register'] = array();
-$FunctionList['selfedit'] = array();
 
 ?>

--- a/settings/menu.ini
+++ b/settings/menu.ini
@@ -310,7 +310,7 @@ PolicyList_collaboration[]=collaboration/view
 Links[dashboard]=content/dashboard
 
 Links[edit_profile]=user/edit/(action)/edit
-PolicyList_edit_profile[]=user/selfedit
+PolicyList_edit_profile[]=content/selfedit
 
 Links[my_bookmarks]=content/bookmark
 PolicyList_my_bookmarks[]=content/bookmark


### PR DESCRIPTION
This is a fix for issue #18642 at http://issues.ez.no/IssueView.php?Id=18642&activeItem=1

Since user/selfedit is not in the content module, access to self editing is denied early in the index.php, because existing access function expression when self editing is only "(edit or create)". And when both of those are missing from policy list, user cannot edit himself.

I propose moving selfedit function from user module to content module which will allow for access function expression to be "(edit or create or selfedit)" thus allowing the module to run, and later relying on ($obj->canEdit()) to return a valid value based on match of current user ID and object ID to be edited.

If you think this is a welcome change, another pull request needs to be added to ezflow so new installs can create content/selfedit policies instead of user/selfedit.
