### PR TITLE
Fixed #019165: createAndPublishObject shouldn't try to create the object...

### DIFF
--- a/kernel/classes/datatypes/ezboolean/ezbooleantype.php
+++ b/kernel/classes/datatypes/ezboolean/ezbooleantype.php
@@ -172,7 +172,8 @@ class eZBooleanType extends eZDataType
 
     function fromString( $contentObjectAttribute, $string )
     {
-        return $contentObjectAttribute->setAttribute( 'data_int', $string );
+        $contentObjectAttribute->setAttribute( 'data_int', $string );
+        return true;
     }
 
     function isIndexable()

--- a/kernel/classes/datatypes/ezcountry/ezcountrytype.php
+++ b/kernel/classes/datatypes/ezcountry/ezcountrytype.php
@@ -378,7 +378,8 @@ class eZCountryType extends eZDataType
 
     function fromString( $contentObjectAttribute, $string )
     {
-        return $contentObjectAttribute->setAttribute( 'data_text', $string );
+        $contentObjectAttribute->setAttribute( 'data_text', $string );
+        return true;
     }
 
     /*!

--- a/kernel/classes/datatypes/ezdate/ezdatetype.php
+++ b/kernel/classes/datatypes/ezdate/ezdatetype.php
@@ -264,7 +264,8 @@ class eZDateType extends eZDataType
 
     function fromString( $contentObjectAttribute, $string )
     {
-        return $contentObjectAttribute->setAttribute( 'data_int', $string );
+        $contentObjectAttribute->setAttribute( 'data_int', $string );
+        return true;
     }
 
     /*!

--- a/kernel/classes/datatypes/ezdatetime/ezdatetimetype.php
+++ b/kernel/classes/datatypes/ezdatetime/ezdatetimetype.php
@@ -293,7 +293,8 @@ class eZDateTimeType extends eZDataType
 
     function fromString( $contentObjectAttribute, $string )
     {
-        return $contentObjectAttribute->setAttribute( 'data_int', $string );
+        $contentObjectAttribute->setAttribute( 'data_int', $string );
+        return true;
     }
 
     /*!

--- a/kernel/classes/datatypes/ezemail/ezemailtype.php
+++ b/kernel/classes/datatypes/ezemail/ezemailtype.php
@@ -189,7 +189,8 @@ class eZEmailType extends eZDataType
 
     function fromString( $contentObjectAttribute, $string )
     {
-        return $contentObjectAttribute->setAttribute( 'data_text', $string );
+        $contentObjectAttribute->setAttribute( 'data_text', $string );
+        return true;
     }
 
     /*!

--- a/kernel/classes/datatypes/ezfloat/ezfloattype.php
+++ b/kernel/classes/datatypes/ezfloat/ezfloattype.php
@@ -340,7 +340,8 @@ class eZFloatType extends eZDataType
 
     function fromString( $contentObjectAttribute, $string )
     {
-        return $contentObjectAttribute->setAttribute( 'data_float', $string );
+        $contentObjectAttribute->setAttribute( 'data_float', $string );
+        return true;
     }
 
     function serializeContentClassAttribute( $classAttribute, $attributeNode, $attributeParametersNode )

--- a/kernel/classes/datatypes/ezinteger/ezintegertype.php
+++ b/kernel/classes/datatypes/ezinteger/ezintegertype.php
@@ -394,7 +394,8 @@ class eZIntegerType extends eZDataType
 
     function fromString( $contentObjectAttribute, $string )
     {
-        return $contentObjectAttribute->setAttribute( 'data_int', $string );
+        $contentObjectAttribute->setAttribute( 'data_int', $string );
+        return true;
     }
 
     /*!

--- a/kernel/classes/datatypes/ezisbn/ezisbntype.php
+++ b/kernel/classes/datatypes/ezisbn/ezisbntype.php
@@ -382,7 +382,8 @@ class eZISBNType extends eZDataType
 
     function fromString( $contentObjectAttribute, $string )
     {
-        return $contentObjectAttribute->setAttribute( self::CONTENT_VALUE, $string );
+        $contentObjectAttribute->setAttribute( self::CONTENT_VALUE, $string );
+        return true;
     }
 
     /*!

--- a/kernel/classes/datatypes/ezstring/ezstringtype.php
+++ b/kernel/classes/datatypes/ezstring/ezstringtype.php
@@ -287,7 +287,8 @@ class eZStringType extends eZDataType
 
     function fromString( $contentObjectAttribute, $string )
     {
-        return $contentObjectAttribute->setAttribute( 'data_text', $string );
+        $contentObjectAttribute->setAttribute( 'data_text', $string );
+        return true;
     }
 
 

--- a/kernel/classes/datatypes/ezxmltext/ezxmltexttype.php
+++ b/kernel/classes/datatypes/ezxmltext/ezxmltexttype.php
@@ -408,7 +408,8 @@ class eZXMLTextType extends eZDataType
 
     function fromString( $contentObjectAttribute, $string )
     {
-        return $contentObjectAttribute->setAttribute( 'data_text', $string );
+        $contentObjectAttribute->setAttribute( 'data_text', $string );
+        return true;
     }
 
 

--- a/kernel/classes/ezcontentfunctions.php
+++ b/kernel/classes/ezcontentfunctions.php
@@ -150,8 +150,16 @@ class eZContentFunctions
                                 default:
                             }
 
-                            $attribute->fromString( $dataString );
-                            $attribute->store();
+                            if ( $attribute->fromString( $dataString ) )
+                            {
+                                $attribute->store();
+                            }
+                            else
+                            {
+                                $db->rollback();                                
+                                eZDebug::writeError( "Error trying to add '$attributeIdentifier' to the '$classIdentifier' object.", __METHOD__ );
+                                return false;
+                            }
                         }
                     }
                 }
@@ -305,8 +313,16 @@ class eZContentFunctions
                     default:
                 }
 
-                $attribute->fromString( $dataString );
-                $attribute->store();
+                if ( $attribute->fromString( $dataString ) )
+                {
+                    $attribute->store();
+                }
+                else
+                {
+                    $db->rollback();
+                    eZDebug::writeError( "Error trying to update '$attributeIdentifier' for object " . $object->attribute( 'id' ) . ".", __METHOD__ );
+                    return false;
+                }
             }
         }
 


### PR DESCRIPTION
... if some errors are detected in fromString calls

see related issue for the info. 

i've changed some fromString datatype functions to make them return truem, only for those returning void previously (setAttribute returns void)

let me know if it works :). 
