### PR TITLE
eZSimplePrice::attributes() doesn't support any arg, but a call uses 1 arg => this arg is useless

### DIFF
--- a/kernel/classes/datatypes/ezmultiprice/ezmultiprice.php
+++ b/kernel/classes/datatypes/ezmultiprice/ezmultiprice.php
@@ -74,8 +74,7 @@ class eZMultiPrice extends eZSimplePrice
     */
     function hasAttribute( $attr )
     {
-        $hasAttribute = in_array( $attr, $this->attributes() );
-        return $hasAttribute;
+        return in_array( $attr, $this->attributes() );
     }
 
     /*!


### PR DESCRIPTION
In order to solve the problem, some lines have been cleaned as the $this->attributes is an array that already contains the eZSimplePrice::attributes (thanks to array_merge function)

so hasAttribute has no need to perform a check on eZSimplePrice::attributes, as a check on $this->attributes is sufficient
