### PR TITLE
Fixed #19039: Incorrect redirect after publishing home page from preview

### DIFF
--- a/kernel/content/versionviewframe.php
+++ b/kernel/content/versionviewframe.php
@@ -112,7 +112,10 @@ if ( $Module->isCurrentAction( 'Publish' ) and
         }
         else
         {
-            $Module->redirectToView( 'view', array( 'full', $object->attribute( 'main_parent_node_id' ) ) );
+            $nodeToView = $object->attribute( 'main_parent_node_id' );
+            if ( $nodeToView == 1 )
+              $nodeToView = $object->attribute( 'main_node_id' );
+            $Module->redirectToView( 'view', array( 'full', $nodeToView ) );
         }
     }
     else


### PR DESCRIPTION
If it were up to me to decide, users would not be redirected to the parent node after publishing...
With this change, whenever the parent node of a node being previewed (through versionviewframe) is 1, publish will redirect to the current node (normally 2, but for safe keeping I am pulling the node id from the object itself) 