### PR TITLE
Initialize content object validation parameters to avoid PHP notice

### DIFF
--- a/kernel/classes/ezcontentobjectattribute.php
+++ b/kernel/classes/ezcontentobjectattribute.php
@@ -1472,6 +1472,8 @@ class eZContentObjectAttribute extends eZPersistentObject
     public $ContentClassAttributeName;
     public $ContentClassAttributeIsInformationCollector;
     public $ContentClassAttributeIsRequired;
+
+    public $ValidationParameters = array();
 }
 
 ?>


### PR DESCRIPTION
Hi,
here is a small patch to enable calling `validateIsRequired()` method out of content/edit context. Currently, `$ValidationParameters` property is only defined when calling `setValidationParameters()` which results in an _undefined property_ notice when trying to access it out of the content/edit module.
