### PR TITLE
eZDBInterface: Converted Doxygen comments to PHPDoc comments

### DIFF
--- a/lib/ezdb/classes/ezdbinterface.php
+++ b/lib/ezdb/classes/ezdbinterface.php
@@ -1648,7 +1648,7 @@ class eZDBInterface
      * The start time of the timer
      *
      * @access protected
-     * @var bol|float
+     * @var bool|float
      */
     public $StartTime;
 


### PR DESCRIPTION
Greetings,

here another class with converted PHPDocs, and this time I learned from the past experiences: no code changes in this pull request, just this has been made:
- Converted Doxygen comments to PHPDoc comments
- Added `@access private`/`@access protected` to variables in the former "protected section" and to methods already marked as `\protected` or `\private`
- Re-indented some lines
- Fixed some typos

Best
- Jérôme
