### PR TITLE
Fix potential bug behaviour in PendingActions with DelayedIndexing and Asynchronous Publish

### DIFF
--- a/kernel/classes/ezpendingactions.php
+++ b/kernel/classes/ezpendingactions.php
@@ -34,7 +34,7 @@ class eZPendingActions extends eZPersistentObject
                                                                                'required' => false )
                                             ),
 
-                      'keys'                 => array( 'action', 'created' ),
+                      'keys'                 => array( 'action', 'created', 'param' ),
                       'class_name'           => 'eZPendingActions',
                       'name'                 => 'ezpending_actions',
                       'function_attributes'  => array()


### PR DESCRIPTION
Hi eZ Team ! 

That was not reproduced, but I think it will inevitably happen.

If we enabled delayedIndexing and enabled the asynchronous publishing, it can be problematic.

The key in ezpendingaction table is action/created. But this table manages pendingactions push to solr (via cronjobs). 

So if 2 objects are published in the same second, the new line in ezpendingaction table will overwrite the previous one. And the previous object will never be indexed in Solr.

is it correct ? 

If not, forget this pull request ;)

++
