### PR TITLE
#019569: Copyright Outdated in eZ Publish 4.6 and 4.7

### DIFF
--- a/kernel/ezinfo/copyright.php
+++ b/kernel/ezinfo/copyright.php
@@ -10,7 +10,7 @@ $Module = $Params['Module'];
 
 $text =
 ## BEGIN COPYRIGHT INFO ##
-'<p>Copyright (C) 1999-2010 eZ Systems AS. All rights reserved.</p>
+'<p>Copyright (C) 1999-2012 eZ Systems AS. All rights reserved.</p>
 
 <p>This file may be distributed and/or modified under the terms of the
 \"GNU General Public License\" version 2 as published by the Free


### PR DESCRIPTION
The Copyright page of eZ Publish is Outdated, it needs to be updated to 2011 in 4.6 and 2012 in 4.7
