### PR TITLE
Implemented: added --list option to runcronjobs.php to list all cronjobs...

### DIFF
--- a/runcronjobs.php
+++ b/runcronjobs.php
@@ -302,21 +302,11 @@ if ( $listCronjobs )
 {
     foreach ( $ini->groups() as $block => $blockValues )
     {
-        $hasScripts = false;
-        if ( $block === 'CronjobSettings' )
-        {
-            $cli->output( $cli->endLineString() );
-            $cli->output( "Standard scripts:" );
-            $hasScripts = true;
-        }
-        if ( strpos( $block, 'CronjobPart-' ) !== false )
+        if ( strpos( $block, 'Cronjob' ) !== false )
         {
             $cli->output( $cli->endLineString() );
             $cli->output( "{$block}:" );
-            $hasScripts = true;
-        }
-        if ( $hasScripts )
-        {
+
             foreach ( $blockValues['Scripts'] as $fileName )
             {
                 $fileExists = false;


### PR DESCRIPTION
I had this on my list for some time and today I found time to do it.

Following the proposal of Gaetano Giunta [@gggeek] - see http://share.ez.no/forums/install-configuration/cron-job-setup-best-practice#comment69237 -  I implemented the --list option on runcronjobs.php that will list all cronjob parts and the scripts contained by each one.

Giving other options together with --list will not have much effect as the script exits before running any of the cronscripts. 

Cheers,
Virgil
