### PR TITLE
Fixed #017773: Publishing the home page after preview triggers an error

### DIFF
--- a/kernel/content/versionviewframe.php
+++ b/kernel/content/versionviewframe.php
@@ -112,7 +112,19 @@ if ( $Module->isCurrentAction( 'Publish' ) and
         }
         else
         {
-            $Module->redirectToView( 'view', array( 'full', $object->attribute( 'main_parent_node_id' ) ) );
+            if ( $node !== null )
+            {
+                $parentNode = $node->attribute( 'parent_node_id' );
+                if ( $parentNode == 1 )
+                {
+                    $parentNode = $node->attribute( 'node_id' );
+                }
+                $Module->redirectToView( 'view', array( 'full', $parentNode ) );
+            }
+            else
+            {
+                $Module->redirectToView( 'view', array( 'full', $object->attribute( 'main_parent_node_id' ) ) );
+            }
         }
     }
     else


### PR DESCRIPTION
The module was redirecting back to the parent node. The fix checks for an
available node, and checks if the parent node_id equals 1. If so,
we redirect back to the current node id.
Code is similar to the one used in content/edit.php
