### PR TITLE
Enable custom HTTP headers to be set for only the front page

### DIFF
--- a/kernel/classes/ezhttpheader.php
+++ b/kernel/classes/ezhttpheader.php
@@ -121,7 +121,7 @@ class eZHTTPHeader
                         $headerValue = gmdate( 'D, d M Y H:i:s', time() + $headerValue ) . ' GMT';
                     }
 
-                    if ( $depth === null )
+                    if ( $depth === null || $uriString === $path )
                     {
                         $headerArray[$header] = $headerValue;
                     }
@@ -129,6 +129,10 @@ class eZHTTPHeader
                     {
                         $pathLevel = count( explode( '/', $path ) );
                         $uriLevel = count( explode( '/', $uriString ) );
+                        if ( $path == '/' )
+                        {
+                            $pathLevel--;
+                        }
                         if ( $level === null )
                         {
                             if ( $uriLevel <= $pathLevel + $depth )


### PR DESCRIPTION
Enables custom HTTP headers to be set for only / without setting them for its children.

This makes Header[/]=value;0;0 behave similarly to Header[/foo]=value;0;0 in that only the specified path will have the header set, and not any of its children. Previously, Header[/]=value;0;0 would also set the header for the immediate children of / (including /foo, but not /foo/bar).
