### PR TITLE
Fixed #19547: Redirect after login always redirecting to home page

### DIFF
--- a/kernel/user/login.php
+++ b/kernel/user/login.php
@@ -50,7 +50,11 @@ if ( $Module->isCurrentAction( 'Login' ) and
         $requireUserLogin = ( $ini->variable( "SiteAccessSettings", "RequireUserLogin" ) == "true" );
         if ( !$requireUserLogin )
         {
-            $userRedirectURI = $http->postVariable( 'RedirectURI', $http->sessionVariable( 'LastAccessesURI', '/' ) );
+            $userRedirectURI = trim( $http->postVariable( 'RedirectURI', '' ) );
+            if ( empty( $userRedirectURI ) )
+            {
+                $userRedirectURI = $http->sessionVariable( 'LastAccessesURI', '/' );
+            }
         }
 
         if ( $http->hasSessionVariable( "RedirectAfterLogin", false ) )


### PR DESCRIPTION
$http->postVariable( 'RedirectURI' ) isset to an empty string. postVariable verifies that the POST variable isset, therefore this is not evaluated to false, LastAccessesURI is never being used.
This patch fixes it
