### PR TITLE
ZURLAliasML::fetchByPath only supports 2 args, but a call uses 4 args => last 2 args are useless

### DIFF
--- a/kernel/classes/ezstaticcache.php
+++ b/kernel/classes/ezstaticcache.php
@@ -293,7 +293,7 @@ class eZStaticCache implements ezpStaticCache
                 {
                     if ( !$quiet and $cli and $parentURL['glob'] )
                         $cli->output( "wildcard cache: " . $parentURL['url'] . '/' . $parentURL['glob'] . "*" );
-                    $elements = eZURLAliasML::fetchByPath( $parentURL['url'], $parentURL['glob'], true, true );
+                    $elements = eZURLAliasML::fetchByPath( $parentURL['url'], $parentURL['glob'] );
                     foreach ( $elements as $element )
                     {
                         $path = '/' . $element->getPath();


### PR DESCRIPTION
Maybe due to a confusion with fetchByParentID() that supports 4 args
