### PR TITLE
New function (imported from ezscriptmonitor) to launch a script in background

### DIFF
--- a/kernel/classes/ezscript.php
+++ b/kernel/classes/ezscript.php
@@ -1100,6 +1100,24 @@ class eZScript
         eZTextCodec::updateSettings( $i18nSettings );
     }
 
+    /*!
+     \static
+     Execute a process in the background, should work on both Linux and Windows
+     From php doc:
+     http://no.php.net/manual/en/function.exec.php#86329
+    */
+    static function execInBackground( $command )
+    {
+        if ( substr( php_uname(), 0, 7 ) == 'Windows' )
+        {
+            pclose( popen( 'start /B ' . $command, 'r' ) );
+        }
+        else
+        {
+            exec( $command . ' > /dev/null &' );
+        }
+    }
+
     /// \privatesection
     public $InitializationErrorMessage;
     public $DebugMessage;


### PR DESCRIPTION
This function that can launch a script in background is very handy, from extension/ezscriptmonitor/cronjobs/runscheduledscripts.php

=> Why not moving it to eZPublish API?

That way, a lot of people could use it

Further more, in eZRunCronjobs, it would be possible to add a new method that launches runcrunjobs at once (in order to not wait the next launch of cronjob)

It would also be possible to have a button somewhere in the backend to force the launch of the runcronjobs for example...

And in fact, as far as I'm concerned, I need to add a script to ezscriptmonitor, and launch this script asap, I just can't wait 5 min (if the cron is running every 5 min), I need to launch runcronjobs asap (hence this function that would let it possible)

This method has been put in eZScript, I really don't know if this is the best place...

Do not hesitate to comment this pull !
