### PR TITLE
Fix for #019575: Auto select attributes in the *wait until date* workflow

### DIFF
--- a/design/admin2/templates/workflow/eventtype/edit/event_ezwaituntildate.tpl
+++ b/design/admin2/templates/workflow/eventtype/edit/event_ezwaituntildate.tpl
@@ -8,7 +8,7 @@ function toggleClass( selection )
         {$class.id} : {ldelim}
         {foreach fetch( 'class', 'attribute_list', hash( 'class_id', $class.id ) ) as $attribute}
             {delimiter},{/delimiter}
-            {$attribute.id} : "{$attribute.name}"
+            {$attribute.id} : '{$attribute.name}'
         {/foreach}
         {rdelim}
     {/foreach}


### PR DESCRIPTION
If you use " while loading the Name of the attributes of the classes this will fail when trying to load the names on "Tempalte look" class, since there is an attribute Hide "Powered by" that with add double ".
