### PR TITLE
Fixed #019549: Incorrect language masks set for URL alias

### DIFF
--- a/kernel/classes/ezurlaliasml.php
+++ b/kernel/classes/ezurlaliasml.php
@@ -1047,6 +1047,7 @@ class eZURLAliasML extends eZPersistentObject
         $filterSQL = trim( eZContentLanguage::languagesSQLFilter( 'ezurlalias_ml', 'lang_mask' ) );
         $query = "SELECT id, parent, lang_mask, text, action FROM ezurlalias_ml WHERE ( {$filterSQL} ) AND action in ( {$actionStr} ) AND is_original = 1 AND is_alias=0";
         $rows = $db->arrayQuery( $query );
+        $objects = eZContentObject::fetchByNodeID( $actionValues );
         $actionMap = array();
         foreach ( $rows as $row )
         {
@@ -1092,8 +1093,8 @@ class eZURLAliasML extends eZPersistentObject
                         $defaultRow = $row;
                         break 2;
                     }
-                    // If the 'always available' bit is set then choose it as the default
-                    if ( ($langMask & 1) > 0 )
+                    // If the 'always available' bit is set AND it corresponds to the main language, then choose it as the default
+                    if ( $langMask & 1 && $objects[$actionValue]->attribute( 'initial_language_id' ) & $langMask )
                     {
                         $defaultRow = $row;
                     }


### PR DESCRIPTION
Simple fix. Language masks in `ezurlalias_ml` always have the _always available_ bit, which leads to inconsistent results.

This patch simply ensures that the main language (aka `initial_language_id`) is used.

Manual tests.
