### PR TITLE
eZDBNoConnectionException() called with only 1 arg, but 3 args are mandatory

### DIFF
--- a/kernel/classes/clusterfilehandlers/ezdbfilehandler.php
+++ b/kernel/classes/clusterfilehandlers/ezdbfilehandler.php
@@ -49,7 +49,7 @@ class eZDBFileHandler implements ezpDatabaseBasedClusterFileHandler
 
             // connection failed
             if( self::$dbbackend->db === false )
-                throw new eZDBNoConnectionException( self::$dbbackend->dbparams['host'] );
+                throw new eZClusterHandlerDBNoConnectionException( self::$dbbackend->dbparams['host'], self::$dbbackend->dbparams['user'], self::$dbbackend->dbparams['pass'] );
         }
 
         $this->filePath = $filePath;


### PR DESCRIPTION
And in fact 2 ways to solve this issue:
- the developer has forgotten to add the 2 other params for eZDBNoConnectionException, but in order to get them, he must get the errorMessage and errorNumber of the problem while trying to connect (as it's done in lib/ezdb/classes/ezmysqlidb.php, via the setError() function), but it's not handled in kernel/classes/clusterfilehandlers/dbbackends/mysqli.php in the _connect() function (if mysqli_connect returns false, then this function doesn't store somewhere the associated errorMessage and errorNumber)
  => as a result, I think the developer cannot give those 2 mandatory args to eZDBNoConnectionException() function, and in the long run, no way to solve this issue by giving the 2 lacking params (no way to get them)
- the other way to solve, as the file kernel/classes/clusterfilehandlers/ezdbfilehandler.php is in a directory that deals with 'cluster', maybe the developer wanted to use the association error function from kernel/private/classes/exceptions/cluster/noconnection.php?
  This patch supposes this error, and in that case, the fix is to give the user and password thanks to dbparams (as it's already done to fetch the host)

(another way would be to keep using eZDBNoConnectionException() function, and handle db error reporting in the _connect() function, but that would be a new feature... So Let's keep with the bugfix for now)
