### PR TITLE
Fixed #19062: URL Wildcard not working due to url alias placeholder

### DIFF
--- a/kernel/classes/ezurlwildcard.php
+++ b/kernel/classes/ezurlwildcard.php
@@ -676,12 +676,13 @@ class eZURLWildcard extends eZPersistentObject
     public static function wildcardExists( $uriString )
     {
         $wildcardIndex = self::wildcardsIndex();
-        $uriString = self::matchRegexpCode( array( 'source_url' => $uriString ) );
-        if ( in_array( $uriString, $wildcardIndex ) )
+        foreach ( $wildcardIndex as $preg )
         {
-            return true;
+            if ( preg_match( $preg, $uriString ) )
+            {
+                return true;
+            }
         }
-
         return false;
     }
 }

--- a/tests/tests/kernel/classes/ezurlwildcard_test.php
+++ b/tests/tests/kernel/classes/ezurlwildcard_test.php
@@ -63,6 +63,7 @@ class eZURLWildcardTest extends ezpDatabaseTestCase
         $this->wildcardObjects["testTranslate1/*/*"] = self::createWildcard( "testTranslate1/*/*", 'foobar/{1}/{2}', eZURLWildcard::TYPE_DIRECT );
         $this->wildcardObjects["testTranslate2/*/abc"] = self::createWildcard( "testTranslate2/*/abc", 'foobar/{1}', eZURLWildcard::TYPE_FORWARD );
         $this->wildcardObjects["test/single-page"] = self::createWildcard( "test/single-page", 'foo/bar', eZURLWildcard::TYPE_FORWARD );
+        $this->wildcardObjects["is/it/working/*"] = self::createWildcard( "is/it/working/*", 'yes/no/maybe', eZURLWildcard::TYPE_FORWARD );
         eZURLWildcard::expireCache();
     }
 
@@ -390,6 +391,21 @@ class eZURLWildcardTest extends ezpDatabaseTestCase
                 $this->wildcardObjects['test/single-page']->attribute( 'source_url' )
             )
         );
+        self::assertTrue(
+            eZURLWildcard::wildcardExists(
+                $this->wildcardObjects['is/it/working/*']->attribute( 'source_url' )
+            )
+        );
+        self::assertFalse(
+            eZURLWildcard::wildcardExists( 'is/it/' )
+        );
+        self::assertTrue(
+            eZURLWildcard::wildcardExists( 'is/it/working/now' )
+        );
+        self::assertTrue(
+            eZURLWildcard::wildcardExists( 'is/it/working/now/yes' )
+        );
+
     }
 }
 ?>

--- a/tests/tests/kernel/classes/urlaliasml_regression.php
+++ b/tests/tests/kernel/classes/urlaliasml_regression.php
@@ -1416,6 +1416,8 @@ class eZURLAliasMLRegression extends ezpDatabaseTestCase
         // By creating following URL alias, "test/single-page" will be registered as a NOP URI segment
         $uriFirstSegment = 'test19062';
         $uriWildcard = "$uriFirstSegment/single-page";
+        $uriFirstSegment2 = 'test19062_2';
+        $uriWildcard2 = "$uriFirstSegment2/*";
         $res = eZURLAliasML::storePath(
             "$uriWildcard/article.html",
             "eznode:{$folder->mainNode->node_id}",
@@ -1423,16 +1425,27 @@ class eZURLAliasMLRegression extends ezpDatabaseTestCase
             0,
             true
         );
+        $res = eZURLAliasML::storePath(
+            "$uriWildcard2/article.html",
+            "eznode:{$folder->mainNode->node_id}",
+            $this->englishLanguage,
+            0,
+            true
+        );
+        $wildcard2 = eZURLWildcardTest::createWildcard( $uriWildcard2, 'bar', eZURLWildcard::TYPE_FORWARD );
         $wildcard = eZURLWildcardTest::createWildcard( $uriWildcard, 'foo', eZURLWildcard::TYPE_FORWARD );
 
         // Translating the wildcard URL should return false in order to be then translated by eZURLWildcard in index.php
         self::assertFalse( eZURLAliasML::translate( $uriWildcard ) );
+        $matchUriWildcard2 = $uriFirstSegment2 . '/something/that/matches/uriWildcard2';
+        self::assertFalse( eZURLAliasML::translate( $matchUriWildcard2 ) );
         // Here no wildcard and test19062 should be a nop segment (points to nothing.
         // Default behaviour is to return true and redirect to root ("/")
         self::assertTrue( eZURLAliasML::translate( $uriFirstSegment ) );
 
         $folder->remove();
         $wildcard->remove();
+        $wildcard2->remove();
     }
 }
 


### PR DESCRIPTION
# Description

URL wildcards might not work if the actual URL is an existing URL alias with the "nop" action in ezurlalias_ml (this happens if you create an URL alias with several levels that do not already exist, ie test/folder/article where test/folder is not an URL of an existing node).
This patch is an additional fix to a previous commit [1] from Jérôme (the usecase solved by Jérôme is still OK with it).

[1] https://github.com/ezsystems/ezpublish/commit/da1aace9db52f5702bc403aef89e093e3143934b
# Testing done

Manual tests + unit tests (existing ones + new test cases)
