### PR TITLE
Fixed #19519: Two user locations with duplicated policy with language filter fails

### DIFF
--- a/kernel/classes/ezrole.php
+++ b/kernel/classes/ezrole.php
@@ -588,24 +588,7 @@ class eZRole extends eZPersistentObject
                 }
             }
         }
-        $accessArray = self::super_unique( $accessArray );
         return $accessArray;
-    }
-
-    /*!
-     Array unique recursive
-     */
-    static function super_unique( $array )
-    {
-        $result = array_map( "unserialize", array_unique( array_map( "serialize", $array ) ) );
-        foreach ( $result as $key => $value )
-        {
-            if ( is_array( $value ) )
-            {
-                $result[$key] = self::super_unique( $value );
-            }
-        }
-        return $result;
     }
 
     /*!


### PR DESCRIPTION
Anonymous policies are being loaded twice for users that belong both to this and members roles.
Might probably be a bad practice to add both roles to an user.
Might even be a worst idea to add a policy stating that anonymous can create objects in a certain language.

But since there is no documentation explaining users not to do so, the bug exists under those circumstances.

There are two roads in this fix:
Commit 1 - The loaded policy array should include unique policies (the super_array function should probably go elsewhere)
Commit 2 - While building a language mask, if a language is added twice to the mask, it should not add up twice. 
