### PR TITLE
iniMatch only supports 4 args, but 2 calls uses 5 args

### DIFF
--- a/kernel/classes/packagehandlers/ezfile/ezfilepackagehandler.php
+++ b/kernel/classes/packagehandlers/ezfile/ezfilepackagehandler.php
@@ -529,7 +529,7 @@ class eZFilePackageHandler extends eZPackageHandler
         return false;
     }
 
-    function iniMatch( $filePath, &$role, &$roleValue, &$file )
+    function iniMatch( $filePath, &$role, &$roleValue, &$file, &$triedFiles )
     {
         if ( preg_match( "#^settings/siteaccess/([^/]+)/([^/]+)$#", $filePath, $matches ) )
         {


### PR DESCRIPTION
Watchout for this commit!! I've done an assumption that may be wrong...

First iniMatch is a function that exists only in the file ezfilepackagehandler.php

In order to solve this problem, 2 options:

1/ as iniMatch supports currently 4 args, then just delete 5th arg whenever this function is called...

2/ or add a 5th arg to iniMatch() method, that is done in that commit (look at fileExists() method in that class)
    Because this function is performing a $triedFiles[] = $filePath; but if a 5th arg is not present, then all those affected values to $triedFiles would be lost. So I guess 2/ is the correct solution and the commit is correct, but please check intensively...
