### PR TITLE
Fixed #19204: Table options don't remember user selection in backend

### DIFF
--- a/design/admin2/javascript/ezajaxsubitems_datatable.js
+++ b/design/admin2/javascript/ezajaxsubitems_datatable.js
@@ -24,8 +24,7 @@ var sortableSubitems = function () {
         YAHOO.util.Cookie.setSub(confObj.cookieName, subName, escape(joined), {
             path : "/",
             expires : expiresDate,
-            secure : confObj.cookieSecure,
-            domain : confObj.cookieDomain
+            secure : confObj.cookieSecure
         });
     }
 


### PR DESCRIPTION
After investigation, explicitely setting the cookie doesn't bring any added value. It uses eZSys::hostname(), which only checks the X-HTTP-FORWARDED-FOR header, useless in client side code.

http://issues.ez.no/19204
