### PR TITLE
When password is generated, send it by mail

### DIFF
--- a/kernel/user/ezuseroperationcollection.php
+++ b/kernel/user/ezuseroperationcollection.php
@@ -81,6 +81,12 @@ class eZUserOperationCollection
         $hostname = eZSys::hostname();
         $tpl->setVariable( 'hostname', $hostname );
 
+        $http = eZHTTPTool::instance();
+        if( $http->hasSessionVariable( 'GeneratedPassword' ) )
+        {
+            $tpl->setVariable( 'password', $http->sessionVariable( 'GeneratedPassword' ) );
+        }
+
         // Check whether account activation is required.
         $verifyUserType = $ini->variable( 'UserSettings', 'VerifyUserType' );
         $sendUserMail = !!$verifyUserType;


### PR DESCRIPTION
`registrationinfo.tpl` has a rule to display password if proper ini configuration is activated. As a matter of fact, password variable was never set to `registrationinfo.tpl`.
