### PR TITLE
Changed output to fputs(STDOUT) instead of print.

### DIFF
--- a/lib/ezutils/classes/ezcli.php
+++ b/lib/ezutils/classes/ezcli.php
@@ -348,9 +348,9 @@ class eZCLI
     {
         if ( $this->isQuiet() )
             return;
-        print( $string );
+        fputs( STDOUT, $string );
         if ( $addEOL )
-            print( $this->endlineString() );
+            fputs( STDOUT, $this->endlineString() );
     }
 
     /*!


### PR DESCRIPTION
Reason: When xdebug activated we received error messages due to already started session
