### PR TITLE
Optimized: eZTemplateSectionIterator attributes handling

### DIFF
--- a/lib/eztemplate/classes/eztemplatesectioniterator.php
+++ b/lib/eztemplate/classes/eztemplatesectioniterator.php
@@ -37,7 +37,6 @@ class eZTemplateSectionIterator
                                            'number' => false,
                                            'sequence' => false,
                                            'last' => false );
-        $this->InternalAttributeNames = array_keys( $this->InternalAttributes );
     }
 
     /*!
@@ -76,15 +75,22 @@ class eZTemplateSectionIterator
     */
     function hasAttribute( $name )
     {
-        if ( in_array( $name, $this->InternalAttributeNames ) )
-            return true;
+        switch ( $name )
+        {
+            case "item":
+            case "key":
+            case "index":
+            case "number":
+            case "sequence":
+            case "last":
+                return true;
+        }
         $item = $this->InternalAttributes['item'];
         if ( is_array( $item ) )
         {
-            return in_array( $name, array_keys( $item ) );
+            return array_key_exists( $name, $item );
         }
-        else if ( is_object( $item ) and
-                  method_exists( $item, 'hasAttribute' ) )
+        if ( is_object( $item ) && method_exists( $item, 'hasAttribute' ) )
         {
             return $item->hasAttribute( $name );
         }
@@ -97,17 +103,22 @@ class eZTemplateSectionIterator
     */
     function attribute( $name )
     {
-        if ( in_array( $name, $this->InternalAttributeNames ) )
+        switch ( $name )
         {
-            return $this->InternalAttributes[$name];
+            case "item":
+            case "key":
+            case "index":
+            case "number":
+            case "sequence":
+            case "last":
+                return $this->InternalAttributes[$name];
         }
         $item = $this->InternalAttributes['item'];
         if ( is_array( $item ) )
         {
             return $item[$name];
         }
-        else if ( is_object( $item ) and
-                  method_exists( $item, 'attribute' ) )
+        if ( is_object( $item ) && method_exists( $item, 'attribute' ) )
         {
             return $item->attribute( $name );
         }


### PR DESCRIPTION
Looks like much efforts has been done in the past to make it particularly inefficient :)

Wondering which of isset()/array_key_exists()/switch...case would be a good candidate:
isset(): avoided because the content might potentially be set to _null_
array_key_exists(): since this method is heavily used while generating templates, I preferred avoiding yet another function call at the price of duplicating the attributes name.
