### PR TITLE
lacking apache config to handle url that contains %2f (/) or %5c (\)

### DIFF
--- a/.htaccess_root
+++ b/.htaccess_root
@@ -3,6 +3,9 @@
 
 DirectoryIndex index.php
 
+# Comment if you use apache < 2.0.46
+AllowEncodedSlashes On
+
 RewriteEngine On
 RewriteRule ^api/ index_rest.php [L]
 RewriteRule ^index_rest\.php - [L]

--- a/doc/examples/ezpublish.conf
+++ b/doc/examples/ezpublish.conf
@@ -23,6 +23,9 @@ NameVirtualHost [IP_ADDRESS]
     # Rewrite rules to enable virtual host mode of eZ Publish
     # Secures eZ Publish by making sure only certain folders is accessible directly
     <IfModule mod_rewrite.c>
+        # Comment if you use apache < 2.0.46
+        AllowEncodedSlashes On
+
         RewriteEngine On
         # REST API
         RewriteRule ^/api/ /index_rest\.php [L]


### PR DESCRIPTION
in the eztagcloud, whenever the keyword contains a slash (/), we get an aggressive 404 error, eZPublish is even not executed

For example: http://ez.no/content/keyword/ez in order to search the keyword 'ez', all is ok

and when hitting http://ez.no/content/keyword/ez%2f, a 404 error is thrown
It comes from an option of apache that rejects by default url containing %2f for security reasons:
http://httpd.apache.org/docs/2.2/mod/core.html#allowencodedslashes

This reason is good, but there's no security problem with eZPublish, thanks to index.php controller, there's no direct access to a file in ezpublish tree
