### PR TITLE
Fixed #19169: duplicated object state groups after changing default language

### DIFF
--- a/kernel/private/classes/ezcontentobjectstategroup.php
+++ b/kernel/private/classes/ezcontentobjectstategroup.php
@@ -207,7 +207,7 @@ class eZContentObjectStateGroup extends eZPersistentObject
 
                 if ( !array_key_exists( $languageID, $allTranslations ) )
                 {
-                    $row = array( 'language_id' => $languageID );
+                    $row = array( 'real_language_id' => $languageID );
                     if ( isset( $this->ID ) )
                     {
                         $row['contentobject_state_group_id'] = $this->ID;
@@ -231,7 +231,7 @@ class eZContentObjectStateGroup extends eZPersistentObject
             $translations = $this->allTranslations();
             foreach ( $translations as $translation )
             {
-                if ( $translation->realLanguageID() == $languageID )
+                if ( $translation->attribute( 'real_language_id' ) == $languageID )
                 {
                     return $translation;
                 }
@@ -307,7 +307,7 @@ class eZContentObjectStateGroup extends eZPersistentObject
         {
             if ( $translation->hasData() )
             {
-                $languageID = $translation->attribute( 'language_id' );
+                $languageID = $translation->attribute( 'real_language_id' );
                 if ( empty( $this->DefaultLanguageID ) )
                 {
                     $this->DefaultLanguageID = $languageID & ~1;
@@ -318,7 +318,7 @@ class eZContentObjectStateGroup extends eZPersistentObject
                     $translation->setAttribute( 'language_id', $languageID | 1 );
                 }
                 // otherwise, remove always available flag if it's set
-                else if ( $languageID & 1 )
+                else
                 {
                     $translation->setAttribute( 'language_id',  $languageID & ~1 );
                 }

--- a/kernel/private/classes/ezcontentobjectstategrouplanguage.php
+++ b/kernel/private/classes/ezcontentobjectstategrouplanguage.php
@@ -38,14 +38,16 @@ class eZContentObjectStateGroupLanguage extends eZPersistentObject
                                          "description" => array( "name" => "Description",
                                                                  "datatype" => "text",
                                                                  "required" => false ),
+                                         "real_language_id" => array( "name" => "RealLanguageID",
+                                                                      "datatype" => "integer",
+                                                                      "required" => true ),
                                          "language_id" => array( "name" => "LanguageID",
                                                                  "datatype" => "integer",
                                                                  "required" => false ) ),
                       "keys" => array( "contentobject_state_group_id",
-                                       "language_id" ),
+                                       "real_language_id" ),
                       "function_attributes" => array( "language" => "language",
-                                                      "is_valid" => "isValid",
-                                                      "real_language_id" => "realLanguageID",
+                                                      "is_valid" => "isValid"
                                                     ),
                       "increment_key" => false,
                       "class_name" => "eZContentObjectStateGroupLanguage",
@@ -96,7 +98,7 @@ class eZContentObjectStateGroupLanguage extends eZPersistentObject
      */
     public function language()
     {
-        return eZContentLanguage::fetch( $this->LanguageID & ~1 );
+        return eZContentLanguage::fetch( $this->RealLanguageID );
     }
 
     /**
@@ -116,7 +118,9 @@ class eZContentObjectStateGroupLanguage extends eZPersistentObject
      */
     public function realLanguageID()
     {
-        return $this->LanguageID & ~1;
+        return $this->RealLanguageID;
     }
+
+
 }
 ?>

--- a/kernel/sql/mysql/kernel_schema.sql
+++ b/kernel/sql/mysql/kernel_schema.sql
@@ -71,8 +71,9 @@ CREATE TABLE ezcobj_state_group_language (
   contentobject_state_group_id int(11) NOT NULL default '0',
   description longtext NOT NULL,
   language_id int(11) NOT NULL default '0',
+  real_language_id int(11) NOT NULL default '0',
   name varchar(45) NOT NULL default '',
-  PRIMARY KEY  (contentobject_state_group_id,language_id)
+  PRIMARY KEY  (contentobject_state_group_id,real_language_id)
 ) ENGINE=InnoDB;
 
 

--- a/kernel/sql/postgresql/kernel_schema.sql
+++ b/kernel/sql/postgresql/kernel_schema.sql
@@ -1238,6 +1238,7 @@ CREATE TABLE ezcobj_state_group_language (
     contentobject_state_group_id integer DEFAULT 0 NOT NULL,
     description text NOT NULL,
     language_id integer DEFAULT 0 NOT NULL,
+    real_language_id integer DEFAULT 0 NOT NULL,
     name character varying(45) DEFAULT ''::character varying NOT NULL
 );
 
@@ -4227,7 +4228,7 @@ ALTER TABLE ONLY ezcobj_state_group
 
 
 ALTER TABLE ONLY ezcobj_state_group_language
-    ADD CONSTRAINT ezcobj_state_group_language_pkey PRIMARY KEY (contentobject_state_group_id, language_id);
+    ADD CONSTRAINT ezcobj_state_group_language_pkey PRIMARY KEY (contentobject_state_group_id, real_language_id);
 
 
 

--- a/share/db_schema.dba
+++ b/share/db_schema.dba
@@ -326,6 +326,13 @@ $schema = array (
         'not_null' => '1',
         'default' => '',
       ),
+      'real_language_id' => 
+      array (
+        'length' => 11,
+        'type' => 'int',
+        'not_null' => '1',
+        'default' => 0,
+      ),
     ),
     'indexes' => 
     array (
@@ -335,7 +342,7 @@ $schema = array (
         'fields' => 
         array (
           0 => 'contentobject_state_group_id',
-          1 => 'language_id',
+          1 => 'real_language_id',
         ),
       ),
     ),

--- a/update/common/scripts/5.0/deduplicatecontentstategrouplanguage.php
+++ b/update/common/scripts/5.0/deduplicatecontentstategrouplanguage.php
@@ -1,0 +1,102 @@
+#!/usr/bin/env php
+<?php
+/**
+ * File containing the deduplicate content object state group language script.
+ *
+ * @copyright Copyright (C) 1999-2012 eZ Systems AS. All rights reserved.
+ * @license http://ez.no/licenses/gnu_gpl GNU GPL v2
+ * @version //autogentag//
+ * @package update
+ */
+
+require 'autoload.php';
+
+set_time_limit( 0 );
+
+$cli = eZCLI::instance();
+$script = eZScript::instance(
+    array(
+        'description' => 'Deduplicates content object state group language ' .
+            'records. See issue http://issues.ez.no/19169.',
+        'use-session' => false,
+        'use-modules' => false,
+        'use-extensions' => true
+    )
+);
+$options = $script->getOptions( '', '', array( '-q' => 'Quiet mode' ) );
+
+$cli = eZCLI::instance();
+
+$script->initialize();
+$script->startup();
+
+$db = eZDB::instance();
+
+$limit = 50;
+$offset = 0;
+
+while ( true )
+{
+    $groups = eZContentObjectStateGroup::fetchByOffset( $limit, $offset );
+    if ( empty( $groups ) )
+    {
+        break;
+    }
+    foreach ( $groups as $group )
+    {
+        $cli->output( 'Fixing translations for group ' . $group->attribute( 'identifier' ), false );
+        $groupId = $group->attribute( 'id' );
+        $defaultLangId = $group->attribute( 'default_language_id' );
+
+        // for the default language id, the correct record is the one with
+        // the always available bit, so we delete records without it
+        // ie language_id = real_language_id = $defaultLangId
+        $queryDefaultLang = "DELETE FROM ezcobj_state_group_language
+            WHERE contentobject_state_group_id={$groupId}
+            AND language_id={$defaultLangId} AND real_language_id={$defaultLangId}";
+
+        // for others languages, the correct records are the ones where
+        // language_id and real_language_id are the same (the always available
+        // bit should not be added)
+        $queryOthersLang = "DELETE FROM ezcobj_state_group_language
+            WHERE contentobject_state_group_id={$groupId}
+            AND real_language_id != {$defaultLangId}
+            AND language_id != real_language_id";
+
+        $db->query( $queryDefaultLang );
+        $db->query( $queryOthersLang );
+        $cli->output( ' Done' );
+    }
+
+    $offset += $limit;
+}
+
+// the records are now correct, we can change the primary key
+$cli->output( 'Changing the primary key in table ezcobj_state_group_language', false );
+if ( $db->databaseName() == 'mysql' )
+{
+    $db->query( 'ALTER TABLE ezcobj_state_group_language DROP PRIMARY KEY' );
+    $db->query(
+        'ALTER TABLE ezcobj_state_group_language ADD PRIMARY KEY (contentobject_state_group_id, real_language_id)'
+    );
+}
+else if ( $db->databaseName() == 'postgresql' )
+{
+    $db->query( 'ALTER TABLE ezcobj_state_group_language DROP CONSTRAINT ezcobj_state_group_language_pkey' );
+    $db->query(
+        'ALTER TABLE ONLY ezcobj_state_group_language
+        ADD CONSTRAINT ezcobj_state_group_language_pkey PRIMARY KEY (contentobject_state_group_id, real_language_id)'
+    );
+}
+else if ( $db->databaseName() == 'oracle' )
+{
+    $db->query( 'ALTER TABLE ezcobj_state_group_language DROP PRIMARY KEY' );
+    $db->query(
+        'ALTER TABLE ezcobj_state_group_language ADD PRIMARY KEY (contentobject_state_group_id, real_language_id)'
+    );
+}
+$cli->output( ' Done' );
+
+
+$script->shutdown();
+?>

--- a/update/database/mysql/5.0/unstable/dbupdate-4.7.0-to-5.0.0alpha1.sql
+++ b/update/database/mysql/5.0/unstable/dbupdate-4.7.0-to-5.0.0alpha1.sql
@@ -1,3 +1,11 @@
 SET storage_engine=InnoDB;
 UPDATE ezsite_data SET value='5.0.0alpha1' WHERE name='ezpublish-version';
 UPDATE ezsite_data SET value='1' WHERE name='ezpublish-release';
+
+-- See http://issues.ez.no/19169
+ALTER TABLE ezcobj_state_group_language ADD COLUMN real_language_id int(11) NOT NULL DEFAULT '0';
+UPDATE ezcobj_state_group_language SET real_language_id = language_id & ~1;
+
+-- dropping the primary key (contentobject_state_group_id, language_id) and creating
+-- the new one (contentobject_state_group_id, real_language_id) are done in the
+-- PHP script after removing the duplicated entries

--- a/update/database/postgresql/5.0/unstable/dbupdate-4.7.0-to-5.0.0alpha1.sql
+++ b/update/database/postgresql/5.0/unstable/dbupdate-4.7.0-to-5.0.0alpha1.sql
@@ -1,2 +1,10 @@
 UPDATE ezsite_data SET value='5.0.0alpha1' WHERE name='ezpublish-version';
 UPDATE ezsite_data SET value='1' WHERE name='ezpublish-release';
+
+-- See http://issues.ez.no/19169
+ALTER TABLE ezcobj_state_group_language ADD real_language_id integer DEFAULT 0 NOT NULL;
+UPDATE ezcobj_state_group_language SET real_language_id = language_id & ~1
+
+-- dropping the primary key (contentobject_state_group_id, language_id) and creating
+-- the new one (contentobject_state_group_id, real_language_id) are done in the
+-- PHP script after removing the duplicated entries


### PR DESCRIPTION
Bug: http://issues.ez.no/19169
# Description

After changing the default language of an existing content object state group, the content object state group is listed twice in /state/groups. This is because the content object state group language objects are not correctly stored. This happens because the primary key of the content object state group language is composed of the content object state group id and the language id, but the language id might be affected by the always available flag used to mark the default language. In short terms, the primary key is not so primary :-)

This patch adds a  `real_language_id` column to store the language_id without the always available flag and changes the primary key to use this new field. There's also a script to remove the duplicated entries.

Corresponding pull request for ezoracle: https://github.com/ezsystems/ezoracle/pull/3
# Testing

Manual tests with PostgreSQL and MySQL (manipulating content object state group through the GUI + using the upgrade scripts with affected and not affected groups).
