### PR TITLE
fflush() used to flush content to browser, but flush() is involved (fflush is for flushing file)

### DIFF
--- a/kernel/setup/datatype.php
+++ b/kernel/setup/datatype.php
@@ -214,7 +214,7 @@ function datatypeDownload( $tpl, &$persistentData, $stepData )
     header( "Content-Transfer-Encoding: binary" );
     ob_end_clean();
     print( $content );
-    fflush();
+    flush();
     eZExecution::cleanExit();
 }
 

--- a/kernel/setup/templateoperator.php
+++ b/kernel/setup/templateoperator.php
@@ -252,7 +252,7 @@ function templateOperatorDownload( $tpl, &$persistentData, $stepData )
     header( "Content-Transfer-Encoding: binary" );
     ob_end_clean();
     print( $content );
-    fflush();
+    flush();
     eZExecution::cleanExit();
 }
 


### PR DESCRIPTION
Man page for flush:
http://fr2.php.net/manual/en/function.flush.php
```Flushes the write buffers of PHP and whatever backend PHP is using (CGI, a web server, etc). This attempts to push current output all the way to the browser with a few caveats. 

``````

and man page for fflush (that needs a mandatory arg, which is the file resource handle to flush):
http://fr2.php.net/manual/en/function.fflush.php
```This function forces a write of all buffered output to the resource pointed to by the file handle.
``````
