### PR TITLE
Fixed #019567: Viewcache generation locks under traffic for user who has...

### DIFF
--- a/kernel/content/view.php
+++ b/kernel/content/view.php
@@ -158,34 +158,36 @@ if ( ( isset( $operationResult['status'] ) && $operationResult['status'] != eZMo
 }
 else
 {
-    $localVars = array( "cacheFileArray", "NodeID",   "Module", "tpl",
-                        "LanguageCode",   "ViewMode", "Offset", "ini",
-                        "cacheFileArray", "viewParameters",  "collectionAttributes",
-                        "validation" );
+    $args = compact(
+        array(
+            "NodeID", "Module", "tpl", "LanguageCode", "ViewMode", "Offset", "ini", "viewParameters", "collectionAttributes", "validation"
+        )
+    );
     if ( $viewCacheEnabled )
     {
-        $user = eZUser::currentUser();
+        $cacheFileArray = eZNodeviewfunctions::generateViewCacheFile(
+            eZUser::currentUser(),
+            $NodeID,
+            $Offset,
+            $layout,
+            $LanguageCode,
+            $ViewMode,
+            $viewParameters,
+            false
+        );
 
-        $cacheFileArray = eZNodeviewfunctions::generateViewCacheFile( $user, $NodeID, $Offset, $layout, $LanguageCode, $ViewMode, $viewParameters, false );
-
-        $cacheFilePath = $cacheFileArray['cache_path'];
-
-        $cacheFile = eZClusterFileHandler::instance( $cacheFilePath );
-        $args = compact( $localVars );
-        $Result = $cacheFile->processCache( array( 'eZNodeviewfunctions', 'contentViewRetrieve' ),
-                                            array( 'eZNodeviewfunctions', 'contentViewGenerate' ),
-                                            null,
-                                            null,
-                                            $args );
-        return $Result;
+        return eZClusterFileHandler::instance( $cacheFileArray['cache_path'] )
+            ->processCache(
+                array( 'eZNodeviewfunctions', 'contentViewRetrieve' ),
+                array( 'eZNodeviewfunctions', 'contentViewGenerate' ),
+                null,
+                null,
+                $args
+            );
     }
-    else
-    {
-        $cacheFileArray = array( 'cache_dir' => false, 'cache_path' => false );
-        $args = compact( $localVars );
-        $data = eZNodeviewfunctions::contentViewGenerate( false, $args ); // the false parameter will disable generation of the 'binarydata' entry
-        return $data['content']; // Return the $Result array
-    }
+
+    $data = eZNodeviewfunctions::contentViewGenerate( false, $args ); // the false parameter will disable generation of the 'binarydata' entry
+    return $data['content']; // Return the $Result array
 }
 
 // Looking for some view-cache code?


### PR DESCRIPTION
... no permissions to view a page

Caching most error cases to prevent the constant cycle:
1. creation of a .generating file
2. generating cache file
3. removing cache file

Tested with Apache Benchmark:

Before:

```
$ sudo ab -k -n 500 -c 80 -t 30  http://ezpublish/
This is ApacheBench, Version 2.3 <$Revision: 655654 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking ezpublish (be patient)
Finished 1172 requests


Server Software:        Apache
Server Hostname:        ezpublish
Server Port:            80

Document Path:          /
Document Length:        12426 bytes

Concurrency Level:      80
Time taken for tests:   30.018 seconds
Complete requests:      1172
Failed requests:        0
Write errors:           0
Keep-Alive requests:    0
Total transferred:      14973472 bytes
HTML transferred:       14563272 bytes
Requests per second:    39.04 [#/sec] (mean)
Time per request:       2049.038 [ms] (mean)
Time per request:       25.613 [ms] (mean, across all concurrent requests)
Transfer rate:          487.12 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.2      0       1
Processing:    24  259 482.3     26    1682
Waiting:       23  258 482.3     25    1681
Total:         24  259 482.4     26    1682

Percentage of the requests served within a certain time (ms)
  50%     26
  66%     27
  75%     33
  80%    416
  90%   1306
  95%   1458
  98%   1535
  99%   1608
 100%   1682 (longest request)
```

After:

```
$ sudo ab -k -n 500 -c 80 -t 30  http://ezpublish/
This is ApacheBench, Version 2.3 <$Revision: 655654 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking ezpublish (be patient)
Completed 5000 requests
Finished 6813 requests


Server Software:        Apache
Server Hostname:        ezpublish
Server Port:            80

Document Path:          /
Document Length:        12426 bytes

Concurrency Level:      80
Time taken for tests:   30.005 seconds
Complete requests:      6813
Failed requests:        0
Write errors:           0
Keep-Alive requests:    0
Total transferred:      87081216 bytes
HTML transferred:       84695616 bytes
Requests per second:    227.06 [#/sec] (mean)
Time per request:       352.324 [ms] (mean)
Time per request:       4.404 [ms] (mean, across all concurrent requests)
Transfer rate:          2834.23 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.1      0       1
Processing:    40  350  85.7    346     736
Waiting:       38  330  82.0    328     710
Total:         40  350  85.7    346     736

Percentage of the requests served within a certain time (ms)
  50%    346
  66%    379
  75%    400
  80%    415
  90%    458
  95%    494
  98%    540
  99%    569
 100%    736 (longest request)
```
