### PR TITLE
viewTemplateSuffix() needs 1 mandatory argument

### DIFF
--- a/kernel/classes/datatypes/ezxmltext/ezxmloutputhandler.php
+++ b/kernel/classes/datatypes/ezxmltext/ezxmloutputhandler.php
@@ -109,7 +109,8 @@ class eZXMLOutputHandler
     function &viewTemplateName()
     {
         $name = 'ezxmltext';
-        $suffix = $this->viewTemplateSuffix();
+        $contentobjectAttribute = false;
+        $suffix = $this->viewTemplateSuffix( $contentobjectAttribute );
         if ( $suffix !== false )
         {
             $name .= '_' . $suffix;


### PR DESCRIPTION
Besides this small fix, one remark:

I can read in this file declaration of function like:
```function &foo() { }

```

This format is not deprecated in php 5.3 ?
```
