### PR TITLE
Adding ezpevent notifications before and after template processing.

### DIFF
--- a/lib/eztemplate/classes/eztemplate.php
+++ b/lib/eztemplate/classes/eztemplate.php
@@ -522,7 +522,7 @@ class eZTemplate
                 eZDebug::addTimingPoint( "Process" );
             eZDebug::accumulatorStart( 'template_processing', 'template_total', 'Template processing' );
 
-            ezpEvent::getInstance()->notify( 'template/pre_processing', array( &$this, $resourceData ) );
+            ezpEvent::getInstance()->notify( 'template/pre_processing', array( $this, $resourceData ) );
 
             $templateCompilationUsed = false;
             if ( $resourceData['compiled-template'] )
@@ -546,7 +546,7 @@ class eZTemplate
                     eZDebug::writeDebug( "FETCH END URI: $template, $fname" );
             }
 
-            ezpEvent::getInstance()->notify( 'template/post_processing', array( &$this, $resourceData ) );
+            ezpEvent::getInstance()->notify( 'template/post_processing', array( $this, $resourceData ) );
 
             eZDebug::accumulatorStop( 'template_processing' );
             if ( $this->ShowDetails )


### PR DESCRIPTION
This pull request adds 2 ezpevent notifications during the template processing :
- template/pre_processing
- template/post_processing

These event notifications enable to hook PHP code just before or just after the template execution.

Example usage :

site.ini :

[Event]
Listeners[]=template/pre_processing@ezkTemplateHook::preProcess

class ezkTemplateHook :

public static function preProcess( $tpl, $resourceData )
{
  // Fetch variable from current node and set template variables :
  $node = $tpl->variable( 'node' );
  $testFieldsByLocation = self::getTestFieldsByLocation( ezpContentLocation::fromNode( $node ), $resourceData );
  foreach( $testFieldsByLocation as $key=>$value )
  {
    $tpl->setVariable( $key, $value );
  }
}

private static function getTestFieldsByLocation( ezpContentLocation $location, $resourceData )
{
  // @TODO return an associative Array with values fetched using the API, depending on location and resource Data
}

Then variables can be used directly within the template's code without using the ugly templating language to do business processing.
