### PR TITLE
Fixed #018662: switchlanguage does not consider RemoveSiteAccessIfDefaultAccess=enabled

### DIFF
--- a/kernel/private/classes/ezplanguageswitcher.php
+++ b/kernel/private/classes/ezplanguageswitcher.php
@@ -156,7 +156,9 @@ class ezpLanguageSwitcher implements ezpLanguageSwitcherCapable
 
         $this->baseDestinationUrl = rtrim( $this->baseDestinationUrl, '/' );
 
-        if ( $GLOBALS['eZCurrentAccess']['type'] === eZSiteAccess::TYPE_URI )
+        if ( $GLOBALS['eZCurrentAccess']['type'] === eZSiteAccess::TYPE_URI &&
+             !( $ini->variable( 'SiteAccessSettings', 'RemoveSiteAccessIfDefaultAccess' ) == "enabled" &&
+                $ini->variable( 'SiteSettings', 'DefaultAccess' ) == $this->destinationSiteAccess ) )
         {
             $finalUrl = $this->baseDestinationUrl . '/' . $this->destinationSiteAccess . '/' . $urlAlias;
         }


### PR DESCRIPTION
This patch has been tested on a fresh 2011.9 install with each 3 modes:
- URL mode
- virtual host mode
- port mode

It also works on my config with MatchOrder=host;uri
#018662 is a duplicate of #017850
