### PR TITLE
Extensible controlbar for node full view in admin

### DIFF
--- a/design/admin/templates/node/view/controlbar.tpl
+++ b/design/admin/templates/node/view/controlbar.tpl
@@ -1,0 +1,35 @@
+<div class="controlbar">
+    {* DESIGN: Control bar START *}
+
+    <form method="post" action={'content/action'|ezurl}>
+        <input type="hidden" name="TopLevelNode" value="{$node.object.main_node_id}" />
+        <input type="hidden" name="ContentNodeID" value="{$node.node_id}" />
+        <input type="hidden" name="ContentObjectID" value="{$node.contentobject_id}" />
+
+        <div class="button-left">
+            <div class='block'>
+                {foreach ezini( 'NodeControlbar', 'Controls', 'controlbar.ini' ) as $cb_control}
+                    {def $cb_template=ezini( concat('NodeControlbar_', $cb_control ), 'Template', 'controlbar.ini' )}
+                    {def $cb_available_for_all=ezini( concat('NodeControlbar_', $cb_control ), 'AvailableForAllClasses', 'controlbar.ini' )}
+                    {def $cb_classes = ezini( concat('NodeControlbar_', $cb_control ), 'AvailableForClasses', 'controlbar.ini' )}
+
+                    {if or( eq($cb_available_for_all, 'true'), $cb_classes|contains( $node.class_identifier ) )}
+                        {include uri=concat( 'design:node/view/controlbar/', $cb_template )}
+                    {/if}
+
+                    {undef $cb_template $cb_available_for_all $cb_classes}
+                {/foreach}
+            </div>
+        </div>
+
+        <div class="button-right">
+            <p class='versions'>
+                {* Link to manage versions *}
+                <a href="{concat("content/history/", $node.contentobject_id )|ezurl('no')}" title="{'View and manage (copy, delete, etc.) the versions of this object.'|i18n( 'design/admin/content/edit' )}">{'Manage versions'|i18n( 'design/admin/content/edit' )}</a>
+            </p>
+        </div>
+
+        <div class="float-break"></div>
+    </form>
+    {* DESIGN: Control bar END *}
+</div>

--- a/design/admin/templates/node/view/controlbar/edit.tpl
+++ b/design/admin/templates/node/view/controlbar/edit.tpl
@@ -1,0 +1,24 @@
+{* Edit button. *}
+{def $can_create_languages = $node.object.can_create_languages
+     $languages            = fetch( 'content', 'prioritized_languages' )}
+{if $node.can_edit}
+    {if and(eq( $languages|count, 1 ), is_set( $languages[0] ) )}
+            <input name="ContentObjectLanguageCode" value="{$languages[0].locale}" type="hidden" />
+    {else}
+            <select name="ContentObjectLanguageCode">
+            {foreach $node.object.can_edit_languages as $language}
+                       <option value="{$language.locale}"{if $language.locale|eq($node.object.current_language)} selected="selected"{/if}>{$language.name|wash}</option>
+            {/foreach}
+            {if gt( $can_create_languages|count, 0 )}
+                <option value="">{'New translation'|i18n( 'design/admin/node/view/full')}</option>
+            {/if}
+            </select>
+    {/if}
+    <input class="button" type="submit" name="EditButton" value="{'Edit'|i18n( 'design/admin/node/view/full' )}" title="{'Edit the contents of this item.'|i18n( 'design/admin/node/view/full' )}" />
+{else}
+    <select name="ContentObjectLanguageCode" disabled="disabled">
+        <option value="">{'Not available'|i18n( 'design/admin/node/view/full')}</option>
+    </select>
+    <input class="button-disabled" type="submit" name="EditButton" value="{'Edit'|i18n( 'design/admin/node/view/full' )}" title="{'You do not have permission to edit this item.'|i18n( 'design/admin/node/view/full' )}" disabled="disabled" />
+{/if}
+{undef $can_create_languages}

--- a/design/admin/templates/node/view/controlbar/move.tpl
+++ b/design/admin/templates/node/view/controlbar/move.tpl
@@ -1,0 +1,6 @@
+{* Move button. *}
+{if $node.can_move}
+    <input class="button" type="submit" name="MoveNodeButton" value="{'Move'|i18n( 'design/admin/node/view/full' )}" title="{'Move this item to another location.'|i18n( 'design/admin/node/view/full' )}" />
+{else}
+    <input class="button-disabled" type="submit" name="MoveNodeButton" value="{'Move'|i18n( 'design/admin/node/view/full' )}" title="{'You do not have permission to move this item to another location.'|i18n( 'design/admin/node/view/full' )}" disabled="disabled" />
+{/if}

--- a/design/admin/templates/node/view/controlbar/remove.tpl
+++ b/design/admin/templates/node/view/controlbar/remove.tpl
@@ -1,0 +1,6 @@
+{* Remove button. *}
+{if $node.can_remove}
+    <input class="button" type="submit" name="ActionRemove" value="{'Remove'|i18n( 'design/admin/node/view/full' )}" title="{'Remove this item.'|i18n( 'design/admin/node/view/full' )}" />
+{else}
+    <input class="button-disabled" type="submit" name="ActionRemove" value="{'Remove'|i18n( 'design/admin/node/view/full' )}" title="{'You do not have permission to remove this item.'|i18n( 'design/admin/node/view/full' )}" disabled="disabled" />
+{/if}

--- a/design/admin/templates/node/view/full.tpl
+++ b/design/admin/templates/node/view/full.tpl
@@ -56,69 +56,7 @@
 
 {* DESIGN: Content END *}</div>
 
-<div class="controlbar">
-{* DESIGN: Control bar START *}
-
-<form method="post" action={'content/action'|ezurl}>
-<input type="hidden" name="TopLevelNode" value="{$node.object.main_node_id}" />
-<input type="hidden" name="ContentNodeID" value="{$node.node_id}" />
-<input type="hidden" name="ContentObjectID" value="{$node.contentobject_id}" />
-
-<div class="button-left">
-<div class='block'>
-{* Edit button. *}
-{def $can_create_languages = $node.object.can_create_languages
-     $languages            = fetch( 'content', 'prioritized_languages' )}
-{if $node.can_edit}
-    {if and(eq( $languages|count, 1 ), is_set( $languages[0] ) )}
-            <input name="ContentObjectLanguageCode" value="{$languages[0].locale}" type="hidden" />
-    {else}
-            <select name="ContentObjectLanguageCode">
-            {foreach $node.object.can_edit_languages as $language}
-                       <option value="{$language.locale}"{if $language.locale|eq($node.object.current_language)} selected="selected"{/if}>{$language.name|wash}</option>
-            {/foreach}
-            {if gt( $can_create_languages|count, 0 )}
-                <option value="">{'New translation'|i18n( 'design/admin/node/view/full')}</option>
-            {/if}
-            </select>
-    {/if}
-    <input class="button" type="submit" name="EditButton" value="{'Edit'|i18n( 'design/admin/node/view/full' )}" title="{'Edit the contents of this item.'|i18n( 'design/admin/node/view/full' )}" />
-{else}
-    <select name="ContentObjectLanguageCode" disabled="disabled">
-        <option value="">{'Not available'|i18n( 'design/admin/node/view/full')}</option>
-    </select>
-    <input class="button-disabled" type="submit" name="EditButton" value="{'Edit'|i18n( 'design/admin/node/view/full' )}" title="{'You do not have permission to edit this item.'|i18n( 'design/admin/node/view/full' )}" disabled="disabled" />
-{/if}
-{undef $can_create_languages}
-
-{* Move button. *}
-{if $node.can_move}
-    <input class="button" type="submit" name="MoveNodeButton" value="{'Move'|i18n( 'design/admin/node/view/full' )}" title="{'Move this item to another location.'|i18n( 'design/admin/node/view/full' )}" />
-{else}
-    <input class="button-disabled" type="submit" name="MoveNodeButton" value="{'Move'|i18n( 'design/admin/node/view/full' )}" title="{'You do not have permission to move this item to another location.'|i18n( 'design/admin/node/view/full' )}" disabled="disabled" />
-{/if}
-
-{* Remove button. *}
-{if $node.can_remove}
-    <input class="button" type="submit" name="ActionRemove" value="{'Remove'|i18n( 'design/admin/node/view/full' )}" title="{'Remove this item.'|i18n( 'design/admin/node/view/full' )}" />
-{else}
-    <input class="button-disabled" type="submit" name="ActionRemove" value="{'Remove'|i18n( 'design/admin/node/view/full' )}" title="{'You do not have permission to remove this item.'|i18n( 'design/admin/node/view/full' )}" disabled="disabled" />
-{/if}
-</div>
-</div>
-
-<div class="button-right">
-	<p class='versions'>
-    {* Link to manage versions *}
-    <a href={concat("content/history/", $node.contentobject_id )|ezurl} title="{'View and manage (copy, delete, etc.) the versions of this object.'|i18n( 'design/admin/content/edit' )}">{'Manage versions'|i18n( 'design/admin/content/edit' )}</a>
-    </p>
-</div>
-
-<div class="float-break"></div>
-</form>
-{* DESIGN: Control bar END *}
-</div>
-
+{include uri='design:node/view/controlbar.tpl'}
 
 </div>
 

--- a/doc/features/5.2/node_controlbar.md
+++ b/doc/features/5.2/node_controlbar.md
@@ -1,0 +1,36 @@
+# Node controlbar
+
+Added possibility to add controls to a node's full view in the admin interface
+
+## Previous behaviour
+
+In order to add new controls to a node's full view in the admin interface, you would have to override the whole
+`design/admin/templates/node/view/full.tpl` template, which meant that you wouldn't automatically receive updates
+to the file coming with an update of eZ Publish.
+
+## New behaviour
+
+To add a new control (besides 'Edit', 'Move' and 'Remove') create a new override for the file `controlbar.ini` in your
+admin siteaccess settings folder:
+
+    <?php /* #?ini charset="utf-8"?
+
+    [NodeControlbar]
+    Controls[]=my_custom_control
+    Controls[]=my_custom_image_control
+
+    [NodeControlbar_my_custom_control]
+    Template=my_custom_control.tpl
+    AvailableForAllClasses=true
+    AvailableForClasses[]
+
+    [NodeControlbar_my_custom_image_control]
+    Template=my_custom_image_control.tpl
+    AvailableForClasses=false
+    AvailableForClasses[]
+    AvailableForClasses[]=image
+
+    /* ?>
+
+Place the new templates in the folder `extension/<my_extension>/design/admin/templates/node/controlbar`. You can take
+the existing controls in `design/admin/templates/node/controlbar` as examples.

--- a/settings/controlbar.ini
+++ b/settings/controlbar.ini
@@ -1,0 +1,35 @@
+#?ini charset="utf-8"?
+# eZ Publish configuration file for custom buttons in the control bar on admin node full views
+#
+# NOTE: It is not recommended to edit this files directly, instead
+#       a file in override should be created for setting the
+#       values that is required for your site. Either create
+#       a file called settings/override/controlbar.ini.append or
+#       settings/override/controlbar.ini.append.php for more security
+#       in non-virtualhost modes (the .php file may already be present
+#       and can be used for this purpose).
+#
+#       You can also place your own override configuration file
+#       in settings/siteaccess/<myaccess>/controlbar.ini.append.php
+
+[NodeControlbar]
+# The buttons available for the controlbar
+Controls[]
+Controls[]=edit
+Controls[]=move
+Controls[]=remove
+
+[NodeControlbar_edit]
+Template=edit.tpl
+AvailableForAllClasses=true
+AvailableForClasses[]
+
+[NodeControlbar_move]
+Template=move.tpl
+AvailableForAllClasses=true
+AvailableForClasses[]
+
+[NodeControlbar_remove]
+Template=remove.tpl
+AvailableForAllClasses=true
+AvailableForClasses[]


### PR DESCRIPTION
At the moment, if you want to extend the control bar on a node's full view in the admin interface with custom buttons, you would have to overwrite the complete node/view/full.tpl

This patch makes it possible to add new buttons by overriding the INI file `controlbar.ini` and adding a new template for the new button.

It is also possible to enable buttons only for specific content classes.

Cheers
:octocat: Jérôme
