### PR TITLE
MAGICK_THREAD_LIMIT=1 for shared hosting

### DIFF
--- a/lib/ezimage/classes/ezimageshellhandler.php
+++ b/lib/ezimage/classes/ezimageshellhandler.php
@@ -102,10 +102,24 @@ class eZImageShellHandler extends eZImageHandler
         {
             $ini = eZINI::instance( 'image.ini' );
             if( $ini->hasVariable( 'ImageMagick', 'MagickThreadLimit' ) )
+            {
                 $imageMagickThreadLimit = $ini->variable( 'ImageMagick', 'MagickThreadLimit' );
-
-            if( is_numeric( $imageMagickThreadLimit ) ) 
-                putenv( 'MAGICK_THREAD_LIMIT='. $imageMagickThreadLimit );
+                if( empty( $imageMagickThreadLimit ) )
+                {
+                    eZDebug::writeNotice( 'image.ini / [ImageMagick] / MagickThreadLimit is an empty string. Assuming default ImageMagick\'s value', __METHOD__ );
+                }
+                elseif( is_numeric( $imageMagickThreadLimit ) )
+                {
+                    eZDebug::writeNotice( 'Setting MAGICK_THREAD_LIMIT environment variable to 1', __METHOD__ );
+                    putenv( 'MAGICK_THREAD_LIMIT='. $imageMagickThreadLimit );
+                }
+                else
+                {
+                    eZDebug::writeWarning( 'image.ini / [ImageMagick] / MagickThreadLimit must be a numeric value', __METHOD__ );
+                }
+            } else {
+                eZDebug::writeNotice( 'image.ini / [ImageMagick] / MagickThreadLimit is not defined. Assuming default ImageMagick\'s value' );
+            }
         }
 
         system( $systemString, $returnCode );

--- a/settings/image.ini
+++ b/settings/image.ini
@@ -295,11 +295,12 @@ PostParameters=
 # This is needed for ImageMagick to provide proper conversions of some formats.
 UseTypeTag=:
 
-# Some shared hosting providers applies memory/threads restrictions that prevents ImageMagick
-# from running properly.
-# Setting the value of MagickThreadLimit to a lower value or even to 1 might solve the problem.
-# This could also help in other situations where you need to set the value to less or equal to
-# the number of available CPU
+# Some shared hosting providers apply memory/threads restrictions that prevents ImageMagick
+# from running properly. For example if your shared hosting server restricts the number of spawned
+# threads then ImageMagick will crash at runtime or if your virtual host has 8 processors
+# but only 2 are assigned to your server instance, the default value of 8 threads might cause
+# performance problems.
+# Setting the value of MagickThreadLimit to a low value (1 or sometimes 0) might solve the problem.
 # For more info, see http://www.imagemagick.org/script/architecture.php
 MagickThreadLimit=
 


### PR DESCRIPTION
As discussed here:
http://share.ez.no/forums/setup-design/no-more-image-variations#comment75944

Adding this environment variable set to 1, this allows convert to run successfully
