### PR TITLE
Fixed #019549: Incorrect language masks set for URL alias, inconsistent ...

### DIFF
--- a/kernel/classes/ezcontentobjecttreenode.php
+++ b/kernel/classes/ezcontentobjecttreenode.php
@@ -3598,11 +3598,28 @@ class eZContentObjectTreeNode extends eZPersistentObject
 
         $languageID = $obj->attribute( 'initial_language_id' );
         $cleanup    = false;
+        $mainLanguageEntry = false;
         foreach ( $nameList as $nameEntry )
         {
             $text     = $nameEntry['text'];
             $language = $nameEntry['language'];
-            $result = eZURLAliasML::storePath( $text, 'eznode:' . $nodeID, $language, false, $alwaysMask, $parentElementID, $cleanup );
+            if ( ( (int)$language->attribute( 'id' ) & (int)$languageID ) == (int)$languageID ) {
+                // update the main language entry in the end, as the mainLangMask may be modified by different languages using the same text
+                $mainLanguageEntry = $nameEntry;
+            }
+            else
+            {
+                $result = eZURLAliasML::storePath( $text, 'eznode:' . $nodeID, $language, false, false, $parentElementID, $cleanup );
+                if ( $result['status'] === true )
+                    $changeCount++;
+            }
+        }
+
+        if ($mainLanguageEntry !== false)
+        {
+            $text     = $mainLanguageEntry['text'];
+            $language = $mainLanguageEntry['language'];
+            $result = eZURLAliasML::storePath( $text, 'eznode:' . $nodeID, $language, false, true, $parentElementID, $cleanup );
             if ( $result['status'] === true )
                 $changeCount++;
         }

--- a/kernel/classes/ezurlaliasml.php
+++ b/kernel/classes/ezurlaliasml.php
@@ -576,6 +576,7 @@ class eZURLAliasML extends eZPersistentObject
                     }
                 }
 
+                // Note: Modifies the language mask for multiple languages using the same text
                 $bitOr = $db->bitOr( $db->bitAnd( 'lang_mask', ~1 ), $languageMask );
                 // Note: The `text` field is updated too, this ensures case-changes are stored.
                 $query = "UPDATE ezurlalias_ml SET link = id, lang_mask = {$bitOr}, text = '{$textEsc}', action = '{$actionStr}', action_type = '{$actionTypeStr}', is_alias = 0, is_original = 1 " .


### PR DESCRIPTION
...behavior.

Make sure that the "always available" bit mask is set only for the actual main language.
The mask must be set after all other languages, or the flag could be unset if the same text translation is used on different languages.
