### PR TITLE
Adding a check in ezpEvent constructor, as it may be possible to add an empty listener, when a user wants to delete an override

### DIFF
--- a/kernel/private/classes/ezpevent.php
+++ b/kernel/private/classes/ezpevent.php
@@ -53,6 +53,12 @@ class ezpEvent
             $listeners = eZINI::instance()->variable( 'Event', 'Listeners' );
             foreach ( $listeners as $listener )
             {
+                // $listener may be empty if some override logic has been involved
+                if ($listener == "")
+                {
+                    continue;
+                }
+
                 // format from ini is seperated by @
                 list( $event, $callback ) = explode( '@', $listener );
                 $this->attach( $event, $callback );


### PR DESCRIPTION
This commit is indeed needed by https://github.com/ezsystems/ezjscore/pull/12

Now when an extension (for example ezjscore) adds a listener, it can provide it with a key like: (the key is here ezjscore_css_optimizer)
Listeners[ezjscore_css_optimizer]=optimize/css@callback

and another extension that extends the previous extension (ezjscore in our example), it can safely 'delete' a previously defined listener by performing Listeners[ezjscore_css_optimizer]=

This logic of keyword indicated by @andrerom is nice, as it gives a lot of liberty to another developer that wants to get ride of some listeners afterwards

This commit is just to fix a php warning, as a listener may be empty here
