### PR TITLE
Fixed #019002: rest api: session always created even for anon users

### DIFF
--- a/kernel/private/rest/classes/auth/auth_configuration.php
+++ b/kernel/private/rest/classes/auth/auth_configuration.php
@@ -75,7 +75,11 @@ class ezpRestAuthConfiguration
         $user = $this->filter->authenticate( $auth, $this->req );
         if ( $user instanceof eZUser )
         {
-            eZUser::setCurrentlyLoggedInUser( $user, $user->attribute( 'contentobject_id' ) );
+            $userID = $user->id();
+            if ( $userID != eZUser::currentUserID() )
+            {
+                eZUser::setCurrentlyLoggedInUser( $user, $userID );
+            }
             $this->filter->setUser( $user );
         }
         else if ( $user instanceof ezcMvcInternalRedirect )


### PR DESCRIPTION
Avoid setting the current user if not needed. This regenerated/initialize session.
