### PR TITLE
eZ DFS

### DIFF
--- a/kernel/private/classes/clusterfilehandlers/dfsbackends/mysql.php
+++ b/kernel/private/classes/clusterfilehandlers/dfsbackends/mysql.php
@@ -17,7 +17,7 @@ CREATE TABLE ezdfsfile (
   `name` text NOT NULL,
   name_trunk text NOT NULL,
   name_hash varchar(34) NOT NULL DEFAULT '',
-  datatype varchar(60) NOT NULL DEFAULT 'application/octet-stream',
+  datatype varchar(255) NOT NULL DEFAULT 'application/octet-stream',
   scope varchar(25) NOT NULL DEFAULT '',
   size bigint(20) unsigned NOT NULL DEFAULT '0',
   mtime int(11) NOT NULL DEFAULT '0',

--- a/kernel/private/classes/clusterfilehandlers/dfsbackends/mysqli.php
+++ b/kernel/private/classes/clusterfilehandlers/dfsbackends/mysqli.php
@@ -17,7 +17,7 @@ CREATE TABLE ezdfsfile (
   `name` text NOT NULL,
   name_trunk text NOT NULL,
   name_hash varchar(34) NOT NULL DEFAULT '',
-  datatype varchar(60) NOT NULL DEFAULT 'application/octet-stream',
+  datatype varchar(255) NOT NULL DEFAULT 'application/octet-stream',
   scope varchar(25) NOT NULL DEFAULT '',
   size bigint(20) unsigned NOT NULL DEFAULT '0',
   mtime int(11) NOT NULL DEFAULT '0',


### PR DESCRIPTION
The maximum size of a mimetype is not correct in the database schema for eZ DFS.
Current size is defined to 60 characters but in the RFC 4288 the maximum is 127 + 1 + 127

You can see more informations about this in [RFC 4288](http://tools.ietf.org/html/rfc4288#section-4.2)

Example with Microsoft Word 2007 (docx) is "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
