### PR TITLE
#19697: Less expensive MySQL query when fetching meta data

### DIFF
--- a/kernel/clustering/dfsmysqli.php
+++ b/kernel/clustering/dfsmysqli.php
@@ -27,7 +27,7 @@ class ezpDfsMySQLiClusterGateway extends ezpClusterGateway
     public function fetchFileMetadata( $filepath )
     {
         $filePathHash = md5( $filepath );
-        $sql = "SELECT * FROM ezdfsfile WHERE name_hash='$filePathHash'" ;
+        $sql = "SELECT `datatype`, `size`, `mtime` FROM ezdfsfile WHERE name_hash='{$filePathHash}'" ;
         if ( !$res = mysqli_query( $this->db, $sql ) )
             throw new RuntimeException( "Failed to fetch file metadata for '$filepath' " .
                 "(error #". mysqli_errno( $this->db ).": " . mysqli_error( $this->db ) );

--- a/kernel/clustering/gateway.php
+++ b/kernel/clustering/gateway.php
@@ -172,8 +172,9 @@ abstract class ezpClusterGateway
         // Output HTTP headers.
         $filesize = $metaData['size'];
         $mtime = $metaData['mtime'];
+        $datatype = $metaData['datatype'];
 
-        header( "Content-Type: $metaData[datatype]" );
+        header( "Content-Type: {$datatype}" );
         header( "Connection: close" );
         header( 'Served-by: ' . $_SERVER["SERVER_NAME"] );
 


### PR DESCRIPTION
When fetching meta data for a file, more columns are fetched than necessary. Only the columns `datatype`, `size` and `mtime` are needed, but all are fetched.

http://issues.ez.no/IssueView.php?Id=19697
