### PR TITLE
Fixed #19397: General digest settings table is not updated when changing email

### DIFF
--- a/kernel/classes/datatypes/ezuser/ezuser.php
+++ b/kernel/classes/datatypes/ezuser/ezuser.php
@@ -198,15 +198,76 @@ class eZUser extends eZPersistentObject
         return new eZUser( $row );
     }
 
+    /**
+     * Magic setter. Currently only handles the Email to store the previous
+     * email address.;
+     *
+     * @param string $name
+     * @param string $value
+     */
+    function __set( $name, $value )
+    {
+        if ( $name === 'Email' )
+        {
+            $this->OldEmail = $this->Email;
+            $this->Email = trim( $value );
+        }
+    }
+
+    /**
+     * Returns the property $name. Currently, it's only able to handle 'Email'.
+     * For others $name, it returns null.
+     *
+     * @param string $name
+     * @return null|string
+     */
+    function __get( $name )
+    {
+        if ( $name === 'Email' )
+        {
+            return $this->Email;
+        }
+        eZDebug::writeError(
+            "Trying to get inexistent property '{$name}' on eZUser",
+            __METHOD__
+        );
+        return null;
+    }
+
+    /**
+     * Reimplements eZPersistentObject::setAttribute() to store the old email
+     * adress.
+     *
+     * @param string $attr
+     * @param mixed $val
+     */
+    function setAttribute( $attr, $val )
+    {
+        if ( $attr === 'email' )
+        {
+            $this->OldEmail = $this->Email;
+            $val = trim( $val );
+        }
+        parent::setAttribute( $attr, $val );
+    }
+
     function store( $fieldFilters = null )
     {
-        $this->Email = trim( $this->Email );
+        $db = eZDB::instance();
         $userID = $this->attribute( 'contentobject_id' );
         // Clear memory cache
         unset( $GLOBALS['eZUserObject_' . $userID] );
         $GLOBALS['eZUserObject_' . $userID] = $this;
         self::purgeUserCacheByUserId( $userID );
+
+        $db->begin();
         eZPersistentObject::store( $fieldFilters );
+        if ( $this->OldEmail !== null && $this->OldEmail != $this->Email )
+        {
+            eZGeneralDigestUserSettings::updateAddress( $this->OldEmail, $this->Email );
+            $this->OldEmail = null;
+        }
+        $db->commit();
     }
 
     function originalPassword()
@@ -2811,13 +2872,32 @@ WHERE user_id = '" . $userID . "' AND
     }
 
     /// \privatesection
+    public $ContentObjectID;
     public $Login;
-    public $Email;
     public $PasswordHash;
     public $PasswordHashType;
     public $Groups;
     public $OriginalPassword;
     public $OriginalPasswordConfirm;
+    public $AccessArray;
+
+
+    /**
+     * Contains the email address of the user.
+     * To not break BC, this property is still publicly
+     * available through eZUser::__get()
+     *
+     * @var string
+     */
+    protected $Email;
+
+    /**
+     * Contains the old email address of the user.
+     * @see eZUser::__set() and eZUser::setAttribute()
+     *
+     * @var null|string
+     */
+    protected $OldEmail = null;
 
     /**
      * Holds user cache like user info and access array

--- a/kernel/classes/notification/handler/ezgeneraldigest/ezgeneraldigestusersettings.php
+++ b/kernel/classes/notification/handler/ezgeneraldigest/ezgeneraldigestusersettings.php
@@ -86,6 +86,22 @@ class eZGeneralDigestUserSettings extends eZPersistentObject
         $db->query( "DELETE FROM ezgeneral_digest_user_settings WHERE address='" . $db->escapeString( $address ) . "'" );
     }
 
+    /**
+     * Update the email address in the database
+     *
+     * @param string $oldAddr the old email address
+     * @param string $newAddr the new email address
+     */
+    static function updateAddress( $oldAddr, $newAddr )
+    {
+        $db = eZDB::instance();
+        $db->query(
+            "UPDATE ezgeneral_digest_user_settings SET address='"
+            . $db->escapeString( $newAddr ) . "' WHERE address='"
+            . $db->escapeString( $oldAddr ) . "'"
+        );
+    }
+
     /*!
      \static
      Removes all general digest settings for all users.


### PR DESCRIPTION
Bug: http://issues.ez.no/19397
# Description

When a user's email address is changed, it's not updated in the table `ezgeneral_digest_user_settings` as a result, the user looses his digest preferences.
# Testing

Manual tests
