### PR TITLE
A required param is put after optional params, that make those mandatory indeed...

### DIFF
--- a/kernel/classes/clusterfilehandlers/dbbackends/mysql.php
+++ b/kernel/classes/clusterfilehandlers/dbbackends/mysql.php
@@ -1005,7 +1005,7 @@ class eZDBFileHandlerMysqlBackend
      \param $debug If true it will display the fetched row in addition to the SQL.
      \param $fetchCall The callback to fetch the row.
      */
-    function _selectOne( $query, $fname, $error = false, $debug = false, $fetchCall )
+    function _selectOne( $query, $fname, $error, $debug, $fetchCall )
     {
         eZDebug::accumulatorStart( 'mysql_cluster_query', 'mysql_cluster_total', 'Mysql_cluster_queries' );
         $time = microtime( true );


### PR DESCRIPTION
This problem occurs several times in the source (more than 30 times)

Please tell me if this fix is done the right way, so that I can fix the others

But maybe sometimes, the fix will be to make the mandatory param (put after the optional ones), in fact optional also...
