### PR TITLE
updateColumns() method only supports 1 arg, but a call uses 3 args => last 2 args are useless

### DIFF
--- a/kernel/classes/datatypes/ezmatrix/ezmatrix.php
+++ b/kernel/classes/datatypes/ezmatrix/ezmatrix.php
@@ -88,10 +88,9 @@ class eZMatrix
     }
 
     /*!
-        Searches in matrix columns with identifiers that in \a $matrixColumnDefinition an
-        a) if column exists and \a $updateColumnsAttributesAllowed is true then modification of
-           column attributes is performed( index, name, etc.);
-        b) if column doesn't exists and \a $addNewColumnsAllowed then new column will be created.
+        Searches in matrix columns with identifiers that in \a $matrixColumnDefinition and
+        a) if column exists then modification of column attributes is performed ( index, name, etc. );
+        b) if column doesn't exist then new column will be created.
     */
     protected function updateColumns( $matrixColumnDefinition )
     {
@@ -201,7 +200,7 @@ class eZMatrix
         $matrixWasModified = false;
 
         $matrixWasModified |= $this->removeUselessColumns( $classColumnsDefinition );
-        $matrixWasModified |= $this->updateColumns( $classColumnsDefinition, true, true );
+        $matrixWasModified |= $this->updateColumns( $classColumnsDefinition );
 
         if ( $matrixWasModified )
         {


### PR DESCRIPTION
I guess the reason comes from the fact, in the past, the updateColumns was supporting 3 args (as you can see in the doc of this method), last 2 args being updateColumnsAttributesAllowed and addNewColumnsAllowed

But nowadays, this method always supposes those 2 variables to true (updateColumns is a method only used in the file ezmatrix.php)

I've updated the doc of the method updateColumns, in that commit, to vanish those 2 args
