### PR TITLE
eZURLAliasML::generateFullSelect only supports 1 arg, but a call uses 3 args

### DIFF
--- a/kernel/classes/ezurlaliasml.php
+++ b/kernel/classes/ezurlaliasml.php
@@ -1211,7 +1211,7 @@ class eZURLAliasML extends eZPersistentObject
             $table     = "e" . $i;
             $langMask  = trim( eZContentLanguage::languagesSQLFilter( $table, 'lang_mask' ) );
 
-            $selects[] = eZURLAliasML::generateFullSelect( $table, $i, $len );
+            $selects[] = eZURLAliasML::generateSelect( $table, $i, $len );
             $tables[]  = "ezurlalias_ml " . $table;
             $conds[]   = eZURLAliasML::generateGlobCond( $table, $prevTable, $i, $langMask, $glob );
             $prevTable = $table;


### PR DESCRIPTION
Watchout for this commit!

Indeed, there're 2 options to solve the problem, and I'm not smart enough to know which one is the good one...

1/ the developer wanted to use the generateSelect() method but has written generateFullSelect() (this commits supposes this kind of error)

2/ the developer really wants to use generateFullSelect, but has indicated 3 args, instead of just 1 (by mixing the use of this function with generateSelect)

If the reality is 2/ then this commit is wrong! the fix is easy, just delete $i, $len from generateFullSelect()...
