### PR TITLE
Fix EZP-21511 : Don't break prioritized languages when fetching eZURLAliasML->getPath in different locale

### DIFF
--- a/kernel/classes/ezurlaliasml.php
+++ b/kernel/classes/ezurlaliasml.php
@@ -352,6 +352,10 @@ class eZURLAliasML extends eZPersistentObject
 
             if ( count( $rows ) == 0 )
             {
+                if ( $incomingLanguageList !== null )
+                {
+                    eZContentLanguage::clearPrioritizedLanguages();
+                }
                 break;
             }
             $result = eZURLAliasML::choosePrioritizedRow( $rows );


### PR DESCRIPTION
Hi,
I stumbled upon this bug by using ezpLanguageSwitcher to generate path for multiple siteaccesses.

Path generation loops on parent nodes, sets temporarily prioritized languages array to wanted locales, fetches path elements in db then resets proritized languages.
This works well until one of the parent nodes is not translated in any of the wanted locales : script breaks loop and returns found path elements without resetting prioritized languages, hence breaking further language related operations.

I believe this fix to be harmless, just resetting things straight but I wonder if loop break shouldn't return an empty path rather than a partial one when an ancestor node is not translated. I didn't go this far since I don't know if this method has anything to do with PathPrefix...
