### PR TITLE
Fixed #019502: If a compiled template does not execute succesfully, view cache and cache-blocks should not be generated

### DIFF
--- a/autoload/ezp_kernel.php
+++ b/autoload/ezp_kernel.php
@@ -445,6 +445,7 @@ return array(
       'eZTemplateDoFunction'                               => 'lib/eztemplate/classes/eztemplatedofunction.php',
       'eZTemplateElementParser'                            => 'lib/eztemplate/classes/eztemplateelementparser.php',
       'eZTemplateExecuteOperator'                          => 'lib/eztemplate/classes/eztemplateexecuteoperator.php',
+      'eZTemplateFailedExecutingCompiledTemplate'          => 'lib/eztemplate/classes/exceptions/failedexecutingcompiledtemplate.php',
       'eZTemplateFileResource'                             => 'lib/eztemplate/classes/eztemplatefileresource.php',
       'eZTemplateForFunction'                              => 'lib/eztemplate/classes/eztemplateforfunction.php',
       'eZTemplateForeachFunction'                          => 'lib/eztemplate/classes/eztemplateforeachfunction.php',

--- a/lib/eztemplate/classes/exceptions/failedexecutingcompiledtemplate.php
+++ b/lib/eztemplate/classes/exceptions/failedexecutingcompiledtemplate.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * File containing the eZTemplateFailedExecutingCompiledTemplate exception.
+ *
+ * @copyright Copyright (C) 1999-2012 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ * @package lib
+ */
+
+/**
+ * Exception occuring when the execution of a compiled template fails
+ *
+ * @package lib
+ */
+class eZTemplateFailedExecutingCompiledTemplate extends Exception
+{
+}

--- a/lib/eztemplate/classes/eztemplatecompiler.php
+++ b/lib/eztemplate/classes/eztemplatecompiler.php
@@ -368,10 +368,22 @@ class eZTemplateCompiler
         return $canRestore;
     }
 
-    /*!
-     Tries to execute the compiled template and returns \c true if succsesful.
-     Returns \c false if caching is disabled or the compiled template could not be executed.
-    */
+    /**
+     * Tries to execute the compiled template. Returns true if successful,
+     * returns false if the compilation is disabled or the compiled template
+     * does not exist.
+     *
+     * @param eZTemplate $tpl
+     * @param array $textElements
+     * @param string $key
+     * @param array $resourceData
+     * @param $rootNamespace
+     * @param $currentNamespace
+     *
+     * @throws eZTemplateFailedExecutingCompiledTemplate if the compiled
+     *         template could not be executed
+     * @return bool
+     */
     static function executeCompilation( $tpl, &$textElements, $key, &$resourceData,
                                  $rootNamespace, $currentNamespace )
      {
@@ -396,7 +408,17 @@ class eZTemplateCompiler
                 return true;
             }
             else
-                eZDebug::writeError( "Failed executing compiled template '$phpScript'", __METHOD__ );
+            {
+                eZDebug::writeError(
+                    "Failed executing compiled template '$phpScript',"
+                        . " if this file is valid, then the error is probably"
+                        . "  related to APC usage, try restarting the webserver",
+                    __METHOD__
+                );
+                throw new eZTemplateFailedExecutingCompiledTemplate(
+                    "Failed executing a compiled template, see error.log for details"
+                );
+            }
         }
         else
             eZDebug::writeError( "Unknown compiled template '$phpScript'", __METHOD__ );


### PR DESCRIPTION
Bug: http://issues.ez.no/19502 (initially created by @gggeek in a project issue tracker)
# Description

From Gaetano's issue, it happens that the execution of a compiled template fails (rarely but it happens, it's probably related to a weird configuration and/or bug in APC). In such case, the execution of the template returns an empty string and then the caches where the result of the template is supposed to be are corrupted.

To avoid this, this patch makes eZ Publish throw an exception in such (rare) case where the template execution fails.
To be honest, I'm not sure whether we should implement something against this situation and implement it like this, so your opinion is very welcome on this :-)
# Tests

Tested by hacking some compiled templates to simulate the bad template execution issue.
