### PR TITLE
Add condition to handle request not served by Apache in eZ DFS mode

### DIFF
--- a/index_cluster.php
+++ b/index_cluster.php
@@ -86,4 +86,10 @@ EOF;
 // We use require_once as the gateway file may have been included before for initialization purpose
 require_once $clusterGatewayFile;
 $gateway = ezpClusterGateway::getGateway();
+
+if ( !isset( $_SERVER['SCRIPT_URL'] ) )
+{
+    $_SERVER['SCRIPT_URL'] = $_SERVER['REQUEST_URI'];
+}
+
 $gateway->retrieve( ltrim( $_SERVER['SCRIPT_URL'], '/' ) );


### PR DESCRIPTION
When eZ DFS cluster mode is used and a different webserver than Apache is used the server variable SCRIPT_URL might not be set (one example is the use of Nginx).
Thus, I suggest to fallback on REQUEST_URI that is available by default.
