### PR TITLE
eZDebug::EZ_LEVEL_TIMING is an unknown constant, should be replaced by eZDebug::LEVEL_TIMING_POINT (I guess..)

### DIFF
--- a/benchmarks/ezmark.php
+++ b/benchmarks/ezmark.php
@@ -191,7 +191,7 @@ for ( $i = 1; $i < count( $argv ); ++$i )
                         else if ( $level == 'notice' )
                             $level = eZDebug::LEVEL_NOTICE;
                         else if ( $level == 'timing' )
-                            $level = eZDebug::EZ_LEVEL_TIMING;
+                            $level = eZDebug::LEVEL_TIMING_POINT;
                         $allowedDebugLevels[] = $level;
                     }
                 }

--- a/ezpm.php
+++ b/ezpm.php
@@ -427,7 +427,7 @@ for ( $i = 1; $i < count( $argv ); ++$i )
                         else if ( $level == 'notice' )
                             $level = eZDebug::LEVEL_NOTICE;
                         else if ( $level == 'timing' )
-                            $level = eZDebug::EZ_LEVEL_TIMING;
+                            $level = eZDebug::LEVEL_TIMING_POINT;
                         $allowedDebugLevels[] = $level;
                     }
                 }

--- a/kernel/classes/ezscript.php
+++ b/kernel/classes/ezscript.php
@@ -999,7 +999,7 @@ class eZScript
                     else if ( $level == 'notice' )
                         $level = eZDebug::LEVEL_NOTICE;
                     else if ( $level == 'timing' )
-                        $level = eZDebug::EZ_LEVEL_TIMING;
+                        $level = eZDebug::LEVEL_TIMING_POINT;
                     $allowedDebugLevels[] = $level;
                 }
                 $this->setUseDebugOutput( true );

--- a/runcronjobs.php
+++ b/runcronjobs.php
@@ -237,7 +237,7 @@ for ( $i = 1; $i < count( $argv ); ++$i )
                         else if ( $level == 'notice' )
                             $level = eZDebug::LEVEL_NOTICE;
                         else if ( $level == 'timing' )
-                            $level = eZDebug::EZ_LEVEL_TIMING;
+                            $level = eZDebug::LEVEL_TIMING_POINT;
                         $allowedDebugLevels[] = $level;
                     }
                 }

--- a/update/common/scripts/updatecontentobjectname.php
+++ b/update/common/scripts/updatecontentobjectname.php
@@ -227,7 +227,7 @@ for ( $i = 1; $i < count( $argv ); ++$i )
                         else if ( $level == 'notice' )
                             $level = eZDebug::LEVEL_NOTICE;
                         else if ( $level == 'timing' )
-                            $level = eZDebug::EZ_LEVEL_TIMING;
+                            $level = eZDebug::LEVEL_TIMING_POINT;
                         $allowedDebugLevels[] = $level;
                     }
                 }


### PR DESCRIPTION
Not sure about this commit, please check it...
