### PR TITLE
Fixed #19495: eZP 4.6 Runcronjobs.php ignoring -q flag

### DIFF
--- a/runcronjobs.php
+++ b/runcronjobs.php
@@ -116,6 +116,7 @@ $optionsWithData = array( 's' );
 $longOptionsWithData = array( 'siteaccess' );
 
 $readOptions = true;
+$siteAccessSet = false;
 
 for ( $i = 1, $count = count( $argv ); $i < $count; ++$i )
 {
@@ -140,7 +141,7 @@ for ( $i = 1, $count = count( $argv ); $i < $count; ++$i )
             }
             else if ( $flag == 'siteaccess' )
             {
-                changeSiteAccessSetting( $siteaccess, $optionData );
+                $siteAccessSet = $optionData;
             }
             else if ( $flag == 'debug' )
             {
@@ -250,7 +251,7 @@ for ( $i = 1, $count = count( $argv ); $i < $count; ++$i )
             }
             else if ( $flag == 's' )
             {
-                changeSiteAccessSetting( $siteaccess, $optionData );
+                $siteAccessSet = $optionData;
             }
         }
     }
@@ -269,6 +270,9 @@ $script->setUseDebugAccumulators( $useDebugAccumulators );
 $script->setUseDebugTimingPoints( $useDebugTimingpoints );
 $script->setUseIncludeFiles( $useIncludeFiles );
 $script->setIsQuiet( $isQuiet );
+
+if ( $siteAccessSet )
+    changeSiteAccessSetting( $siteaccess, $siteAccessSet );
 
 if ( $webOutput )
     $useColors = true;


### PR DESCRIPTION
In good truth, it was not ignoring. It was just that changeSiteAccessSetting produced output and was executed "before" setIsQuiet had been set

I believe that runcronjobs should be enhanced and fully incorporated in the common script working logic (from what I could understand, the only things that runcronjobs implements that are not on common eZScript is cronjob-part and sql.
sql doesn't seem to be used anywhere
cronjob-part can be dealt with, with ease.

For the time being, this patch enables -q -s to be used together without producing any output.  
