### PR TITLE
eZDebug::accumulatorStop only accepts 2 args, second is false by default, but sometimes eZ gives 3 args

### DIFF
--- a/kernel/classes/clusterfilehandlers/ezfsfilehandler.php
+++ b/kernel/classes/clusterfilehandlers/ezfsfilehandler.php
@@ -914,7 +914,7 @@ class eZFSFileHandler
 
         eZDebug::accumulatorStart( 'dbfile', false, 'dbfile' );
         eZFileHandler::copy( $srcPath, $dstPath );
-        eZDebug::accumulatorStop( 'dbfile', false, 'dbfile' );
+        eZDebug::accumulatorStop( 'dbfile' );
     }
 
     /**
@@ -929,7 +929,7 @@ class eZFSFileHandler
 
         eZDebug::accumulatorStart( 'dbfile', false, 'dbfile' );
         eZFileHandler::linkCopy( $srcPath, $dstPath, $symLink );
-        eZDebug::accumulatorStop( 'dbfile', false, 'dbfile' );
+        eZDebug::accumulatorStop( 'dbfile' );
     }
 
     /**

--- a/lib/ezi18n/classes/eztextcodec.php
+++ b/lib/ezi18n/classes/eztextcodec.php
@@ -353,7 +353,7 @@ class eZTextCodec
     {
         eZDebug::accumulatorStart( 'textcodec_codepage', false, 'String conversion w/ codepage' );
         $tmp = $this->Codepage->convertString( $str );
-        eZDebug::accumulatorStop( 'textcodec_codepage', false, 'String conversion w/ codepage' );
+        eZDebug::accumulatorStop( 'textcodec_codepage' );
         return $tmp;
     }
 
@@ -361,7 +361,7 @@ class eZTextCodec
     {
         eZDebug::accumulatorStart( 'textcodec_codepage_rev', false, 'String conversion w/ codepage reverse' );
         $tmp = $this->Codepage->convertStringFromUTF8( $str );
-        eZDebug::accumulatorStop( 'textcodec_codepage_rev', false, 'String conversion w/ codepage reverse' );
+        eZDebug::accumulatorStop( 'textcodec_codepage_rev' );
         return $tmp;
     }
 
@@ -369,7 +369,7 @@ class eZTextCodec
     {
         eZDebug::accumulatorStart( 'textcodec_codepage_mapper', false, 'String conversion w/ codepage mapper' );
         $tmp = $this->CodepageMapper->convertString( $str );
-        eZDebug::accumulatorStop( 'textcodec_codepage_mapper', false, 'String conversion w/ codepage mapper' );
+        eZDebug::accumulatorStop( 'textcodec_codepage_mapper' );
         return $tmp;
     }
 
@@ -380,7 +380,7 @@ class eZTextCodec
         // NOTE:
         // Uses the mbstring function directly instead of going trough the class
         $tmp = mb_convert_encoding( $str, $this->OutputCharsetCode, $this->InputCharsetCode );
-        eZDebug::accumulatorStop( 'textcodec_mbstring', false, 'String conversion w/ mbstring' );
+        eZDebug::accumulatorStop( 'textcodec_mbstring' );
         return $tmp;
     }
 

--- a/lib/eztemplate/classes/eztemplatedebugfunction.php
+++ b/lib/eztemplate/classes/eztemplatedebugfunction.php
@@ -333,7 +333,7 @@ class eZTemplateDebugFunction
                     }
                 }
 
-                eZDebug::accumulatorStop( $id, 'Debug-Accumulator', $name );
+                eZDebug::accumulatorStop( $id );
 
             } break;
 

--- a/lib/eztemplate/classes/eztemplatefileresource.php
+++ b/lib/eztemplate/classes/eztemplatefileresource.php
@@ -270,7 +270,7 @@ class eZTemplateFileResource
                 {
                     eZDebug::accumulatorStart( 'template_resource_conversion', 'template_total', 'String conversion in template resource' );
                     $text = $codec->convertString( $text );
-                    eZDebug::accumulatorStop( 'template_resource_conversion', 'template_total', 'String conversion in template resource' );
+                    eZDebug::accumulatorStop( 'template_resource_conversion' );
                 }
                 $result = true;
             }

--- a/lib/ezutils/classes/ezini.php
+++ b/lib/ezutils/classes/ezini.php
@@ -706,7 +706,7 @@ class eZINI
             {
                 eZDebug::accumulatorStart( 'ini_conversion', false, 'INI string conversion' );
                 $contents = $this->Codec->convertString( $contents );
-                eZDebug::accumulatorStop( 'ini_conversion', false, 'INI string conversion' );
+                eZDebug::accumulatorStop( 'ini_conversion' );
             }
         }
         else


### PR DESCRIPTION
surely because of quick copy/paste of accumulatorStart, that uses 3 args or more
