### PR TITLE
Load a users latest draft when viewing av tree node

### DIFF
--- a/kernel/classes/ezcontentobjecttreenode.php
+++ b/kernel/classes/ezcontentobjecttreenode.php
@@ -220,7 +220,32 @@ class eZContentObjectTreeNode extends eZPersistentObject
     */
     function dataMap()
     {
-        return $this->object()->fetchDataMap( $this->attribute( 'contentobject_version' ) );
+        return $this->object()->fetchDataMap( $this->displayedVersion() );
+    }
+
+    /**
+     * Find what version of the content object to display
+     * for the current user
+     *
+     * @return int Version to display
+     */
+    protected function displayedVersion()
+    {
+        $contentINI = eZINI::instance( 'content.ini' );
+        $displayMode = $contentINI->variable( 'VersionManagement', 'DisplayMode' );
+
+        // Default behavior will always be to return the current contentobject_version
+        $version = $this->attribute( 'contentobject_version' );
+        switch ( $displayMode )
+        {
+            case 'latest':
+                $user = eZUser::currentUser();
+                $userDraft = eZContentObjectVersion::fetchUserDraft( $this->ContentObjectID, $user->id() );
+                if ( is_object( $userDraft ) && $draft = $userDraft->attribute( 'version' ) )
+                    $version = $draft;
+                break;
+        }
+        return $version;
     }
 
     /*!

--- a/settings/content.ini
+++ b/settings/content.ini
@@ -50,6 +50,11 @@ InternalDraftsDuration[seconds]=0
 # Clean-up limit per one run of the 'internal_drafts_cleanup.php' cronjob script
 InternalDraftsCleanUpLimit=100
 
+# Define what version to display:
+# latest = Default on published, but use my draft if its newer
+# published = Always use published (default)
+DisplayMode=latest
+
 [EditSettings]
 # A list of extensions containing custom content edit handlers.
 # These handler must be placed in : <extensions>/<extension-name>/content/<extension-name>handler.php


### PR DESCRIPTION
This is an implementation of http://share.ez.no/feature-requests/display-latest-draft-for-editors.
I'm unsure how much more than this is needed, this takes care of a regular content node view.
Go ahead and discuss :)
