### PR TITLE
ezpEvent::filter can now handle many args for the listener, and not only the value to alter

### DIFF
--- a/kernel/private/classes/ezpevent.php
+++ b/kernel/private/classes/ezpevent.php
@@ -140,9 +140,9 @@ class ezpEvent
 
         foreach ( $this->listeners[$name] as $listener )
         {
-            $value = call_user_func_array( $listener, $params );
+            $params[0] = call_user_func_array( $listener, $params );
         }
-        return $value;
+        return $params[0];
     }
 
     /**


### PR DESCRIPTION
Small commit to let ezpEvent::filter handle more than only the value to alter

Because we may imagine to call a filter on a value to alter, and give also some extra params that indicate _how_ to alter the value (or whatever extra params indeed)

This commit comes from a need in https://github.com/ezsystems/ezjscore/pull/12, where the idea is to upgrade js/css optimizers of ezjscore to ezpEvent logic
The extra param needed here is the packLevel which indicates how aggressive the process must be to optimize the value (let it be css or js)
