### PR TITLE
Fixed #18592: php warning on array_merge when 2nd arg is not an array

### DIFF
--- a/lib/eztemplate/classes/eztemplate.php
+++ b/lib/eztemplate/classes/eztemplate.php
@@ -1757,8 +1757,19 @@ class eZTemplate
         if ( eZTemplate::isXHTMLCodeIncluded() )
             $preText .= "<p class=\"small\">$path</p><br/>\n";
         $postText = "\n<!-- STOP: including template: $path ($uri) -->\n";
-        $root[1] = array_merge( array( eZTemplateNodeTool::createTextNode( $preText ) ), is_array( $root[1] ) ? $root[1] : array() );
-        $root[1][] = eZTemplateNodeTool::createTextNode( $postText );
+
+        $preNode = eZTemplateNodeTool::createTextNode( $preText );
+        $postNode = eZTemplateNodeTool::createTextNode( $postText );
+
+        if ( is_array( $root[1] ) )
+        {
+            $root[1] = array_merge( array( $preNode ), $root[1] );
+        }
+        else
+        {
+            $root[1] = array( $preNode );
+        }
+        $root[1][] = $postNode;
     }
 
     /*!


### PR DESCRIPTION
Fixed #18592: php warning on array_merge when 2nd arg is not an array, when a datatype template contains no \n
