### PR TITLE
Fixed #019440: Installation failed at Site selection

### DIFF
--- a/lib/ezi18n/classes/ezchartransform.php
+++ b/lib/ezi18n/classes/ezchartransform.php
@@ -394,8 +394,8 @@ class eZCharTransform
     {
         $sep  = eZCharTransform::wordSeparator();
         $sepQ = preg_quote( $sep );
-        $text = preg_replace( array( "#[^a-zA-Z0-9_!.-]+#",
-                                     "#^[.]+|[!.]+$#", # Remove dots at beginning/end
+        $text = preg_replace( array( "#[^a-zA-Z0-9_!\.-]+#",
+                                     "#^[\.]+|[!\.]+$#", # Remove dots at beginning/end
                                      "#\.\.+#", # Remove double dots
                                      "#[{$sepQ}]+#", # Turn multiple separators into one
                                      "#^[{$sepQ}]+|[{$sepQ}]+$#" ), # Strip separator from beginning/end
@@ -423,7 +423,7 @@ class eZCharTransform
         if ( $sep != "-" )
             $prepost .= "-";
         $text = preg_replace( array( "#[ \\\\%\#&;/:=?\[\]()+]+#",
-                                     "#^[.]+|[!.]+$#", # Remove dots at beginning/end
+                                     "#^[\.]+|[!\.]+$#", # Remove dots at beginning/end
                                      "#\.\.+#", # Remove double dots
                                      "#[{$sepQ}]+#", # Turn multiple separators into one
                                      "#^[{$prepost}]+|[{$prepost}]+$#" ),


### PR DESCRIPTION
In my warning.log,  this line appeared:

preg_replace(): Compilation failed: POSIX collating elements are not supported at offset 1 in /home/patrice/Workspace/xproject/lib/ezi18n/classes/ezchartransform.php on line 407

Then I added escape character before "." in regex at line 397 and 425  of ezchartransform.php file.
