### PR TITLE
Bigint is not compatible with an oracle insert schema.

### DIFF
--- a/share/db_schema.dba
+++ b/share/db_schema.dba
@@ -5181,7 +5181,7 @@ $schema = array (
       'expirytime' => 
       array (
         'length' => 20,
-        'type' => 'bigint',
+        'type' => 'int',
         'not_null' => '1',
         'default' => '0',
       ),
@@ -5388,7 +5388,7 @@ $schema = array (
       'expirytime' => 
       array (
         'length' => 20,
-        'type' => 'bigint',
+        'type' => 'int',
         'not_null' => '1',
         'default' => '0',
       ),


### PR DESCRIPTION
The script fail with this query, bigINTEGER is not recognize

``` sql
CREATE TABLE ezprest_authcode (
  client_id VARCHAR2(200) NOT NULL,
  expirytime bigINTEGER(20) DEFAULT '0' NOT NULL,
  id VARCHAR2(200) NOT NULL,
  scope VARCHAR2(200),
  user_id INTEGER DEFAULT 0 NOT NULL,
  PRIMARY KEY ( id )
)
```
