### PR TITLE
serverVariable has to be quiet there as a false value returned by the latter is correctly handled by the function

### DIFF
--- a/lib/ezutils/classes/ezsys.php
+++ b/lib/ezutils/classes/ezsys.php
@@ -756,7 +756,7 @@ class eZSys
             $hostName = trim( $forwardedHosts[0] );
         }
 
-        if ( !$hostName && self::serverVariable( 'HTTP_HOST' ) )
+        if ( !$hostName && self::serverVariable( 'HTTP_HOST', true ) )
         {
             $hostName = self::serverVariable( 'HTTP_HOST' );
         }
@@ -905,7 +905,7 @@ class eZSys
             }
             else
             {
-                $port = (int) self::serverVariable( 'SERVER_PORT' );
+                $port = (int) self::serverVariable( 'SERVER_PORT', true );
             }
 
             if ( !$port )


### PR DESCRIPTION
in order to avoid nasty lines in error.log, for an error which is not one indeed
