### PR TITLE
Fixed #019544: Showing/hiding a large number of objects generates fatal error

### DIFF
--- a/bin/php/ezcontentcache.php
+++ b/bin/php/ezcontentcache.php
@@ -117,7 +117,7 @@ else if ( $options['clear-subtree'] )
                          'Limitation' => array() ); // Empty array means no permission checking
 
         $subtreeCount = $node->subTreeCount( $params );
-        $script->resetIteration( $subtreeCount );
+        $script->resetIteration( $subtreeCount / $limit );
         while ( $offset < $subtreeCount )
         {
             $params['Offset'] = $offset;
@@ -137,11 +137,11 @@ else if ( $options['clear-subtree'] )
             $objectIDList = array_unique( $objectIDList );
             unset( $subtree );
 
-            foreach ( $objectIDList as $objectID )
-            {
-                $status = eZContentCacheManager::clearContentCache( $objectID );
-                $script->iterate( $cli, $status, "Cleared view cache for object $objectID" );
-            }
+            $script->iterate(
+                $cli,
+                eZContentCacheManager::clearContentCache( $objectIDList ),
+                "Cleared view cache for object(s): " . implode( ", ", $objectIDList )
+            );
             eZContentObject::clearCache();// Clear all object memory cache to free memory
         }
     }

--- a/kernel/classes/ezcontentcachemanager.php
+++ b/kernel/classes/ezcontentcachemanager.php
@@ -740,37 +740,125 @@ class eZContentCacheManager
         return true;
     }
 
-    /*!
-     \static
-     Clears view cache for specified object.
-     Checks 'ViewCaching' ini setting to determine whether cache is enabled or not.
-    */
-    static function clearObjectViewCacheIfNeeded( $objectID, $versionNum = true, $additionalNodeList = false )
+    /**
+     * Clears view caches of nodes, parent nodes and relating nodes
+     * of content objects with ids contained in $objectIDList.
+     * It will use 'viewcache.ini' to determine additional nodes.
+     *
+     * @see clearObjectViewCache
+     *
+     * @param array $objectIDList List of object ID
+     */
+    public static function clearObjectViewCacheArray( array $objectIDList )
     {
-        $ini = eZINI::instance();
-        if ( $ini->variable( 'ContentSettings', 'ViewCaching' ) === 'enabled' )
-            eZContentCacheManager::clearObjectViewCache( $objectID, $versionNum, $additionalNodeList );
+        eZDebug::accumulatorStart( 'node_cleanup_list', '', 'Node cleanup list' );
+
+        $nodeList = array();
+
+        foreach ( $objectIDList as $objectID )
+        {
+            $tempNodeList = self::nodeList( $objectID, true );
+
+            if ( $tempNodeList !== false )
+            {
+                $nodeList = array_merge( $nodeList, $tempNodeList );
+            }
+        }
+
+        $nodeList = array_unique( $nodeList );
+
+        eZDebug::accumulatorStop( 'node_cleanup_list' );
+
+        eZDebugSetting::writeDebug( 'kernel-content-edit', count( $nodeList ), "count in nodeList" );
+
+        if ( eZINI::instance()->variable( 'ContentSettings', 'StaticCache' ) === 'enabled' )
+        {
+            $staticCacheHandler = eZExtension::getHandlerClass(
+                new ezpExtensionOptions(
+                    array(
+                        'iniFile' => 'site.ini',
+                        'iniSection' => 'ContentSettings',
+                        'iniVariable' => 'StaticCacheHandler',
+                    )
+                )
+            );
+
+            $staticCacheHandler->generateAlwaysUpdatedCache();
+            $staticCacheHandler->generateNodeListCache( $nodeList );
+        }
+
+        eZDebug::accumulatorStart( 'node_cleanup', '', 'Node cleanup' );
+
+        $nodeList = ezpEvent::getInstance()->filter( 'content/cache', $nodeList );
+
+        eZContentObject::expireComplexViewModeCache();
+        $cleanupValue = eZContentCache::calculateCleanupValue( count( $nodeList ) );
+
+        if ( eZContentCache::inCleanupThresholdRange( $cleanupValue ) )
+        {
+            eZContentCache::cleanup( $nodeList );
+        }
+        else
+        {
+            eZDebug::writeDebug( "Expiring all view cache since list of nodes({$cleanupValue}) exceeds site.ini\[ContentSettings]\CacheThreshold", __METHOD__ );
+            eZContentObject::expireAllViewCache();
+        }
+
+        eZDebug::accumulatorStop( 'node_cleanup' );
+        return true;
     }
 
-    /*!
-     \static
-     Clears template-block cache and template-block with subtree_expiry parameter caches for specified object.
-     Checks 'TemplateCache' ini setting to determine whether cache is enabled or not.
-     If $objectID is \c false all template block caches will be cleared.
-    */
-    static function clearTemplateBlockCacheIfNeeded( $objectID )
+    /**
+     * Clears view cache for specified object(s).
+     * Checks 'ViewCaching' ini setting to determine whether cache is enabled or not.
+     *
+     * @param array $objectID (list of) object ID
+     * @param bool|int $versionNum
+     * @param bool|array $additionalNodeList
+     */
+    public static function clearObjectViewCacheIfNeeded( $objectID, $versionNum = true, $additionalNodeList = false )
+    {
+        if ( eZINI::instance()->variable( 'ContentSettings', 'ViewCaching' ) !== 'enabled' )
+            return;
+
+        if ( is_array( $objectID ) )
+        {
+            if ( $versionNum !== true || $additionalNodeList !== false )
+            {
+                trigger_error( "This method does not support second and third parameters when operating on many objects!" );
+                return false;
+            }
+
+            self::clearObjectViewCacheArray( $objectID );
+        }
+        else
+        {
+            self::clearObjectViewCache( $objectID, $versionNum, $additionalNodeList );
+        }
+    }
+
+    /**
+     * Clears template-block cache and template-block with subtree_expiry parameter caches for specified object(s).
+     * Checks 'TemplateCache' ini setting to determine whether cache is enabled or not.
+     * If $objectID is \c false all template block caches will be cleared.
+     *
+     * @param int|array $objectID (list of) object ID.
+     */
+    public static function clearTemplateBlockCacheIfNeeded( $objectID )
     {
         $ini = eZINI::instance();
         if ( $ini->variable( 'TemplateSettings', 'TemplateCache' ) === 'enabled' )
-            eZContentCacheManager::clearTemplateBlockCache( $objectID, true );
+            self::clearTemplateBlockCache( $objectID, true );
     }
 
-    /*!
-     \static
-     Clears template-block cache and template-block with subtree_expiry parameter caches for specified object
-     without checking 'TemplateCache' ini setting. If $objectID is \c false all template block caches will be cleared.
-    */
-    static function clearTemplateBlockCache( $objectID, $checkViewCacheClassSettings = false )
+    /**
+     * Clears template-block cache and template-block with subtree_expiry parameter caches for specified object
+     * without checking 'TemplateCache' ini setting. If $objectID is \c false all template block caches will be cleared.
+     *
+     * @param int|array $objectID (list of) object ID.
+     * @param bool $checkViewCacheClassSettings Check whether ViewCache class settings should be verified
+     */
+    public static function clearTemplateBlockCache( $objectID, $checkViewCacheClassSettings = false )
     {
         // ordinary template block cache
         eZContentObject::expireTemplateBlockCache();
@@ -779,24 +867,39 @@ class eZContentCacheManager
         $nodeList = false;
         $object = false;
         if ( $objectID )
-            $object = eZContentObject::fetch( $objectID );
-        if ( $object instanceof eZContentObject )
         {
-            $getAssignedNodes = true;
-            if ( $checkViewCacheClassSettings )
+            if ( is_array( $objectID ) )
             {
-                $ini = eZINI::instance('viewcache.ini');
-                $objectClassIdentifier = $object->attribute('class_identifier');
-                if ( $ini->hasVariable( $objectClassIdentifier, 'ClearCacheBlocks' )
-                  && $ini->variable( $objectClassIdentifier, 'ClearCacheBlocks' ) === 'disabled' )
-                {
-                    $getAssignedNodes = false;
-                }
+                $objects = eZContentObject::fetchIDArray( $objectID );
             }
-
-            if ( $getAssignedNodes )
+            else
             {
-                $nodeList = $object->assignedNodes();
+                $objects = array( $objectID => eZContentObject::fetch( $objectID ) );
+            }
+        }
+
+        $ini = eZINI::instance( 'viewcache.ini' );
+
+        foreach ( $objects as $object )
+        {
+            $nodeList = array();
+            if ( $object instanceof eZContentObject )
+            {
+                $getAssignedNodes = true;
+                if ( $checkViewCacheClassSettings )
+                {
+                    $objectClassIdentifier = $object->attribute('class_identifier');
+                    if ( $ini->hasVariable( $objectClassIdentifier, 'ClearCacheBlocks' )
+                      && $ini->variable( $objectClassIdentifier, 'ClearCacheBlocks' ) === 'disabled' )
+                    {
+                        $getAssignedNodes = false;
+                    }
+                }
+
+                if ( $getAssignedNodes )
+                {
+                    $nodeList = array_merge( $nodeList, $object->assignedNodes() );
+                }
             }
         }
 
@@ -964,24 +1067,29 @@ class eZContentCacheManager
         // fetch all objects of this section
         $objectList = eZContentObject::fetchList( false, array( 'section_id' => "$sectionID" ) );
         // Clear cache
+        $objectIDList = array();
         foreach ( $objectList as $object )
         {
-            eZContentCacheManager::clearContentCacheIfNeeded( $object['id'] );
+            $objectIDList[] = $object['id'];
         }
+        self::clearContentCacheIfNeeded( $objectIDList );
         return true;
     }
 
-    /*!
-     \static
-     Clears content cache for specified object: view cache, template-block cache, template-block with subtree_expiry parameter cache.
-     Checks appropriate ini settings to determine whether caches are enabled or not.
-    */
-    static function clearContentCacheIfNeeded( $objectID, $versionNum = true, $additionalNodeList = false )
+    /**
+     * Clears content cache for specified (list of) object: view cache, template-block cache, template-block with subtree_expiry parameter cache.
+     * Checks appropriate ini settings to determine whether caches are enabled or not.
+     *
+     * @param int|array $objectID (list of) object ID
+     * @param bool|int $versionNum
+     * @param bool|array $additionalNodeList
+     */
+    public static function clearContentCacheIfNeeded( $objectID, $versionNum = true, $additionalNodeList = false )
     {
         eZDebug::accumulatorStart( 'check_cache', '', 'Check cache' );
 
-        eZContentCacheManager::clearObjectViewCacheIfNeeded( $objectID, $versionNum, $additionalNodeList );
-        eZContentCacheManager::clearTemplateBlockCacheIfNeeded( $objectID );
+        self::clearObjectViewCacheIfNeeded( $objectID, $versionNum, $additionalNodeList );
+        self::clearTemplateBlockCacheIfNeeded( $objectID );
 
         // Clear cached path strings of content SSL zones.
         eZSSLZone::clearCacheIfNeeded();
@@ -990,17 +1098,34 @@ class eZContentCacheManager
         return true;
     }
 
-    /*!
-     \static
-     Clears content cache for specified object: view cache, template-block cache, template-block with subtree_expiry parameter cache
-     without checking of ini settings.
-    */
+    /**
+     * Clears content cache for specified object: view cache, template-block cache, template-block with subtree_expiry parameter cache
+     * without checking of ini settings.
+     *
+     * @param int|array $objectID (list of) object ID
+     * @param bool|int $versionNum
+     * @param bool|array $additionalNodeList
+     */
     static function clearContentCache( $objectID, $versionNum = true, $additionalNodeList = false )
     {
         eZDebug::accumulatorStart( 'check_cache', '', 'Check cache' );
 
-        eZContentCacheManager::clearObjectViewCache( $objectID, $versionNum, $additionalNodeList );
-        eZContentCacheManager::clearTemplateBlockCache( $objectID );
+        if ( is_array( $objectID ) )
+        {
+            if ( $versionNum !== true || $additionalNodeList !== false )
+            {
+                trigger_error( "This method does not support second and third parameters when operating on many objects!" );
+                return false;
+            }
+
+            self::clearObjectViewCacheArray( $objectID );
+        }
+        else
+        {
+            self::clearObjectViewCache( $objectID, $versionNum, $additionalNodeList );
+        }
+
+        self::clearTemplateBlockCache( $objectID );
 
         // Clear cached path strings of content SSL zones.
         eZSSLZone::clearCache();

--- a/kernel/classes/ezcontentobject.php
+++ b/kernel/classes/ezcontentobject.php
@@ -1617,13 +1617,15 @@ class eZContentObject extends eZPersistentObject
                                           link.to_contentobject_id=$objectID" );
         if ( count( $result ) > 0 )
         {
+            $objectIDList = array();
             foreach( $result as $row )
             {
                 $attr = new eZContentObjectAttribute( $row );
                 $dataType = $attr->dataType();
                 $dataType->fixRelatedObjectItem( $attr, $objectID, $mode );
-                eZContentCacheManager::clearObjectViewCache( $attr->attribute( 'contentobject_id' ), true );
+                $objectIDList[] = $attr->attribute( 'contentobject_id' );
             }
+            eZContentCacheManager::clearObjectViewCacheArray( $objectIDList );
         }
     }
 
@@ -1652,6 +1654,7 @@ class eZContentObject extends eZPersistentObject
                 $attr = new eZContentObjectAttribute( $row );
                 $dataType = $attr->dataType();
                 $dataType->removeRelatedObjectItem( $attr, $objectID );
+                // @todo Check whether we can use eZContentCacheManager::clearObjectViewCacheArray() instead
                 eZContentCacheManager::clearObjectViewCache( $attr->attribute( 'contentobject_id' ), true );
                 $attr->storeData();
             }

--- a/kernel/classes/ezcontentobjecttreenode.php
+++ b/kernel/classes/ezcontentobjecttreenode.php
@@ -6005,7 +6005,7 @@ class eZContentObjectTreeNode extends eZPersistentObject
     static function clearViewCacheForSubtree( eZContentObjectTreeNode $node, $clearForRootNode = true )
     {
         // Max nodes to fetch at a time
-        static $limit = 50;
+        static $limit = 200;
 
         if ( $clearForRootNode )
         {
@@ -6032,11 +6032,9 @@ class eZContentObjectTreeNode extends eZPersistentObject
             $objectIDList = array();
             foreach ( $subtreeChunk as $curNode )
                 $objectIDList[] = $curNode['contentobject_id'];
-            $objectIDList = array_unique( $objectIDList );
             unset( $subtreeChunk );
 
-            foreach ( $objectIDList as $objectID )
-                eZContentCacheManager::clearContentCacheIfNeeded( $objectID );
+            eZContentCacheManager::clearContentCacheIfNeeded( array_unique( $objectIDList ) );
         }
 
         return true;


### PR DESCRIPTION
eZContentCacheManager's API was mostly made to handle one object ID at a time. This prevented optimizing some parts of the code by handling many objects at once.

Full BC is kept and error handling has been put to prevent inconsistent calls like passing a version number and a list of objectc IDs.

Having a subtree made of 6 863 objects with different tree depth, it took:
- previously:
  - To hide:
    - 286049680 bytes (peak) of memory (+/- 273Mb)
    - 42.89 sec to execute
  - To unhide:
    - 286048672 bytes (peak) of memory (+/- 273Mb)
    - 43.65 sec to execute
  - To execute: `$ php bin/php/ezcontentcache.php --clear-subtree`
    - 15.02 sec to execute
- with this fix:
  - To hide:
    - 34053424 bytes (peak) of memory (+/- 32Mb)
    - 40.24 sec to execute
  - To unhide:
    - 34054184 bytes (peak) of memory (+/- 32Mb)
    - 39.52 sec to execute
  - To execute: `$ php bin/php/ezcontentcache.php --clear-subtree`
    - 9.83 sec to execute

`eZContentObjectTreeNode::clearViewCacheForSubtree()` has been limited to handle 50 objects at the same time in a previous commit. This fix increases this limit to 200 objects since the culprit of high memory
consumption has been fixed. It requires about **39Mb** of memory (compared to **32Mb**) but makes it possible to hide/unhide the whole subtree in **19.7** seconds rather than about **40** seconds.
