### PR TITLE
Fixed #019521: Content - action view defines some not necessary vars as ...

### DIFF
--- a/kernel/content/action.php
+++ b/kernel/content/action.php
@@ -9,10 +9,6 @@
 $http = eZHTTPTool::instance();
 $module = $Params['Module'];
 
-/* We retrieve the class ID for users as this is used in many places in this
- * code in order to be able to cleanup the user-policy cache. */
-$userClassIDArray = eZUser::contentClassIDs();
-
 if ( $module->hasActionParameter( 'LanguageCode' ) )
     $languageCode = $module->actionParameter( 'LanguageCode' );
 else
@@ -390,7 +386,6 @@ else if ( $module->isCurrentAction( 'SwapNode' ) )
     if ( !$object )
         return $module->handleError( eZError::KERNEL_NOT_AVAILABLE, 'kernel', array() );
     $objectID = $object->attribute( 'id' );
-    $objectVersion = $object->attribute( 'current_version' );
 
     if ( $module->hasActionParameter( 'NewNode' ) )
     {
@@ -420,8 +415,6 @@ else if ( $module->isCurrentAction( 'SwapNode' ) )
     eZContentCacheManager::clearContentCacheIfNeeded( $objectID );
 
     $selectedObject = $selectedNode->object();
-    $selectedObjectID = $selectedObject->attribute( 'id' );
-    $selectedObjectVersion = $selectedObject->attribute( 'current_version' );
     $selectedNodeParentNodeID = $selectedNode->attribute( 'parent_node_id' );
 
 
@@ -1004,7 +997,6 @@ else if ( $http->hasPostVariable( 'MoveButton' ) )
             if ( !$parentObject )
                 return $module->handleError( eZError::KERNEL_NOT_AVAILABLE, 'kernel', array() );
             $parentObjectID = $parentObject->attribute( 'id' );
-            $parentClass = $parentObject->contentClass();
 
             $ignoreNodesSelect = array_unique( $ignoreNodesSelect );
             $ignoreNodesSelectSubtree = array_unique( $ignoreNodesSelectSubtree );
@@ -1132,8 +1124,6 @@ else if ( $http->hasPostVariable( "ActionAddToNotification" ) )
 else if ( $http->hasPostVariable( "ContentObjectID" )  )
 {
     $objectID = $http->postVariable( "ContentObjectID" );
-    $action = $http->postVariable( "ContentObjectID" );
-
 
     // Check which action to perform
     if ( $http->hasPostVariable( "ActionAddToBasket" ) )


### PR DESCRIPTION
...they're not used at all in the code
t 
These removed vars aren't used in that script anymore. 
i keep 

<pre>
$bookmark = eZContentBrowseBookmark::createNew( $user->id(), $nodeID, $node->attribute( 'name' ) );
</pre>

because that function is returnin an eZContentBrowseBookmark user, even this created object isn't used in that code anymore... 
