### PR TITLE
the magic getter __get() is never called due to an already existing protected property

### DIFF
--- a/kernel/private/classes/clusterfilehandlers/ezfs2filehandler.php
+++ b/kernel/private/classes/clusterfilehandlers/ezfs2filehandler.php
@@ -739,10 +739,11 @@ class eZFS2FileHandler extends eZFSFileHandler
         {
             case 'cacheType':
             {
-                static $cacheType = null;
-                if ( $cacheType == null )
-                    $cacheType = $this->_cacheType();
-                return $cacheType;
+                if ( $this->internalCacheType === null )
+                {
+                    $this->internalCacheType = $this->_cacheType();
+                }
+                return $this->internalCacheType;
             } break;
         }
     }
@@ -822,5 +823,12 @@ class eZFS2FileHandler extends eZFSFileHandler
      * @var int
      */
     protected $generationStartTimestamp = false;
+
+    /**
+     * Cached value of cache type
+     *
+     * @var string|null
+     */
+    protected $internalCacheType = null;
 }
 ?>


### PR DESCRIPTION
Some kind of tricky bug...

While testing the bin/php/makestaticcache.php script (I use eZFS2FileHandler), I've encountered a bunch of PHP notice:
Undefined index:  in [...]/kernel/private/classes/clusterfilehandlers/ezfs2filehandler.php on line 147, in fact at the line:
if ( $this->nonExistantStaleCacheHandling[ $this->cacheType ] == 'generate' )

The reason is because $this->cacheType is null, due to the fact the magic getter __get() in that class is never called!
Why __get() is never called ? because of an already existing protected variable with that name ($cacheType) at the end of the class: protected $cacheType = null;

=> so, a fix is to delete this protected variable, then at least the getter function is called(), but then the latter yells because $this->cacheType doesn't exist (of course, we've just deleted it...)

=> so the second fix is to use a static variable at that place

Hence full current commit, which is indeed the clone of the behavior in eZDFSFileHandler (no protected variable $cacheType, and a static variable in the getter, to avoid calling it again and again)
