### PR TITLE
Fixed #19576: SSLZones subtrees not updated with cache clearing

### DIFF
--- a/kernel/classes/ezcache.php
+++ b/kernel/classes/ezcache.php
@@ -706,6 +706,8 @@ class eZCache
     static function clearGlobalINICache( $cacheItem )
     {
         eZDir::recursiveDelete( $cacheItem['path'] );
+        // There might exist some changes in ssl zones as well.
+        eZSSLZone::clearCacheIfNeeded();
     }
 
     /**


### PR DESCRIPTION
I propose that ssl cached information is refreshed when ini cache is regenerated.

Note: 
clearCacheIfNeeded checks if SSLZones are enabled before it proceeds with the removal of the cache file. This means that the cache clearing will not be executed when SSLZones are disabled. 

A way to solve this would be to always check if the file exists in clearCacheIfNeeded, but that would have huge impact on content publishing (since the method is being called every time content is updated)

My suggestion is that instead of trying to solve that problem in code, we just append a note to SSLZone documentation explaining that manual removal of var/ezwebin_site/cache/ssl_zones_cache.php is required if SSLZones are toggled to disabled state.
