### PR TITLE
eZTrigger::createNew() needs mandatory args, but no arg provided

### DIFF
--- a/kernel/trigger/list.php
+++ b/kernel/trigger/list.php
@@ -143,12 +143,6 @@ if ( $http->hasPostVariable( 'RemoveButton' )  )
     }
 }
 
-if ( $http->hasPostVariable( 'NewButton' )  )
-{
-    $trigger = eZTrigger::createNew( );
-}
-
-
 $tpl = eZTemplate::factory();
 
 $triggers = eZTrigger::fetchList( array(


### PR DESCRIPTION
In fact the createNew() call with no args has been deleted as I don't see where $trigger is used indeed...

I'm not sure either the NewButton action exists in the trigger/list module (and in fact I don't see either the RemoveButton... I'm surely looking at a bad template, so please check this bug fix heavily...)
