### PR TITLE
Create a new event in order to be able to alter the events

### DIFF
--- a/kernel/private/classes/ezpevent.php
+++ b/kernel/private/classes/ezpevent.php
@@ -112,6 +112,11 @@ class ezpEvent
             return false;
         }
 
+        if ( $name != 'alter/events' )
+        {
+            $this->listeners = self::getInstance()->filter( 'alter/events', $this->listeners );
+        }
+
         foreach ( $this->listeners[$name] as $listener )
         {
             call_user_func_array( $listener, $params );
@@ -131,6 +136,11 @@ class ezpEvent
         if ( empty( $this->listeners[$name] ) )
         {
             return $value;
+        }
+
+        if ( $name != 'alter/events' )
+        {
+            $this->listeners = self::getInstance()->filter( 'alter/events', $this->listeners );
         }
 
         foreach ( $this->listeners[$name] as $listener )


### PR DESCRIPTION
It's more a pull request in order to start a discussion, cause I'm not finding a perfect solution...

The problem:
I have a filter A (in a custom extension A), a filter B (in a custom extension B), and a filter C (in a custom extension C) all triggered on response/preoutput event in order to alter the output pushed to the client

BUT filer A _must_ be launched before filter B and C

=> I was first thinking I could do the thing, in the custom extension A, by detaching all filters from response/preoutput, and then reattaching all of them, but starting by filter A
Well it doesn't seem possible, because, asap extension A takes the hand, filter B or C may have already been launched... tell me if I'm wrong

Therefore 2 solutions come to mind:
1/ Well... just load the extension A in first, before B and C, and all is ok, But:
- not perfect, because we may imagine that extension A extends extension B (overrides some templates for example), and then extension B should be loaded first. Therefore we come to a deadlock...

2/ let the developer have the hand on the events fifo _before_ any foreach() is triggered to launch all callbacks for a specific event
This pull request shows this possibility

If you have a better idea than this commit, please feel free to explain it, I have no more idea...
