### PR TITLE
Fixed check if checkbox is checked

### DIFF
--- a/design/admin2/javascript/ezajaxsubitems_datatable.js
+++ b/design/admin2/javascript/ezajaxsubitems_datatable.js
@@ -310,7 +310,7 @@ var sortableSubitems = function () {
                         }
                         var shownKeys = [];
                         $('#to-dialog-container input[name=TableOptionColumn]').each(function(i, e) {
-                            if ( $(this).prop('checked') == true )
+                            if ( $(this).prop('checked') )
                                 shownKeys.push( $(this).prop('value') );
                         });
 


### PR DESCRIPTION
What a nice commit message :). Here's the thing:

Depending on the jQuery version defined in ezjscore (1.4.x or 1.6.x), `$(this).prop('checked')` returns either `true` (1.4.x) or `"checked"` (1.6.x).

By removing the explicit check for "true", both cases can be matched.
