### PR TITLE
addToBasket uses 3 mandatory args, only 2 provided, further more cleaning static call style in a non static function

### DIFF
--- a/kernel/shop/ezshopoperationcollection.php
+++ b/kernel/shop/ezshopoperationcollection.php
@@ -330,7 +330,7 @@ class eZShopOperationCollection
         {
             if ( substr( $optionKey, 0, 4 ) == 'set_' )
             {
-                $returnStatus = eZShopOperationCollection::addToBasket( $objectID, $optionList[$optionKey] );
+                $returnStatus = $this->addToBasket( $objectID, $optionList[$optionKey], $quantity );
                 // If adding one 'option set' fails we should stop immediately
                 if ( $returnStatus['status'] == eZModuleOperationInfo::STATUS_CANCELLED )
                     return $returnStatus;


### PR DESCRIPTION
Watch out ! fix on the shop code, but I've never used it before. Please check it intensively...
