### PR TITLE
Recursive delete should work with cache dir on absolute path

### DIFF
--- a/lib/ezfile/classes/ezdir.php
+++ b/lib/ezfile/classes/ezdir.php
@@ -269,9 +269,15 @@ class eZDir
             return false;
 
         // rootCheck is enabled and $dir is not part of the root directory
-        if ( $rootCheck && strpos( dirname( realpath( $dir ) ) . DIRECTORY_SEPARATOR, realpath( eZSys::rootDir() ) . DIRECTORY_SEPARATOR ) === false )
-            return false;
-
+        // or the cache directory (if set to an absolute path)
+        if ( $rootCheck )
+        {
+        	$dirPath = dirname( realpath( $dir ) ) . DIRECTORY_SEPARATOR;
+        	if ( strpos( $dirPath, realpath( eZSys::rootDir() ) . DIRECTORY_SEPARATOR ) === false )
+        		if ( strpos( $dirPath, realpath( eZSys::cacheDirectory() ) . DIRECTORY_SEPARATOR ) === false )
+	            	return false;
+        }
+        
         // the directory cannot be opened
         if ( ! ( $handle = @opendir( $dir ) ) )
             return false;


### PR DESCRIPTION
How to observe and reproduce:
- Set CacheDir with an absolute path (outside of ez root) directory in site.ini (e.g. /my/abs/cache)
- Compile some templates (either by browsing or using bin/php/eztc.php) => templates are compiled in /my/abs/cache/template/compiled
- Empty the template cache (php bin/php/ezcache.php --clear-id=template)

Expected result:
directory /my/abs/cache/template doesn't exist anymore

Actual result:
directory still exist with all compiled templates still there

This patch will let the script recursively delete the dir (and any other) if it is part of the defined CacheDir.
