### PR TITLE
elementValue() needs 3 args at least, only 2 provided

### DIFF
--- a/lib/eztemplate/classes/eztemplate.php
+++ b/lib/eztemplate/classes/eztemplate.php
@@ -1373,7 +1373,7 @@ class eZTemplate
             } break;
             case "variable":
             {
-                return $this->elementValue( $data["content"], $nspace );
+                return $this->elementValue( $data["content"], $nspace, '' );
             } break;
             default:
             {


### PR DESCRIPTION
Have I to say to be careful with this fix, which has been coded completely blindly?

In fact, elementValue() needs the currentNamespace as third param, but attributeValue() hasn't it in its args
Maybe it's in $data for each content ?

Please check, really dunno...
