### PR TITLE
Fixed #13472: SSL Zones - invalid redirection from SSL/HTTPS to plain HTTP

### DIFF
--- a/kernel/classes/ezsslzone.php
+++ b/kernel/classes/ezsslzone.php
@@ -238,7 +238,7 @@ class eZSSLZone
             $port = parse_url( "http://$host", PHP_URL_PORT );
             $host = eZSys::serverVariable( 'HTTP_HOST' );
             $host = preg_replace( '/:\d+$/', '', $host );
-            if( $port && $port != 80 )
+            if ( $port && $port != 80 )
                 $host .= ":$port";
             $sslZoneRedirectionURL = "http://" . $host . $indexDir . $requestURI;
         }


### PR DESCRIPTION
Siteaccess is getting duplicated in URL mode configuration.
See public issue for example and reproducible steps 
(the fix is not my suggestion. it was pulled from there. I just tested to confirm it worked in my test cases)
