### PR TITLE
Fixed EZP-19451: get rid of require_once calls in ezdbschema

### DIFF
--- a/settings/dbschema.ini
+++ b/settings/dbschema.ini
@@ -10,10 +10,10 @@
 #       and can be used for this purpose).
 
 [SchemaSettings]
+# DEPRECATED
+# we now rely on class autoloading for db schema handlers, this is kept for compatibility
+# and will be removed in the future
 SchemaPaths[]
-SchemaPaths[mysql]=lib/ezdbschema/classes/ezmysqlschema.php
-SchemaPaths[mysqli]=lib/ezdbschema/classes/ezmysqlschema.php
-SchemaPaths[postgresql]=lib/ezdbschema/classes/ezpgsqlschema.php
 
 SchemaHandlerClasses[]
 SchemaHandlerClasses[mysql]=eZMysqlSchema


### PR DESCRIPTION
Allow php-based autoloading for db schema handlers

Issue: https://jira.ez.no/browse/EZP-19451
