### PR TITLE
putVirtualFolderData and deleteVirtualFolder doesn't support the $fullPath param

### DIFF
--- a/kernel/private/classes/webdav/ezwebdavcontentbackend.php
+++ b/kernel/private/classes/webdav/ezwebdavcontentbackend.php
@@ -886,7 +886,7 @@ class eZWebDAVContentBackend extends ezcWebdavSimpleBackend implements ezcWebdav
             return false; // @as self::FAILED_FORBIDDEN;
         }
 
-        $result = $this->putVirtualFolderData( $currentSite, $target, $tempFile, $fullPath );
+        $result = $this->putVirtualFolderData( $currentSite, $target, $tempFile );
 
         unlink( $tempFile );
         eZDir::cleanupEmptyDirectories( dirname( $tempFile ) );
@@ -1004,7 +1004,7 @@ class eZWebDAVContentBackend extends ezcWebdavSimpleBackend implements ezcWebdav
         $fullPath = $target;
         $target = $this->splitFirstPathElement( $target, $currentSite );
 
-        $status = $this->deleteVirtualFolder( $currentSite, $target, $fullPath );
+        $status = $this->deleteVirtualFolder( $currentSite, $target );
         // @as @todo return based on $status
 
         // Return success


### PR DESCRIPTION
and none of those functions use the $fullPath variable internally, so all calls of those 2 functions should not send the $fullPath param

I guess this error comes from a mix with those functions from kernel/classes/webdav/ezwebdavcontentserver.php, where $fullPath is supported and used
