### PR TITLE
raises level error from Notice to Error, in case of hostname not correct or Apache not running

### DIFF
--- a/kernel/classes/ezstaticcache.php
+++ b/kernel/classes/ezstaticcache.php
@@ -415,8 +415,7 @@ class eZStaticCache implements ezpStaticCache
                             }
                             if ( $content === false )
                             {
-                                eZDebug::writeError( "Could not grab content (from $fileName), is the hostname correct and Apache running?",
-                                                      'Static Cache' );
+                                eZDebug::writeError( "Could not grab content (from $fileName), is the hostname correct and Apache running?", 'Static Cache' );
                             }
                             else
                             {
@@ -624,7 +623,7 @@ class eZStaticCache implements ezpStaticCache
                         }
                         if ( $fileContentCache[$source] === false )
                         {
-                            eZDebug::writeError( 'Could not grab content, is the hostname correct and Apache running?', 'Static Cache' );
+                            eZDebug::writeError( "Could not grab content (from $source), is the hostname correct and Apache running?", 'Static Cache' );
                         }
                         else
                         {


### PR DESCRIPTION
Currently if hostname is false or Apache is not running, eZStaticCache only raises a Notice, however this problem can be considered as a big one! So a warning (at least) is better, and even a frank error!

Also a modification, in order to have the same error text (adding the string "from $source" in the error, the same way as it's done when the same kind of error is raised in another case)
