### PR TITLE
Added an 'is_file()'-check on $file in md5sum() to prevent a php-error when $file is a directory and not a file.

### DIFF
--- a/kernel/classes/ezpackage.php
+++ b/kernel/classes/ezpackage.php
@@ -503,7 +503,7 @@ class eZPackage
     {
         if ( function_exists( 'md5_file' ) )
         {
-            if ( file_exists( $file ) && is_file( $file ) )
+            if ( is_file( $file ) )
             {
                 return md5_file( $file );
             }


### PR DESCRIPTION
The function md5sum() will throw a php-error if $file is a directory and not a file. This fix will prevent any error being thrown.
