### PR TITLE
eZCompressionHandler needs 2 args but no arg provided

### DIFF
--- a/lib/ezfile/classes/ezbzip2compressionhandler.php
+++ b/lib/ezfile/classes/ezbzip2compressionhandler.php
@@ -23,7 +23,7 @@ class eZBZIP2Handler extends eZCompressionHandler
     */
     function eZBZIP2Handler()
     {
-        $this->eZCompressionHandler();
+        $this->eZCompressionHandler( 'BZIP2', 'bz2' );
     }
 
     function doOpen( $filename, $mode )


### PR DESCRIPTION
Please check the $handlerIdentifier and $handlerName, according to eZ API standard

In fact, when looking at ezgzipcompressionhandler, maybe $handlerName should be bzip2 instead of the common extension bz2
Don't know well the meaning of those 2 params indeed...
