### PR TITLE
Better errors handling when mkdir or chmod encounters a problem

### DIFF
--- a/kernel/private/classes/ezautoloadgenerator.php
+++ b/kernel/private/classes/ezautoloadgenerator.php
@@ -249,7 +249,7 @@ class eZAutoloadGenerator
             $filename = $this->nameTable( $location );
             $filePath = $targetBasedir . DIRECTORY_SEPARATOR . $filename;
 
-             $file = fopen( $filePath, "w+" );
+             $file = @fopen( $filePath, "w+" );
              if ( $file )
              {
                  fwrite( $file, $this->dumpArrayStart( $location ) );


### PR DESCRIPTION
Indeed maybe other persons have encounters this problem

The fact is generally (according to doc I think), var must be owned by www-data:www-data
However, sometimes the user may want to generate autoloads, and does this in a shell (I remember it's that way explained when doing an upgrade)

So the user runs:
`php bin/php/ezpgenerateautoloads.php`

and then get the warning:
`PHP Warning:  chmod(): Opération non permise in /[...]ezpublish/kernel/private/classes/ezautoloadgenerator.php on line 259`

The aim of this pull is to fix this small problem, by handling this error (and also the mkdir in the function to handle all errors indeed)

You'll notice a test in this commit with existing mode to avoid to perform a chmod that would do nothing.
That way it avoids to print a useless error to the user (but prints it when it's really needed)

Feel free to comment...
