### PR TITLE
Fixed #19001: possibility to gives an encoded slash as a param to a module

### DIFF
--- a/lib/ezutils/classes/ezsys.php
+++ b/lib/ezutils/classes/ezsys.php
@@ -1293,7 +1293,7 @@ class eZSys
         }
         else
         {
-            $requestUri = '/' . urldecode( trim( $requestUri, '/ ' ) );
+            $requestUri = '/' . self::urlDecode( trim( $requestUri, '/ ' ) );
         }
 
         $instance->AccessPath = array( 'siteaccess' => array( 'name' => '', 'url' => array() ),
@@ -1304,6 +1304,22 @@ class eZSys
         $instance->IndexFile  = $IndexFile;
         $instance->RequestURI = $requestUri;
         $instance->QueryString = $queryString;
+    }
+
+    /**
+     * decode an url except the specific %2F character which is the encoded slash
+     *
+     * @param string $uri
+     * @return string The encoded uri
+     */
+    public static function urlDecode( $uri )
+    {
+        $uri = str_replace( "%2f", "%2F", $uri );
+
+        $elements = explode( "%2F", $uri );
+        array_walk( $elements, create_function( '&$val', '$val = urldecode( $val );' ) );
+
+        return implode( "%2F", $elements );
     }
 
     /**

--- a/lib/ezutils/classes/ezuri.php
+++ b/lib/ezutils/classes/ezuri.php
@@ -86,7 +86,7 @@ class eZURI
      */
     public static function decodeIRI( $str )
     {
-        $str = urldecode( $str ); // Decode %xx entries, we now have a utf-8 string
+        $str = eZSys::urlDecode( $str ); // Decode %xx entries, we now have a utf-8 string
         $codec = eZTextCodec::instance( 'utf-8' ); // Make sure string is converted from utf-8 to internal encoding
         return $codec->convertString( $str );
     }


### PR DESCRIPTION
Indeed, it's impossible for now to give an urlencoded string that contains a / (slash) to a module.
However this particular case can occur for the content/keyword module

It's a proposal for discussion...

Would maybe be better to have the urlDecode function somewhere in ezhttp*, and urlDecode could take an array of symbols to exclude from the decode process instead of only exclude the hardcoded %2f symbol...
