### PR TITLE
added inline HostUriMatchMapItems ordering documentation to site.ini

### DIFF
--- a/settings/site.ini
+++ b/settings/site.ini
@@ -725,12 +725,12 @@ HostMatchSubtextPost=.example.com
 # Last optional paramter controls host matching method, 'strict' by default
 #
 # Note: Only strict matching is supported by static cache, reason is the rewrite
-#       rules needs a strict convention between host/uri & match (basis for folder name)
-#       urlmatch is also optional, so you can do pure host matching with this as well.
+#       rules needs a strict convention between host/uri & match (basis for folder name).
+#       Uri part is also optional, so you can do pure host matching with this as well.
+#       Empty hostname parts are not possible.
 #
 # Ordering: eZ Publish searches HostUriMatchMapItems[] from top to bottom, so place
-#           more specific entries at the top and entries with empty uri parts at the bottom
-#           Empty hostname parts are not possible.
+#           more specific entries at the top and entries with empty uri parts at the bottom.
 
 # Change HostUriMatchMethodDefault to one of these options to chenge default value
 HostUriMatchMethodDefault=strict


### PR DESCRIPTION
Explicit docs on HostUriMatchMapItems ordering, so that users don't have to grep the docs for this, or write a blog post about it ( http://www.netgen.hr/eng/Blog/Setting-up-eZ-Publish-host_uri-matching-properly ).
