### PR TITLE
Absolute CacheDir path fix for index cluster

### DIFF
--- a/config.php-RECOMMENDED
+++ b/config.php-RECOMMENDED
@@ -223,4 +223,14 @@ define( 'CLUSTER_STORAGE_PASS', 'dbpassword' );
  */
 // define( 'CLUSTER_HEADER_X_POWERED_BY', true );
 
+
+/**
+ * Define to true if you registered an absolute path
+ * to CacheDir in site.ini so that path to public
+ * caches (i.e. ezjscore) are calculated correctly
+ * by the index_cluster.
+ * Optional. Defaults to false.
+ */
+// define( 'CLUSTER_CACHE_DIR_IS_ABSOLUTE', true);
+ 
 ?>

--- a/index_cluster.php
+++ b/index_cluster.php
@@ -30,6 +30,7 @@ if ( !defined( 'CLUSTER_PERSISTENT_CONNECTION' ) ) define( 'CLUSTER_PERSISTENT_C
 if ( !defined( 'CLUSTER_STORAGE_USER' ) )          define( 'CLUSTER_STORAGE_USER', '' );
 if ( !defined( 'CLUSTER_STORAGE_PASS' ) )          define( 'CLUSTER_STORAGE_PASS', '' );
 if ( !defined( 'CLUSTER_STORAGE_DB' ) )            define( 'CLUSTER_STORAGE_DB', '' );
+if ( !defined( 'CLUSTER_CACHE_DIR_IS_ABSOLUTE' ) ) define( 'CLUSTER_CACHE_DIR_IS_ABSOLUTE', false );
 
 ini_set( 'display_errors', CLUSTER_ENABLE_DEBUG );
 
@@ -57,4 +58,15 @@ $gateway = new $gatewayClass(
     )
 );
 
-$gateway->retrieve( ltrim( $_SERVER['SCRIPT_URL'], '/' ) );
+// Path to public cache files (ezjscore) should not be ltrimed if CacheDir is absolute
+// as they are stored in cluster meta with the pre-pending slash
+if ( CLUSTER_CACHE_DIR_IS_ABSOLUTE && preg_match( '/\/public\/.*(css|js)/', $_SERVER['SCRIPT_URL'] ) )
+{
+	$filename = $_SERVER['SCRIPT_URL'];
+}
+else
+{
+	$filename = ltrim( $_SERVER['SCRIPT_URL'], '/' );
+}
+
+$gateway->retrieve( $filename );


### PR DESCRIPTION
When CacheDir is set to an absolute path in site.ini, paths are store
in the cluster metadata with a prepending slash.
ltriming that slash before passing the filename to the index_cluster
leads to a 404 error.

This patch is somewhat related to an other pull request on ezjscore
https://github.com/ezsystems/ezjscore/pull/15
