### PR TITLE
eZSelectionType::toString() doesn't work when no options set

### DIFF
--- a/kernel/classes/datatypes/ezselection/ezselectiontype.php
+++ b/kernel/classes/datatypes/ezselection/ezselectiontype.php
@@ -312,6 +312,7 @@ class eZSelectionType extends eZDataType
 
         if ( count( $selected ) )
         {
+            $returnData = array();
             $optionArray = $classContent['options'];
             foreach ( $selected as $id )
             {


### PR DESCRIPTION
It is possible in some cases that `$returnData` is not set, so that `eZStringUtils::implodeStr( $returnData, '|' );` throws an error. Besides, it's always a good idea to declare an array before adding values to it :)

This pull request addresses the following issue in the issue tracker: http://issues.ez.no/IssueView.php?Id=13689
