### PR TITLE
eZPersistentObject: Warning when$def["grouping"] is not set

### DIFF
--- a/kernel/classes/ezpersistentobject.php
+++ b/kernel/classes/ezpersistentobject.php
@@ -816,7 +816,7 @@ class eZPersistentObject
         $grouping_text = "";
         if ( isset( $def["grouping"] ) or ( is_array( $grouping ) and count( $grouping ) > 0 ) )
         {
-            $grouping_list = $def["grouping"];
+            $grouping_list = isset( $def["grouping"] ) ? $def["grouping"] : array();
             if ( is_array( $grouping ) )
                 $grouping_list = $grouping;
             if ( count( $grouping_list ) > 0 )


### PR DESCRIPTION
Greetings,

the if statement just before tha change asks whether `$def["grouping"]` or `$grouping` is a non-empty array.

In the next line `$grouping_list` is always set to `$def["grouping"]`, even when it is not set, which results in a PHP Warning.

Unfortunately I don't remember anymore where exactly this was an issue, but I do remember that the Display of the warning in the ezadmin interface was not... visually appealing :), and in another case a CLI script stopped working because of that.

Best
- Jérôme
