### PR TITLE
Fixed #018451: oauth/authorize doesn't work to deny access

### DIFF
--- a/kernel/private/modules/oauth/authorize.php
+++ b/kernel/private/modules/oauth/authorize.php
@@ -252,7 +252,7 @@ function getHTTPVariable( $variable )
         $http = eZHTTPTool::instance();
 
     if ( $hasPost === null )
-        $hasPost = $http->hasPostVariable( 'AuthorizeButton' ) or $http->hasPostVariable( 'DenyButton' );
+        $hasPost = $http->hasPostVariable( 'AuthorizeButton' ) || $http->hasPostVariable( 'DenyButton' );
 
     if ( $hasPost )
         return $http->hasPostVariable( $variable ) ? $http->postVariable( $variable ) : false;


### PR DESCRIPTION
"||" has a greater precedence than "=" which has a greater precedence than "or"
