### PR TITLE
Implemented #19667: separate embed image classes from generic embed obje...

### DIFF
--- a/kernel/classes/datatypes/ezxmltext/ezxmlinputparser.php
+++ b/kernel/classes/datatypes/ezxmltext/ezxmlinputparser.php
@@ -647,7 +647,7 @@ class eZXMLInputParser
                 if( $embedObject instanceof eZContentObject )
                 {
                     $embedClassIdentifier = $embedObject->attribute( 'class_identifier' );
-                    $contentType = eZOEXMLInput::embedTagContentType( $embedClassIdentifier, $embedClassID );
+                    $contentType = self::embedTagContentType( $embedClassIdentifier, $embedClassID );
                     if ( $contentIni->hasVariable( 'embed_' . $embedClassIdentifier, 'AvailableClasses' ) )
                         $classListData = $contentIni->variable( 'embed_' . $embedClassIdentifier, 'AvailableClasses' );
                     else if ( $contentIni->hasVariable( 'embed-type_' . $contentType, 'AvailableClasses' ) )
@@ -713,6 +713,29 @@ class eZXMLInputParser
                 }
             }
         }
+    }
+
+    /*
+     * Get content type by class identifier (Copied from eZOE)
+     */
+    public static function embedTagContentType( $classIdentifier  )
+    {
+        $contentIni = eZINI::instance('content.ini');
+
+        foreach ( $contentIni->variable( 'RelationGroupSettings', 'Groups' ) as $group )
+        {
+            $settingName = ucfirst( $group ) . 'ClassList';
+            if ( $contentIni->hasVariable( 'RelationGroupSettings', $settingName ) )
+            {
+                if ( in_array( $classIdentifier, $contentIni->variable( 'RelationGroupSettings', $settingName ) ) )
+                    return $group;
+            }
+            else
+                eZDebug::writeDebug( "Missing content.ini[RelationGroupSettings]$settingName setting.",
+                                     __METHOD__ );
+        }
+
+        return $contentIni->variable( 'RelationGroupSettings', 'DefaultGroup' );
     }
 
     function washText( $textContent )


### PR DESCRIPTION
...cts's classes

Nowadays it is not possible to define customized css classes that can be selected only in embed image popup window. The class needs to be listed in the generic embed object AvailableClasses array in order to have it saved.
With this change, the previous behavior is maintained (if one sets am invalid class with editor disabled the class is still considered valid, and saved) but classes defined exclusively in embed-type_images are also considered valid.
