### PR TITLE
Move the response/output filter just before the print of the report, that way, the filter can use accumulator or append some bottom report

### DIFF
--- a/index.php
+++ b/index.php
@@ -238,7 +238,6 @@ function eZDisplayDebug()
 */
 function eZDisplayResult( $templateResult )
 {
-    ob_start();
     if ( $templateResult !== null )
     {
         $classname = eZINI::instance()->variable( "OutputSettings", "OutputFilterName" );//deprecated
@@ -246,6 +245,7 @@ function eZDisplayResult( $templateResult )
         {
             $templateResult = call_user_func( array ( $classname, 'filter' ), $templateResult );
         }
+        $templateResult = ezpEvent::getInstance()->filter( 'response/output', $templateResult );
         $debugMarker = '<!--DEBUG_REPORT-->';
         $pos = strpos( $templateResult, $debugMarker );
         if ( $pos !== false )
@@ -264,8 +264,6 @@ function eZDisplayResult( $templateResult )
     {
         eZDisplayDebug();
     }
-    $fullPage = ob_get_clean();
-    echo ezpEvent::getInstance()->filter( 'response/output', $fullPage );
 }
 
 function fetchModule( $uri, $check, &$module, &$module_name, &$function_name, &$params )


### PR DESCRIPTION
I really think it's useful to move this filter just above the report

In fact, think of some filters that may take some time or need to print some log, it's nice to have an accumulator to know the time consumed by this filter and some info in the full report

It's possible to use an accumulator or appendBottomReport in an OutputFilterName, but no more in this response/output filter which is a regression I think

Because actually, the filter is silence, we can't see anything in the log in the page

This code has been tested with Debug=inline style and with Debug=popup style

Strangely the latter works without any modification in lib/ezutils/ezdebug.php, eZDebug::printReport(), the modification in index.php seems enough

So please double check!

I was ready to send a pull to make OutputFilterName accept many classes to launch several filters, but no more needed with this nice listener / filter process!
