### PR TITLE
Implemented eZSys::tempDirectory() function for returning the temporary directory

### DIFF
--- a/lib/ezutils/classes/ezsys.php
+++ b/lib/ezutils/classes/ezsys.php
@@ -578,6 +578,29 @@ class eZSys
         $ini = eZINI::instance();
         return eZDir::path( array( $ini->variable( 'FileSettings', 'VarDir' ) ) );
     }
+
+    /**
+     * Returns the path of the current temporary directory
+     *
+     * @return string
+     */
+    public static function tempDirectory()
+    {
+        if ( function_exists( 'sys_get_temp_dir' ) )
+        {
+            return realpath( sys_get_temp_dir() );
+        }
+
+        foreach( array( 'TMP', 'TEMP', 'TMPDIR' ) as $tempEnv )
+        {
+            if ( $temp = getenv( $tempEnv ) )
+            {
+                return $temp;
+            }
+        }
+
+        return null;
+    }
     
     /**
      * Returns the current storage directory


### PR DESCRIPTION
In several extensions, I need to store temporary files for a moment, (for example convert a video to another format and then add some filters on it etc.)

eZSys::varDirectory() could be used, but if the extension crashs for one reason, this temporary file will never be deleted automatically in the future

=> Therefore, it would be nice to have a function in eZ that indicates where to store temporary files (each OS has a specific room for that, with some tools to clean it, for example /tmp on linux and a reboot to clean it)
This implementation relies on sys_get_temp_dir() php function, (code is inspired from comments at http://fr2.php.net/manual/en/function.sys-get-temp-dir.php)
