### PR TITLE
eZPersistentObject::store() is a void function, but eZCollaborationItemStatus is getting a returned value from it

### DIFF
--- a/kernel/classes/ezcollaborationitemstatus.php
+++ b/kernel/classes/ezcollaborationitemstatus.php
@@ -72,9 +72,9 @@ class eZCollaborationItemStatus extends eZPersistentObject
 
     function store( $fieldFilters = null )
     {
-        $stored = eZPersistentObject::store( $fieldFilters );
+        eZPersistentObject::store( $fieldFilters );
         $this->updateCache();
-        return $stored;
+        return true;
     }
 
     function updateCache()


### PR DESCRIPTION
This problem exists on several other files

Please tell me if the fix is done the correct way, and I could then send more pull requests

Because, in fact, the other way is to force store() (indeed only storeObject()) to return a status value, dunno if it's possible...
