### PR TITLE
Implements a fileExists() function in eZFS2FileHandler to handle the fact file may exist with this fs, but can be obsolete, and therefore is not valid anymore

### DIFF
--- a/kernel/private/classes/clusterfilehandlers/ezfs2filehandler.php
+++ b/kernel/private/classes/clusterfilehandlers/ezfs2filehandler.php
@@ -532,6 +532,22 @@ class eZFS2FileHandler extends eZFSFileHandler
     }
 
     /**
+     * Check if given file/dir exists.
+     *
+     * \public
+     */
+    function fileExists( $path )
+    {
+        eZDebugSetting::writeDebug( 'kernel-clustering', "fs::fileExists( '$path' )", __METHOD__ );
+
+        eZDebug::accumulatorStart( 'dbfile', false, 'dbfile' );
+        $rc = !$this->isExpired( -1, time(), null );
+        eZDebug::accumulatorStop( 'dbfile' );
+
+        return $rc;
+    }
+
+    /**
      * Delete files located in a directories from dirList, with common prefix specified by
      * commonPath, and common suffix with added wildcard at the end
      *


### PR DESCRIPTION
While coding a new extension with a sample template file, the latter wasn't found despite cache purge.
After some debug, here what seems to be the reason:

First I use eZFS2FileHandler (no bug if I was using eZFSFileHandler)
And the fact is this file handler doesn't seem to delete files, it just expires them. As a result, the file physically exists on disk, but is no more valid

In my configuration, after a cache purge I have var/ezwebin_site/cache/designbase_53410641646....php that exists but with timestamp: 1977-05-25 02:00, which means this cache file has expired (because of the cache purge)

But in kernel/common/eztemplatedesignresource.php file, in eZTemplateDesignResource::allDesignBases() static function, you can see the code:

```
            $clusterFileHandler = eZClusterFileHandler::instance( $cachePath );
            if( $clusterFileHandler->fileExists( $cachePath ) )
            {
                $designBaseList = unserialize( $clusterFileHandler->fetchContents() );

                self::savesMemoryCache( $designBaseList, $siteAccess );
            }
            else
            { ... }
```

So if the $cachePath exists, then push it ($cachePath is my file var/ezwebin_site/cache/designbase_53410641646....php)

_The bug is here, ezpublish always pushs the content of a cache that is no more valid..._

To understand why, eZFS2FileHandler class extends eZFSFileHandler, and there's no fileExists() in eZFS2FileHandler, as a result, is used the fileExists function from eZFSFileHandler, which is below, and that just doesn't take consideration of the obsolete files (in eZFSFileHandler, purging a file means to really delete it, so no problem)

```
    function fileExists( $path )
    {
        eZDebugSetting::writeDebug( 'kernel-clustering', "fs::fileExists( '$path' )", __METHOD__ );

        eZDebug::accumulatorStart( 'dbfile', false, 'dbfile' );
        $rc = file_exists( $path );
        eZDebug::accumulatorStop( 'dbfile' );

        return $rc;
    }
```

=> 2 options to correct it:
- if the developer really wanted to have a function that returns true if the file exists (let it be obsolete or not), then, another function isValid() should be developped, and should be spreaded everywhere!
  => look at this feature request: 
  http://issues.ez.no/IssueView.php?Id=18603
- or code a fileExists() in eZFS2FileHandler that takes consideration of obsolete files (this is the aim of this pull request), no need to spread new code, but then every call to this fileExists() function should be checked to be sure that the call wants to check validity of a cache, and doesn't want to just check the presence of a cache file (let it be obsolete or not)

Indeed, I guess we really don't care to know that a cache file exists but is unusable... better to say the cache doesn't exist to force the regeneration of it...

Don't hope to go on holidays without some tricky bugs to fix before ;)
