### PR TITLE
Fixed #19658: OGA Mime Type missing

### DIFF
--- a/settings/mime.ini
+++ b/settings/mime.ini
@@ -282,6 +282,9 @@ Types[]=application/vnd.oasis.opendocument.spreadsheet
 [odt]
 Types[]=application/vnd.oasis.opendocument.text
 
+[oga]
+Types[]=audio/ogg
+
 [ogv]
 Types[]=video/ogg
 


### PR DESCRIPTION
Added the following top mime.ini

[oga]
Types[]=audio/ogg
