### PR TITLE
Removing useless hard-coded values

### DIFF
--- a/lib/ezutils/classes/ezini.php
+++ b/lib/ezutils/classes/ezini.php
@@ -131,7 +131,7 @@ class eZINI
      * @param bool $load @since 4.5 Lets you disable automatic loading of ini values in
      *                   cases where changes on instance will be done first.
      */
-    function eZINI( $fileName = null, $rootDir = null, $useTextCodec = null, $useCache = null, $useLocalOverrides = null, $directAccess = false, $addArrayDefinition = false, $load = true )
+    function eZINI( $fileName = self::CONFIG_FILENAME, $rootDir = self::CONFIG_ROOTDIR, $useTextCodec = null, $useCache = null, $useLocalOverrides = null, $directAccess = false, $addArrayDefinition = false, $load = true )
     {
         $this->Charset = 'utf8';
 
@@ -295,11 +295,8 @@ class eZINI
      * @param string parameter parameter name
      * @return bool True if the the parameter is set.
      */
-    static function parameterSet( $fileName = null, $rootDir = null, &$section, &$parameter )
+    static function parameterSet( $fileName = self::CONFIG_FILENAME, $rootDir = self::CONFIG_ROOTDIR, &$section, &$parameter )
     {
-        if( empty( $fileName ) ) $fileName = self::CONFIG_FILENAME;
-        if( empty( $rootDir ) )  $rootDir  = self::CONFIG_ROOTDIR;
-
         if ( !eZINI::exists( $fileName, $rootDir ) )
             return false;
 
@@ -312,7 +309,7 @@ class eZINI
      \return true if the INI file \a $fileName exists in the root dir \a $rootDir.
      $fileName defaults to site.ini and rootDir to settings.
     */
-    static function exists( $fileName = null, $rootDir = null )
+    static function exists( $fileName = self::CONFIG_FILENAME, $rootDir = self::CONFIG_ROOTDIR )
     {
         if( empty( $fileName ) ) $fileName = self::CONFIG_FILENAME;
         if( empty( $rootDir ) )  $rootDir  = self::CONFIG_ROOTDIR;
@@ -1663,11 +1660,8 @@ class eZINI
      *
      * @return bool
      */
-    static function isLoaded( $fileName = null, $rootDir = null, $useLocalOverrides = null )
+    static function isLoaded( $fileName = self::CONFIG_FILENAME, $rootDir = self::CONFIG_ROOTDIR, $useLocalOverrides = null )
     {
-        if( empty( $fileName ) ) $fileName = self::CONFIG_FILENAME;
-        if( empty( $rootDir ) )  $rootDir  = self::CONFIG_ROOTDIR;
-
         return isset( self::$instances["$rootDir-$fileName-$useLocalOverrides"] );
     }
 
@@ -1688,16 +1682,13 @@ class eZINI
      * @param bool $addArrayDefinition @deprecated since version 4.5, use "new eZINI()" (instance not used if true!)
      * @return eZINI
      */
-    static function instance( $fileName = null, $rootDir = null, $useTextCodec = null, $useCache = null, $useLocalOverrides = null, $directAccess = false, $addArrayDefinition = false )
+    static function instance( $fileName = self::CONFIG_FILENAME, $rootDir = self::CONFIG_ROOTDIR, $useTextCodec = null, $useCache = null, $useLocalOverrides = null, $directAccess = false, $addArrayDefinition = false )
     {
         if ( $addArrayDefinition !== false  || $directAccess !== false || $useTextCodec !== null || $useCache !== null )
         {
             // Could have trown strict error here but will cause issues if ini system has not been setup yet..
             return new eZINI( $fileName, $rootDir, $useTextCodec, $useCache, $useLocalOverrides, $directAccess, $addArrayDefinition );
         }
-
-        if( empty( $fileName ) ) $fileName = self::CONFIG_FILENAME;
-        if( empty( $rootDir ) )  $rootDir  = self::CONFIG_ROOTDIR;
 
         $key = "$rootDir-$fileName-$useLocalOverrides";
         if ( !isset( self::$instances[$key] ) )
@@ -1734,7 +1725,7 @@ class eZINI
       \static
       Similar to instance() but will always create a new copy.
     */
-    static function create( $fileName = null, $rootDir = null, $useTextCodec = null, $useCache = null, $useLocalOverrides = null )
+    static function create( $fileName = self::CONFIG_FILENAME, $rootDir = self::CONFIG_ROOTDIR, $useTextCodec = null, $useCache = null, $useLocalOverrides = null )
     {
         $impl = new eZINI( $fileName, $rootDir, $useTextCodec, $useCache, $useLocalOverrides );
         return $impl;
@@ -1767,7 +1758,7 @@ class eZINI
      *
      * @see resetInstance()
      */
-    static function resetGlobals( $fileName = null, $rootDir = null, $useLocalOverrides = null )
+    static function resetGlobals( $fileName = self::CONFIG_FILENAME, $rootDir = self::CONFIG_ROOTDIR, $useLocalOverrides = null )
     {
         self::resetInstance( $fileName, $rootDir, $useLocalOverrides );
     }
@@ -1781,11 +1772,8 @@ class eZINI
      * @param string $rootDir
      * @param null|bool $useLocalOverrides default system setting if null
      */
-    static function resetInstance( $fileName = null, $rootDir = null, $useLocalOverrides = null )
+    static function resetInstance( $fileName = self::CONFIG_FILENAME, $rootDir = self::CONFIG_ROOTDIR, $useLocalOverrides = null )
     {
-        if( empty( $fileName ) ) $fileName = self::CONFIG_FILENAME;
-        if( empty( $rootDir ) )  $rootDir  = self::CONFIG_ROOTDIR;
-
         unset( self::$instances["$rootDir-$fileName-$useLocalOverrides"] );
     }
 


### PR DESCRIPTION
I will use an example to explain what I did in my commit.

If we had this script:

``` php
<?php
class A
{
    static function b( $file = 'site.ini' ) {
        return "[".$file."]\n";
    }

    static function c( $file = 'site.ini' )
    {
        return self::b( $file );
    }
}

echo A::b();
echo A::b('');
echo A::c();
echo A::c('');
```

There are redundant hard-coded 'site.ini' values and there is no test to check if $file is not null.

The result will be :

```
[site.ini]
[]
[site.ini]
[]
```

So I changed the code this way :

``` php
<?php
class A
{
    const FILE = 'site.ini';

    static function b( $file = null ) {

        if( empty( $file ) ) $file = self::FILE;

        return "[".$file."]\n";
    }

    static function c( $file = null )
    {
        return self::b( $file );
    }
}
```

site.ini is in a constant, if $file is null, false, or en empty string, it will get the A::FILE value.

You can notice that there is no test in A::c( $file ), it's because the test is not necessary here, and would be redundant with the one in A::b($file);

In eZINI there are lot of functions like file_exists, mkdir, etc. So empty string will always lead to errors.

Let me know if you think that something is not correct in this modification.
