### PR TITLE
Fixed #19500: dfscleanup on win32 lists/deletes files which are valid

### DIFF
--- a/bin/php/dfscleanup.php
+++ b/bin/php/dfscleanup.php
@@ -141,5 +141,8 @@ $script->shutdown();
  */
 function fixWinPath( $path )
 {
-    return str_replace( '\\', '/', $path );
+    if ( DIRECTORY_SEPARATOR == '\\' )
+        return str_replace( '\\', '/', $path );
+    else
+        return $path;
 }


### PR DESCRIPTION
Makes sure the win32 separator is taken into account when scanning for FS files against the DFS database
