### PR TITLE
Underscore not escape in LIKE query 

### DIFF
--- a/kernel/classes/clusterfilehandlers/dbbackends/mysql.php
+++ b/kernel/classes/clusterfilehandlers/dbbackends/mysql.php
@@ -1356,9 +1356,13 @@ class eZDBFileHandlerMysqlBackend
         return $res;
     }
 
-    /*!
-     Make sure that $value is escaped and qouted according to type and returned as a string.
-     The returned value can directly be put into SQLs.
+    /**
+     * Make sure that $value is escaped and qouted according to type and returned
+     * as a string.
+     *
+     * @param string $value a SQL parameter to escape
+     * @param bool $like if we quote for a LIKE
+     * @return string a string that can safely be used in SQL queries
      */
     function _quote( $value, $like = false )
     {
@@ -1366,11 +1370,12 @@ class eZDBFileHandlerMysqlBackend
             return 'NULL';
         elseif ( is_integer( $value ) )
             return (string)$value;
-        else {
+        else
+        {
            if ($like)
-                return "'".addcslashes(mysql_real_escape_string( $this->db, $value ),"_")."'";
+                return "'" . addcslashes( mysql_real_escape_string( $this->db, $value ), "_" ) . "'";
            else
-                return "'".mysql_real_escape_string( $this->db, $value )."'";
+                return "'" . mysql_real_escape_string( $this->db, $value ) . "'";
         }
     }
 

--- a/kernel/classes/clusterfilehandlers/dbbackends/mysqli.php
+++ b/kernel/classes/clusterfilehandlers/dbbackends/mysqli.php
@@ -1364,9 +1364,13 @@ class eZDBFileHandlerMysqliBackend
         return $res;
     }
 
-    /*!
-     Make sure that $value is escaped and qouted according to type and returned as a string.
-     The returned value can directly be put into SQLs.
+    /**
+     * Make sure that $value is escaped and qouted according to type and returned
+     * as a string.
+     *
+     * @param string $value a SQL parameter to escape
+     * @param bool $like if we quote for a LIKE
+     * @return string a string that can safely be used in SQL queries
      */
     function _quote( $value, $like = false )
     {
@@ -1374,11 +1378,12 @@ class eZDBFileHandlerMysqliBackend
             return 'NULL';
         elseif ( is_integer( $value ) )
             return (string)$value;
-        else {
+        else
+        {
            if ($like)
-                return "'".addcslashes(mysqli_real_escape_string( $this->db, $value ),"_")."'";
+                return "'" . addcslashes( mysqli_real_escape_string( $this->db, $value ), "_" ) . "'";
            else
-                return "'".mysqli_real_escape_string( $this->db, $value )."'";
+                return "'" . mysqli_real_escape_string( $this->db, $value ) . "'";
         }
     }
 

--- a/kernel/classes/datatypes/ezimage/ezimagefile.php
+++ b/kernel/classes/datatypes/ezimage/ezimagefile.php
@@ -105,8 +105,8 @@ class eZImageFile extends eZPersistentObject
         $contentObjectID = (int)( $rows[0]['contentobject_id'] );
         $contentClassAttributeID = (int)( $rows[0]['contentclassattribute_id'] );
         $filepath = $db->escapeString( $filepath );
-        // escape _ in like
-        $filepath = addcslashes($filepath, "_");
+        // escape _ in like !
+        $filepath = addcslashes( $filepath, "_" );
         $query = "SELECT id, version
                   FROM   ezcontentobject_attribute
                   WHERE  contentobject_id = $contentObjectID and

--- a/kernel/private/classes/clusterfilehandlers/dfsbackends/mysql.php
+++ b/kernel/private/classes/clusterfilehandlers/dfsbackends/mysql.php
@@ -1287,11 +1287,12 @@ class eZDFSFileHandlerMySQLBackend
             return 'NULL';
         elseif ( is_integer( $value ) )
             return (string)$value;
-        else {
+        else
+        {
            if ($like)
-                return "'".addcslashes(mysql_real_escape_string( $this->db, $value ),"_")."'";
+                return "'" . addcslashes( mysql_real_escape_string( $this->db, $value ), "_") . "'";
            else
-                return "'".mysql_real_escape_string( $this->db, $value )."'";
+                return "'" . mysql_real_escape_string( $this->db, $value ) . "'";
         }
     }
 

--- a/kernel/private/classes/clusterfilehandlers/dfsbackends/mysqli.php
+++ b/kernel/private/classes/clusterfilehandlers/dfsbackends/mysqli.php
@@ -1297,9 +1297,10 @@ class eZDFSFileHandlerMySQLiBackend
             return 'NULL';
         elseif ( is_integer( $value ) )
             return (string)$value;
-        else {
+        else
+        {
            if ($like)
-                return "'".addcslashes(mysqli_real_escape_string( $this->db, $value ),"_")."'";
+                return "'" . addcslashes( mysqli_real_escape_string( $this->db, $value ), "_" ) . "'";
            else
                 return "'".mysqli_real_escape_string( $this->db, $value )."'";
         }


### PR DESCRIPTION
Underscore is a special character in MySQL LIKE queries.
http://dev.mysql.com/doc/refman/5.0/fr/mysql-indexes.html

In a big cluster database, this bug result to not use Indexes. With this fix, we reduce the examinated rows from 3.6+ million to 10 rows in ezdfsfile (for exemple)

This bug can appear in all eZ Publish LIKE query. (not only in the cluster)

```
16:46:06 localhost> EXPLAIN SELECT ezdfsfile.name FROM ezdfsfile  WHERE name LIKE "var/plain_site/storage/images/media/images/evenements/diaporamas/les-cheerleaders-d-halloween/new-england-patriots-cheerleader-haloween-4/%";
+----+-------------+-----------+------+----------------+------+---------+------+---------+-------------+
| id | select_type | table     | type | possible_keys  | key  | key_len | ref  | rows    | Extra       |
+----+-------------+-----------+------+----------------+------+---------+------+---------+-------------+
|  1 | SIMPLE      | ezdfsfile | ALL  | ezdfsfile_name | NULL | NULL    | NULL | 3611370 | Using where |
+----+-------------+-----------+------+----------------+------+---------+------+---------+-------------+
1 row in set (0.00 sec)


16:46:12 localhost> EXPLAIN SELECT ezdfsfile.name FROM ezdfsfile  WHERE name LIKE "var/plain\_site/storage/images/media/images/evenements/diaporamas/les-cheerleaders-d-halloween/new-england-patriots-cheerleader-haloween-4/%";
+----+-------------+-----------+-------+----------------+----------------+---------+------+------+-------------+
| id | select_type | table     | type  | possible_keys  | key            | key_len | ref  | rows | Extra       |
+----+-------------+-----------+-------+----------------+----------------+---------+------+------+-------------+
|  1 | SIMPLE      | ezdfsfile | range | ezdfsfile_name | ezdfsfile_name | 752     | NULL |   10 | Using where |
+----+-------------+-----------+-------+----------------+----------------+---------+------+------+-------------+
1 row in set (0.01 sec)

```
