### PR TITLE
Deprecate eZExpiryHandler::registerShutdownFunction() and explicitly call eZExpiryHandler::store() instead

### DIFF
--- a/kernel/classes/datatypes/ezuser/ezuser.php
+++ b/kernel/classes/datatypes/ezuser/ezuser.php
@@ -1821,7 +1821,6 @@ WHERE user_id = '" . $userID . "' AND
     static protected function userInfoExpiry()
     {
         /* Figure out when the last update was done */
-        eZExpiryHandler::registerShutdownFunction();
         $handler = eZExpiryHandler::instance();
         if ( $handler->hasTimestamp( 'user-info-cache' ) )
         {
@@ -1831,6 +1830,7 @@ WHERE user_id = '" . $userID . "' AND
         {
             $expiredTimestamp = time();
             $handler->setTimestamp( 'user-info-cache', $expiredTimestamp );
+            $handler->store();
         }
 
         return $expiredTimestamp;
@@ -2589,7 +2589,6 @@ WHERE user_id = '" . $userID . "' AND
      */
     static function cleanupCache()
     {
-        eZExpiryHandler::registerShutdownFunction();
         $handler = eZExpiryHandler::instance();
         $handler->setTimestamp( 'user-info-cache', time() );
         $handler->store();

--- a/kernel/classes/ezcache.php
+++ b/kernel/classes/ezcache.php
@@ -442,7 +442,6 @@ class eZCache
         if ( isset( $cacheItem['expiry-key'] ) )
         {
             $key = $cacheItem['expiry-key'];
-            eZExpiryHandler::registerShutdownFunction();
             $expiryHandler = eZExpiryHandler::instance();
             $keyValue = $expiryHandler->getTimestamp( $key );
             if ( $keyValue !== false )
@@ -515,7 +514,6 @@ class eZCache
      */
     static function clearImageAlias( $cacheItem )
     {
-        eZExpiryHandler::registerShutdownFunction();
         $expiryHandler = eZExpiryHandler::instance();
         $expiryHandler->setTimestamp( 'image-manager-alias', time() );
         $expiryHandler->store();
@@ -624,7 +622,6 @@ class eZCache
      */
     static function clearContentTreeMenu( $cacheItem )
     {
-        eZExpiryHandler::registerShutdownFunction();
         $expiryHandler = eZExpiryHandler::instance();
         $expiryHandler->setTimestamp( 'content-tree-menu', time() );
         $expiryHandler->store();
@@ -635,7 +632,6 @@ class eZCache
      */
     static function clearTemplateBlockCache( $cacheItem )
     {
-        eZExpiryHandler::registerShutdownFunction();
         $expiryHandler = eZExpiryHandler::instance();
         $expiryHandler->setTimestamp( 'global-template-block-cache', time() );
         $expiryHandler->store();
@@ -683,7 +679,6 @@ class eZCache
      */
     static function clearUserInfoCache( $cacheItem )
     {
-        eZExpiryHandler::registerShutdownFunction();
         $handler = eZExpiryHandler::instance();
         $handler->setTimestamp( 'user-info-cache', time() );
         $handler->store();
@@ -694,7 +689,6 @@ class eZCache
      */
     static function clearContentCache( $cacheItem )
     {
-        eZExpiryHandler::registerShutdownFunction();
         $handler = eZExpiryHandler::instance();
         $handler->setTimestamp( 'content-view-cache', time() );
         $handler->store();
@@ -742,8 +736,6 @@ class eZCache
      */
     static function clearActiveExtensions( $cacheItem )
     {
-        eZExpiryHandler::registerShutdownFunction();
-
         $handler = eZExpiryHandler::instance();
         $handler->setTimestamp( $cacheItem['expiry-key'], time() );
         $handler->store();

--- a/kernel/classes/ezcontentclass.php
+++ b/kernel/classes/ezcontentclass.php
@@ -389,7 +389,6 @@ class eZContentClass extends eZPersistentObject
         if ( $enableCaching )
         {
             $http = eZHTTPTool::instance();
-            eZExpiryHandler::registerShutdownFunction();
             $handler = eZExpiryHandler::instance();
             $expiredTimeStamp = 0;
             if ( $handler->hasTimestamp( 'user-class-cache' ) )
@@ -910,7 +909,6 @@ You will need to change the class of the node by using the swap functionality.' 
            }
         }
 
-        eZExpiryHandler::registerShutdownFunction();
         $handler = eZExpiryHandler::instance();
         $handler->setTimestamp( 'user-class-cache', time() );
         $handler->store();
@@ -1026,7 +1024,6 @@ You will need to change the class of the node by using the swap functionality.' 
         }
         eZContentClassClassGroup::removeClassMembers( $this->ID, $previousVersion );
 
-        eZExpiryHandler::registerShutdownFunction();
         $handler = eZExpiryHandler::instance();
         $time = time();
         $handler->setTimestamp( 'user-class-cache', $time );
@@ -1827,7 +1824,6 @@ You will need to change the class of the node by using the swap functionality.' 
                                           '',
                                           array( 'clustering' => 'classidentifiers' ) );
 
-            eZExpiryHandler::registerShutdownFunction();
             $handler = eZExpiryHandler::instance();
             $expiryTime = 0;
             if ( $handler->hasTimestamp( 'class-identifier-cache' ) )

--- a/kernel/classes/ezcontentclassattribute.php
+++ b/kernel/classes/ezcontentclassattribute.php
@@ -589,8 +589,6 @@ class eZContentClassAttribute extends eZPersistentObject
 
     static function cachedInfo()
     {
-        eZExpiryHandler::registerShutdownFunction();
-
         $info = array();
         $db = eZDB::instance();
         $dbName = md5( $db->DB );
@@ -912,7 +910,6 @@ class eZContentClassAttribute extends eZPersistentObject
                                           '',
                                           array( 'clustering' => 'classattridentifiers' ) );
 
-            eZExpiryHandler::registerShutdownFunction();
             $handler = eZExpiryHandler::instance();
             $expiryTime = 0;
             if ( $handler->hasTimestamp( 'class-identifier-cache' ) )

--- a/kernel/classes/ezcontentobject.php
+++ b/kernel/classes/ezcontentobject.php
@@ -5437,7 +5437,6 @@ class eZContentObject extends eZPersistentObject
     */
     static function expireAllViewCache()
     {
-        eZExpiryHandler::registerShutdownFunction();
         $handler = eZExpiryHandler::instance();
         $handler->setTimestamp( 'content-view-cache', time() );
         $handler->store();
@@ -5450,7 +5449,6 @@ class eZContentObject extends eZPersistentObject
     */
     static function expireAllCache()
     {
-        eZExpiryHandler::registerShutdownFunction();
         $handler = eZExpiryHandler::instance();
         $handler->setTimestamp( 'content-view-cache', time() );
         $handler->setTimestamp( 'template-block-cache', time() );
@@ -5466,7 +5464,6 @@ class eZContentObject extends eZPersistentObject
     */
     static function expireTemplateBlockCache()
     {
-        eZExpiryHandler::registerShutdownFunction();
         $handler = eZExpiryHandler::instance();
         $handler->setTimestamp( 'template-block-cache', time() );
         $handler->store();
@@ -5490,7 +5487,6 @@ class eZContentObject extends eZPersistentObject
     */
     static function expireComplexViewModeCache()
     {
-        eZExpiryHandler::registerShutdownFunction();
         $handler = eZExpiryHandler::instance();
         $handler->setTimestamp( 'content-complex-viewmode-cache', time() );
         $handler->store();
@@ -5501,7 +5497,6 @@ class eZContentObject extends eZPersistentObject
     */
     static function isCacheExpired( $timestamp )
     {
-        eZExpiryHandler::registerShutdownFunction();
         $handler = eZExpiryHandler::instance();
         if ( !$handler->hasTimestamp( 'content-view-cache' ) )
             return false;
@@ -5528,7 +5523,6 @@ class eZContentObject extends eZPersistentObject
     {
         if ( !eZContentObject::isComplexViewMode( $viewMode ) )
             return false;
-        eZExpiryHandler::registerShutdownFunction();
         $handler = eZExpiryHandler::instance();
         if ( !$handler->hasTimestamp( 'content-complex-viewmode-cache' ) )
             return false;

--- a/kernel/classes/ezrole.php
+++ b/kernel/classes/ezrole.php
@@ -262,7 +262,6 @@ class eZRole extends eZPersistentObject
         $db->commit();
 
         // Expire role cache
-        eZExpiryHandler::registerShutdownFunction();
         $handler = eZExpiryHandler::instance();
         $handler->setTimestamp( 'user-info-cache', time() );
         $handler->setTimestamp( 'user-class-cache', time() );

--- a/kernel/classes/ezuserdiscountrule.php
+++ b/kernel/classes/ezuserdiscountrule.php
@@ -62,7 +62,6 @@ class eZUserDiscountRule extends eZPersistentObject
         }
         else
         {
-            eZExpiryHandler::registerShutdownFunction();
             $handler = eZExpiryHandler::instance();
             $handler->setTimestamp( 'user-discountrules-cache', time() );
             $handler->store();
@@ -100,7 +99,6 @@ class eZUserDiscountRule extends eZPersistentObject
         {
             $http = eZHTTPTool::instance();
 
-            eZExpiryHandler::registerShutdownFunction();
             $handler = eZExpiryHandler::instance();
             $expiredTimeStamp = 0;
             if ( $handler->hasTimestamp( 'user-discountrules-cache' ) )

--- a/kernel/content/ezcontentfunctioncollection.php
+++ b/kernel/content/ezcontentfunctioncollection.php
@@ -1507,8 +1507,6 @@ class eZContentFunctionCollection
 
     static public function fetchContentTreeMenuExpiry()
     {
-        eZExpiryHandler::registerShutdownFunction();
-
         $expiryHandler = eZExpiryHandler::instance();
 
         if ( !$expiryHandler->hasTimestamp( 'content-tree-menu' ) )

--- a/kernel/content/treemenu.php
+++ b/kernel/content/treemenu.php
@@ -6,8 +6,6 @@
  * @package kernel
  */
 
-eZExpiryHandler::registerShutdownFunction();
-
 if ( !defined( 'MAX_AGE' ) )
 {
     define( 'MAX_AGE', 86400 );

--- a/kernel/private/classes/ezcontentobjectstategroup.php
+++ b/kernel/private/classes/ezcontentobjectstategroup.php
@@ -354,9 +354,9 @@ class eZContentObjectStateGroup extends eZPersistentObject
             }
         }
 
-        eZExpiryHandler::registerShutdownFunction();
         $handler = eZExpiryHandler::instance();
         $handler->setTimestamp( 'state-limitations', time() );
+        $handler->store();
 
         $db->commit();
     }
@@ -691,8 +691,8 @@ class eZContentObjectStateGroup extends eZPersistentObject
 
             if ( $storedTimeStamp === false )
             {
-                eZExpiryHandler::registerShutdownFunction();
                 $handler->setTimestamp( 'state-limitations', time() );
+                $handler->store();
             }
         }
 

--- a/kernel/private/rest/classes/cache/apc.php
+++ b/kernel/private/rest/classes/cache/apc.php
@@ -23,7 +23,6 @@ class ezpRestCacheStorageApcCluster extends ezcCacheStorageApcPlain
 
     public function __construct( $location = null, array $options = array() )
     {
-        eZExpiryHandler::registerShutdownFunction();
         $this->expiryHandler = eZExpiryHandler::instance();
 
         parent::__construct( $location, $options );
@@ -102,6 +101,7 @@ class ezpRestCacheStorageApcCluster extends ezcCacheStorageApcPlain
         // Update clustered expiry timestamp
         $expiryTime = time() + $this->properties['options']['ttl'];
         $this->expiryHandler->setTimestamp( ezpRestRouter::ROUTE_CACHE_KEY, $expiryTime );
+        $this->expiryHandler->store();
 
         return $storeResult;
     }

--- a/lib/ezi18n/classes/eztstranslator.php
+++ b/lib/ezi18n/classes/eztstranslator.php
@@ -732,8 +732,6 @@ class eZTSTranslator extends eZTranslatorHandler
      */
     public static function expireCache( $timestamp = false, $locale = null )
     {
-        eZExpiryHandler::registerShutdownFunction();
-
         if ( $timestamp === false )
             $timestamp = time();
 

--- a/lib/ezimage/classes/ezimagemanager.php
+++ b/lib/ezimage/classes/ezimagemanager.php
@@ -275,7 +275,6 @@ class eZImageManager
     */
     function isImageTimestampValid( $timestamp )
     {
-        eZExpiryHandler::registerShutdownFunction();
         $expiryHandler = eZExpiryHandler::instance();
         if ( $expiryHandler->hasTimestamp( 'image-manager-alias' ) )
         {

--- a/lib/eztemplate/classes/eztemplatecacheblock.php
+++ b/lib/eztemplate/classes/eztemplatecacheblock.php
@@ -61,7 +61,6 @@ class eZTemplateCacheBlock
     static function handle( $cachePath, $nodeID, $ttl, $useGlobalExpiry = true )
     {
         $globalExpiryTime = -1;
-        eZExpiryHandler::registerShutdownFunction();
         if ( $useGlobalExpiry )
         {
             $globalExpiryTime = eZExpiryHandler::getTimestamp( 'template-block-cache', -1 );

--- a/lib/eztemplate/classes/eztemplatecachefunction.php
+++ b/lib/eztemplate/classes/eztemplatecachefunction.php
@@ -262,7 +262,6 @@ class eZTemplateCacheFunction
         }
 
         $globalExpiryTime = -1;
-        eZExpiryHandler::registerShutdownFunction();
         if ( $ignoreContentExpiry == false )
         {
             $globalExpiryTime = eZExpiryHandler::getTimestamp( 'template-block-cache', -1 );

--- a/lib/ezutils/classes/ezexpiryhandler.php
+++ b/lib/ezutils/classes/ezexpiryhandler.php
@@ -148,6 +148,7 @@ class eZExpiryHandler
 
     /**
      * Called at the end of execution and will store the data if it is modified.
+     * @deprecated
      */
     static function shutdown()
     {
@@ -160,6 +161,7 @@ class eZExpiryHandler
     /**
      * Registers the shutdown function.
      * @see eZExpiryHandler::shutdown()
+     * @deprecated
      */
     public static function registerShutdownFunction(){
         if ( !eZExpiryHandler::$isShutdownFunctionRegistered ) {
@@ -182,6 +184,7 @@ class eZExpiryHandler
     /**
      * Indicates if thre shutdown function has been registered
      * @var bool
+     * @deprecated
      */
     private static $isShutdownFunctionRegistered = false;
 

--- a/templates/classcreatelist.ctpl
+++ b/templates/classcreatelist.ctpl
@@ -82,7 +82,6 @@
         if ( $enableCaching )
         {
             $http = eZHTTPTool::instance();
-            eZExpiryHandler::registerShutdownFunction();
             $handler = eZExpiryHandler::instance();
             $expiredTimeStamp = 0;
             if ( $handler->hasTimestamp( 'user-class-cache' ) )

--- a/tests/tests/lib/ezutils/ezphpcreator_regression.php
+++ b/tests/tests/lib/ezutils/ezphpcreator_regression.php
@@ -63,7 +63,6 @@ class eZPHPCreatorRegression extends ezpDatabaseTestCase
                                       '',
                                       array( 'clustering' => 'classidentifiers' ) );
 
-        eZExpiryHandler::registerShutdownFunction();
         $handler = eZExpiryHandler::instance();
         $expiryTime = 0;
         if ( $handler->hasTimestamp( 'class-identifier-cache' ) )


### PR DESCRIPTION
Because the "working directory of the script can change inside the shutdown function under some web servers, e.g. Apache." (from register_shutdown_function() PHP.net documentation), we can end up with eZExpiryHandler::store() writing to a different path than the expected one.

Replace this with an explicit call to eZExpiryHandler::store(), and deprecate eZExpiryHandler::registerShutdownFunction(), eZExpiryHandler::shutdown() and eZExpiryHandler::$isShutdownFunctionRegistered.
