### PR TITLE
Fixed #018596: BackEnd generates a bunch of errors on specific case

### DIFF
--- a/kernel/common/eztemplatedesignresource.php
+++ b/kernel/common/eztemplatedesignresource.php
@@ -682,7 +682,8 @@ class eZTemplateDesignResource extends eZTemplateFileResource
 
         if( $designLocationCache )
         {
-            $siteAccessName = $GLOBALS['eZCurrentAccess']['name'];
+            // Using current SA if none given
+            $siteAccessName = $siteAccess !== false ? $siteAccess : $GLOBALS['eZCurrentAccess']['name'];
 
             $cachePath = eZSys::cacheDirectory()
                          . '/'


### PR DESCRIPTION
After some investigation, it looks like the problem resides in the caching part of the allDesignBases() method which completely ignore the argument passed to the method and as such, cached results are always the one of the current siteaccess and not of the one requested.

This has been tested in the frame of this bug, it has not been _extensively_ tested.
