### PR TITLE
Implemented #18381: add description/author in ezinfo/about when using extension.xml, to have same behavior as ezinfo.php

### DIFF
--- a/kernel/private/classes/ezpextension.php
+++ b/kernel/private/classes/ezpextension.php
@@ -109,7 +109,7 @@ class ezpExtension
         // try extension.xml first
         if ( is_readable( $XMLFilePath = eZExtension::baseDirectory() . "/{$this->name}/extension.xml" ) )
         {
-            $infoFields = array( 'name', 'version', 'copyright', 'license', 'info_url' );
+            $infoFields = array( 'name', 'description', 'version', 'copyright', 'author', 'license', 'info_url' );
 
             libxml_use_internal_errors( true );
             $xml = simplexml_load_file( $XMLFilePath );


### PR DESCRIPTION
Implemented #18381: add description/author in ezinfo/about when using extension.xml, to have same behavior as ezinfo.php
