### PR TITLE
Added possibility to store log files into subfolders

### DIFF
--- a/lib/ezutils/classes/ezdebug.php
+++ b/lib/ezutils/classes/ezdebug.php
@@ -733,8 +733,8 @@ class eZDebug
         {
             $ini = eZINI::instance();
             $varDir = $ini->variable( 'FileSettings', 'VarDir' );
-            $logSubDir = $ini->variable( 'FileSettings', 'LogDir' );
-            $fileName = array( $varDir . DIRECTORY_SEPARATOR . $logSubDir . DIRECTORY_SEPARATOR,
+            $logDir = $ini->variable( 'FileSettings', 'LogDir' );
+            $fileName = array( eZDir::path( array( $varDir, $logDir ), true ),
                                $files[$verbosityLevel] );
         }
         if ( $this->MessageOutput & self::OUTPUT_MESSAGE_STORE or $alwaysLog )


### PR DESCRIPTION
If you have an eZ Publish project with many siteaccesses, it can be difficult to determine which error/warning/notice in the log files belongs to which siteaccess.

This change allows it to define in logfile.ini whether subfolders should be used or not (default is false so eZPublish's present behaviour is not affected).

If set to true, subfolders with the name of the current siteaccess are created and the logfiles are created/updated in these subfolders.

If you have three siteaccesses `admin`, `website1` and `website2`, this will result in the following directory structure:

```
var/log/
        admin/
              debug.log
              error.log
              notice.log
              warning.log
        website1/
                 debug.log
                 error.log
                 notice.log
                 warning.log
        website2/
                 debug.log
                 error.log
                 notice.log
                 warning.log
```

with each logfile only containing those events which took place in the according siteaccess.
