### PR TITLE
Implemented: EZP-23289: Add view parameter support to layout module views

### DIFF
--- a/kernel/private/classes/ezpkernelweb.php
+++ b/kernel/private/classes/ezpkernelweb.php
@@ -550,6 +550,20 @@ class ezpKernelWeb implements ezpWebBasedKernelHandler
                 $tpl->setVariable( 'requested_uri_string', $this->actualRequestedURI );
             }
 
+            // Set the view parameters
+            $viewParameters = array();
+            $uriUserParameters = $uri->userParameters();
+
+            foreach( $uriUserParameters as $key => $param )
+            {
+                if( $param != '' )
+                {
+                    $viewParameters = array_merge( $viewParameters, array( $key => $param ) );
+                }
+            }
+
+            $tpl->setVariable( 'view_parameters', $viewParameters );
+
             // Set UI context and component
             $tpl->setVariable( 'ui_context', $moduleResult['ui_context'] );
             $tpl->setVariable( 'ui_component', $moduleResult['ui_component'] );


### PR DESCRIPTION
...the original request view parameters are available to templates within the context of the original request

Hello eZ Community and eZ Crew!

This solution allows normal requests to modules which support the use of the eZModule:STATUS_RERUN feature provided in the default index.php to provide access to the view parameters of the original request for use within any of the templates of the original request.

This allows module views provide within the context of an extension to support view parameters within module views which make use of the eZModule:STATUS_RERUN functionality provided within the index.php.

Without this functionality view parameters are not supported within the context of custom module view extensions using the eZModule:STATUS_RERUN functionality by default.

This poses some problems for custom modules trying to support the same view parameter usage within templates used within one module view's context within another very similar module regardless of the use of the eZModule :STATUS_RERUN functionality.

A prime example this problem is the use of view_parameters within templates used by the content/view module view by default while the layout/set module view's use of the eZModule:STATUS_RERUN functionality currently prevents use of the view parameters provided by the request to layout/set URL.

If you wanted to use the same templates and view parameters for requests to the layout/set module view then this solution may be helpful you and others developers.

Please note that this solution requires no changes to any existing modules, module views or any other code to provide the support desired in the above described use case(s). The problem is isolated to a very specific feature of the eZModule class within the default eZ Publish index file, index.php

This use case can come up when users wish to link to a 'printer friendly' layout of say an 'article' content object (display all pages of an article in one page for example) with the same view parameters as the original request (to view the article using the default pagelayout) URL. Without this solution view parameters are simply unavailable to the templates within this request context.

This is a frustrating inconsistency that leads users to use custom templates, template operators and ultimately GET/POST request variables which are all fine but much less friendly to the view parameter support we have all come to respect, enjoy using and ultimately (good or bad) expect within the template context of most template usage use cases. 

The use of GET/POST variables as always is retained after use of the provided pull request, yet additionally if your request provided view parameters, those are also now available for your use within the original requests templates as well.

Additionally if your custom module makes use of the eZModule:STATUS_RERUN feature (like modified copies of the default layout module or other similar such module as an easily understood example) they would automatically have access to the view parameters provided within the context of the original request as well. With no code changes required to your existing module view or templates. Though re-factoring to support this feature within your custom templates may be required to make use of the view parameters that would be then provided / available.

Again we would not request this change for inclusion into eZ Publish master if we did not truly believe that the additions of these improvements represent an important standardization of view parameters support  within templates despite the module's use of the eZModule:STATUS_RERUN feature.

Note: Before considering a pull request we took the time to ask more than three other expert eZ Publish developers in the eZ Community to review this patch and share their opinions of the changes. All the eZ Publish developers strongly urged us to send these changes as a pull request back to the eZ Publish master repository.  Which we are doing here now with this pull request on their / our combined behalf.

Please let us know directly if there are any further improvements or refinements we can make to this solution / pull request in order to reach approval of these improvements to module view parameter support back into the eZ Publish everyone loves so much.

Thank you for your continued support and support of the eZ Community!

This is our first public eZ Publish / eZ Community related pull request back to the original project master repository please understand if we have made mistakes within the bounds of this our first time making such a request. We seek to help the user and developers but we may make mistakes. Simply help us understand and we will do our very best to improve right away.

Best wishes

Cheers,
Brookins Consulting

Note: Brookins Consulting has long ago (and on more than one occasion) provided a signed and registered CLA with eZ Systems AS
