### PR TITLE
Fixed #18426: matchHostMethod can be defined to an empty string when HostUriMatchMapItems ends with a comma, eZPublish should use the defaultHostMatchMethod in that case

### DIFF
--- a/kernel/classes/ezsiteaccess.php
+++ b/kernel/classes/ezsiteaccess.php
@@ -286,7 +286,7 @@ class eZSiteAccess
                             $matchHost       = $matchMapItem[0];
                             $matchURI        = $matchMapItem[1];
                             $matchAccess     = $matchMapItem[2];
-                            $matchHostMethod = isset( $matchMapItem[3] ) ? $matchMapItem[3] : $defaultHostMatchMethod;
+                            $matchHostMethod = ( isset( $matchMapItem[3] ) && trim( $matchMapItem[3] ) ) ? $matchMapItem[3] : $defaultHostMatchMethod;
 
                             if ( $matchURI !== '' && strpos($uriString, $matchURI) !== 0 )
                                 continue;


### PR DESCRIPTION
Fixed #18426: matchHostMethod can be defined to an empty string when HostUriMatchMapItems ends with a comma, eZPublish should use the defaultHostMatchMethod in that case
