### PR TITLE
Nice to have the version of eZ in the X-Powered-By http header

### DIFF
--- a/kernel/setup/datatype.php
+++ b/kernel/setup/datatype.php
@@ -203,13 +203,11 @@ function datatypeDownload( $tpl, &$persistentData, $stepData )
     $contentLength = strlen( $content );
     $mimeType = 'application/octet-stream';
 
-    $version = eZPublishSDK::version();
-
     header( "Pragma: " );
     header( "Cache-Control: " );
     header( "Content-Length: $contentLength" );
     header( "Content-Type: $mimeType" );
-    header( "X-Powered-By: eZ Publish $version" );
+    header( "X-Powered-By: eZ Publish" );
     header( "Content-Disposition: attachment; filename=$filename" );
     header( "Content-Transfer-Encoding: binary" );
     ob_end_clean();

--- a/kernel/setup/templateoperator.php
+++ b/kernel/setup/templateoperator.php
@@ -241,13 +241,11 @@ function templateOperatorDownload( $tpl, &$persistentData, $stepData )
     $contentLength = strlen( $content );
     $mimeType = 'application/octet-stream';
 
-    $version = eZPublishSDK::version();
-
     header( "Pragma: " );
     header( "Cache-Control: " );
     header( "Content-Length: $contentLength" );
     header( "Content-Type: $mimeType" );
-    header( "X-Powered-By: eZ Publish $version" );
+    header( "X-Powered-By: eZ Publish" );
     header( "Content-Disposition: attachment; filename=$filename" );
     header( "Content-Transfer-Encoding: binary" );
     ob_end_clean();


### PR DESCRIPTION
Which is already the case in:
- kernel/setup/datatype.php
- kernel/setup/templateoperator.php

(the same logic has been spread whenever an X-Powered-By is used)

Nice to have this version number in order (later) for eZ Systems to scan all websites using eZ, in order to know the usage per version of eZ

Further more, existing scanning tools will know what version of eZ is involved
