### PR TITLE
Fixed #18614: Edit menu hidden when item at the bottom of the screen

### DIFF
--- a/design/admin2/javascript/popupmenu/ezpopupmenu.js
+++ b/design/admin2/javascript/popupmenu/ezpopupmenu.js
@@ -209,8 +209,8 @@ function _showTopLevel( event, menuID, substituteValues, menuHeader, disableIDLi
     _doItemSubstitution( menuID, menuHeader );
 
     // make menu visible
-    _moveTopLevelOnScreen( menuID, mousePos );
     _makeVisible( menuID );
+    _moveTopLevelOnScreen( menuID, mousePos );
 }
 
 /*!


### PR DESCRIPTION
This makes sure the contextual menu on the cogwheel stays on screen, even if the menu item is at the bottom of it.
