### PR TITLE
Switchlanguage : correct a BUG of a redirection when a non-existing siteaccess has been writen in the URL

### DIFF
--- a/kernel/private/classes/ezplanguageswitcher.php
+++ b/kernel/private/classes/ezplanguageswitcher.php
@@ -55,7 +55,19 @@ class ezpLanguageSwitcher implements ezpLanguageSwitcherCapable
     {
         if ( $this->destinationSiteAccessIni === null )
         {
-            $this->destinationSiteAccessIni = eZSiteAccess::getIni( $this->destinationSiteAccess, 'site.ini' );
+            $siteaccess=eZSiteAccess::siteAccessList();
+        	$findsiteaccess=false;
+        	foreach($siteaccess as $sa){
+        		if($sa['name']==$this->destinationSiteAccess){
+        			$findsiteaccess=true;
+        		}
+        	}
+        	if($findsiteaccess){
+            	$this->destinationSiteAccessIni = eZSiteAccess::getIni( $this->destinationSiteAccess, 'site.ini' );
+        	}else{
+        		$current=eZSiteAccess::current();
+            	$this->destinationSiteAccessIni = eZSiteAccess::getIni( $current['name'], 'site.ini' );
+        	}
         }
         return $this->destinationSiteAccessIni;
     }


### PR DESCRIPTION
Correct a BUG of a redirection to "example.com" when a non-existing siteaccess has been writen in the URL.

For example, this URL redirect to "http://example.com" :
http://ez.no/switchlanguage/to/fail
