### PR TITLE
Fixed #019565: eZOrder (statistics)

### DIFF
--- a/kernel/classes/ezorder.php
+++ b/kernel/classes/ezorder.php
@@ -394,6 +394,7 @@ class eZOrder extends eZPersistentObject
 
         // add last product info
         if ( !empty( $productArray ) )
+        {
             $productItemArray[] = array(
                 'name' => $name,
                 // Reference to the entry that will contain the ContentObject at the end
@@ -401,10 +402,11 @@ class eZOrder extends eZPersistentObject
                 'product_info' => $productInfo
             );
         
-        // Fetching all ContentObject ids in one query, filling the hash with the corresponding ContentObject
-        foreach ( eZContentObject::fetchList( true, array( "id" => array( array_keys( $contentObjectIDHash ) ) ) ) as $contentObject )
-        {
-            $contentObjectIDHash[$contentObject->ID] = $contentObject;
+            // Fetching all ContentObject ids in one query, filling the hash with the corresponding ContentObject
+            foreach ( eZContentObject::fetchList( true, array( "id" => array( array_keys( $contentObjectIDHash ) ) ) ) as $contentObject )
+            {
+                $contentObjectIDHash[$contentObject->ID] = $contentObject;
+            }
         }
 
         return array(


### PR DESCRIPTION
## Fatal error in function orderStatistics

sql error when there is no product for selected date

`Query error (1064): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ')  ORDER BY id ASC' at line 2.`
`Query: SELECT id, section_id, owner_id, contentclass_id, name, published, modified,       current_version, status, remote_id, language_mask, initial_language_id FROM   ezcontentobject WHERE  id IN (  )  ORDER BY id ASC`
