### PR TITLE
Fixed: isset() not checking the array key used, only array, in eZMysqlSchema::tableCharsetName

### DIFF
--- a/lib/ezdbschema/classes/ezmysqlschema.php
+++ b/lib/ezdbschema/classes/ezmysqlschema.php
@@ -598,7 +598,7 @@ class eZMysqlSchema extends eZDBSchemaInterface
                                  'koi8-r' => 'koi8r',
                                  'koi8-u' => 'koi8u' );
         $charset = strtolower( $charset );
-        if ( isset( $charsetMapping ) )
+        if ( isset( $charsetMapping[$charset] ) )
             return $charsetMapping[$charset];
         return $charset;
     }


### PR DESCRIPTION
(replaces https://github.com/ezsystems/ezpublish/pull/131 which has been done the bad way with git)
