### PR TITLE
eZOption() needs 1 mandatory argument

### DIFF
--- a/kernel/classes/datatypes/ezoption/ezoptiontype.php
+++ b/kernel/classes/datatypes/ezoption/ezoptiontype.php
@@ -349,7 +349,7 @@ class eZOptionType extends eZDataType
 
         $optionArray = eZStringUtils::explodeStr( $string, '|' );
 
-        $option = new eZOption( );
+        $option = new eZOption( "" );
 
         $option->OptionCount = 0;
         $option->Options = array();


### PR DESCRIPTION
It may seem fancy to give "" (empty string) as a param to solve this issue, but this way is already used several times in ezoptiontype.php
