### PR TITLE
Add name parameter to cache-block template function

### DIFF
--- a/bin/php/ezexpiretemplateblock.php
+++ b/bin/php/ezexpiretemplateblock.php
@@ -1,5 +1,13 @@
 #!/usr/bin/env php
 <?php
+/**
+ * File containing ezexpiretemplateblock.php script.
+ *
+ * @copyright Copyright (C) 1999-2012 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ * @package kernel
+ */
 
 require 'autoload.php';
 
@@ -40,7 +48,7 @@ if ( $options['clear-block'] )
         $cli->output( "No block name given!" );
         $script->shutdown( 0 );
     }
-    if ($nodeID)
+    if ( $nodeID )
     {
         $cli->output( "Clearing cache for template block <" . $blockName . "> and Node <" . $nodeID . ">." );
     }

--- a/lib/eztemplate/classes/eztemplatecacheblock.php
+++ b/lib/eztemplate/classes/eztemplatecacheblock.php
@@ -17,30 +17,42 @@
 class eZTemplateCacheBlock
 {
     /*!
-    USAGE:
+     Helper function for setting the expired flag to 1 to all cache block files related to the given cache block name and (optional) node id. 
+
+     \param $name Name of the cache block which should be expired.
+     \param $nodeID Optional the node id of which the named cache block should be expired.
+
+
+     Example of usage:
+     \code
         eZTemplateCacheBlock::expireCacheByName( $name, $nodeID);
-    
-    */
+     \endcode
+
+     Note: If only the $name is given all files of the named cache block will be expired. 
+           If a $nodeID is given only the file related to name and node id will be expired.
+
+     */
     static function expireCacheByName( $name, $nodeID = false )
     {
-        if ($name == '')
+        if ( $name == '' )
         {
             return;
         }
+
         $cachePath = eZTemplateCacheBlock::cachePath( eZTemplateCacheBlock::keyString( $keys ), $nodeID, $name );
 
         $phpPath = eZTemplateCacheBlock::templateBlockCacheDir() . '/';
 
         if ( is_numeric( $nodeID ) )
         {
-            $phpPath .= eZTemplateCacheBlock::subtreeCacheSubDirForNode( $nodeID, $name );
+            $phpPath .= eZTemplateCacheBlock::subtreeCacheSubDirForNode( $nodeID, $name ) . '/';
         }
         else
         {
-            $phpPath .= $name;
+            $phpPath .= $name . '/';
         }
 
-        $phpPath = $phpPath . '/' . $filename;
+        $phpPath .= $filename;
 
         $fileHandler = eZClusterFileHandler::instance($phpPath);
 
@@ -182,7 +194,7 @@ class eZTemplateCacheBlock
         }
         else
         {
-            if ($name)
+            if ( $name )
             {
                 $phpDir .= $name . '/' . $filename[0] . '/' . $filename[1] . '/' . $filename[2];
             }
@@ -202,7 +214,7 @@ class eZTemplateCacheBlock
     */
     static function templateBlockCacheDir()
     {
-        $cacheDir = eZSys::cacheDirectory() . '/template-block/' ;
+        $cacheDir = eZSys::cacheDirectory() . '/template-block/';
         return $cacheDir;
     }
 
@@ -300,7 +312,7 @@ class eZTemplateCacheBlock
     {
         $cacheDir = eZTemplateCacheBlock::subtreeCacheBaseSubDir();
 
-        if ($name != '' )
+        if ( $name != '' )
         {
             $cacheDir =  $name . '/' . $cacheDir;
         }

--- a/lib/eztemplate/classes/eztemplatecachefunction.php
+++ b/lib/eztemplate/classes/eztemplatecachefunction.php
@@ -42,7 +42,7 @@ class eZTemplateCacheFunction
                                                  'static' => false,
                                                  'transform-children' => true,
                                                  'tree-transformation' => true,
-                                                 'transform-parameters' => true ) );
+                                                    'transform-parameters' => true ) );
     }
 
     function templateNodeTransformation( $functionName, &$node,
@@ -120,7 +120,7 @@ class eZTemplateCacheFunction
             $newNodes[] = eZTemplateNodeTool::createVariableNode( false, $name, false, array(), 'name' );
 
             $code = '';
-            if ($name == '')
+            if ( $name == '')
             {
                 $code = "\$cacheKeys = array( \$cacheKeys, $placementKeyStringText, $accessNameText );\n";
             }
@@ -128,6 +128,7 @@ class eZTemplateCacheFunction
             {
                 $code = "\$cacheKeys = array( \$cacheKeys, $accessNameText );\n";
             }
+            
             $cachePathText = "\$cachePath";
         }
         else
@@ -152,6 +153,7 @@ class eZTemplateCacheFunction
             $nodeIDText = var_export( $nodeID, true );
             $code .= "list(\$cacheHandler_{$codePlacementHash}, \$contentData) =\n  eZTemplateCacheBlock::handle( $cachePathText, $nodeIDText, $ttlCode, " . ($ignoreContentExpiry ? "false" : "true") . " );\n";
         }
+  
         $code .=
             "if ( !( \$contentData instanceof eZClusterFileFailure ) )\n" .
             "{\n";
@@ -258,7 +260,7 @@ class eZTemplateCacheFunction
         if ( isset( $GLOBALS['eZCurrentAccess']['name'] ) )
             $accessName = $GLOBALS['eZCurrentAccess']['name'];
 
-        if ($name == '')
+        if ( $name == '')
         {
             if ( $keys === null )
             {
@@ -301,6 +303,7 @@ class eZTemplateCacheFunction
         {
             $globalExpiryTime = eZExpiryHandler::getTimestamp( 'template-block-cache', -1 );
         }
+  
         $globalExpiryTime = max( eZExpiryHandler::getTimestamp( 'global-template-block-cache', -1 ), // This expiry value is the true global expiry for cache-blocks
                                  $globalExpiryTime );
 


### PR DESCRIPTION
This pull request contains the functionality to give cache-blocks a name and expire the cache blocks by its name.

A new parameter "name" is intruduced to the cache-block function. The parameter is not mandotory, if its not given the cache block will work as now. So this functionality is backwards compatible.

If a name is given the cache files will be stored into a structure simliar to now. But as new subfolder the name is added. So that a cache block file is stored into 
"var/cache/template-block/[subtree/]{cache_block_name}/*".

A newly intruduced script "./bin/php/ezexpiretemplateblock.php" is able to expire all cache files of a certain cache-block or a certain file of a specific node.

The template name and code line will not used for the cache keys if a cache block name is given. So template changes will not directly expire a cache block. If there are template changes inside a cache block function an explicit cache expiration action is needed.

This pull request is an alternative to https://github.com/ezsystems/ezpublish/pull/292.
The advantage of this pull request is, that it will keep the backwards compability and adds the possibility to use the script or the API function to expire a certain cache block by a custom name.
