### PR TITLE
eZDisplayResult() uses only one arg, but some calls give an extra param (that eZDisplayResult() is fetching by its own indeed)

### DIFF
--- a/kernel/setup/ezsetup.php
+++ b/kernel/setup/ezsetup.php
@@ -54,7 +54,7 @@ if ( file_exists( $stepDataFile ) )
 if ( $stepData == null )
 {
     print "<h1>Setup step data file not found. Setup is exiting...</h1>"; //TODO : i18n translate
-    eZDisplayResult( $templateResult, eZDisplayDebug() );
+    eZDisplayResult( $templateResult );
     eZExecution::cleanExit();
 }
 
@@ -198,7 +198,7 @@ while( !$done && $step != null )
     else
     {
         print( '<h1>Step '.$step['class'].' is not valid, no such file '.$includeFile.'. I\'m exiting...</h1>' ); //TODO : i18n
-        eZDisplayResult( $templateResult, eZDisplayDebug() );
+        eZDisplayResult( $templateResult );
         eZExecution::cleanExit();
     }
 }
@@ -215,7 +215,7 @@ eZDebug::addTimingPoint( "End" );
 
 return $result;
 
-//eZDisplayResult( $templateResult, eZDisplayDebug() );
+//eZDisplayResult( $templateResult );
 
 //eZExecution::cleanExit();
 ?>

--- a/webdav.php
+++ b/webdav.php
@@ -84,7 +84,7 @@ function eZFatalError()
     eZWebDAVContentBackend::appendLogEntry( "The execution of eZ Publish was abruptly ended, the debug output is present below." );
     eZWebDAVContentBackend::appendLogEntry( "****************************************" );
     // $templateResult = null;
-    // eZDisplayResult( $templateResult, eZDisplayDebug() );
+    // eZDisplayResult( $templateResult );
 }
 
 // Check and proceed only if WebDAV functionality is enabled:


### PR DESCRIPTION
eZDisplayResult() is defined in index.php and only uses 1 arg, this function gets the debug from eZDisplayDebug() and knows well how to show it.

This function doesn't need to have eZDisplayDebug() as a param, so all calls giving eZDisplayDebug() as param should be cleaned to not give this arg
