### PR TITLE
Fixed EZP-197: Warning: session already started when logging in

### DIFF
--- a/lib/ezsession/classes/ezpsessionhandler.php
+++ b/lib/ezsession/classes/ezpsessionhandler.php
@@ -185,16 +185,15 @@ abstract class ezpSessionHandler
     }
 
     /**
-     * Checks if session start have to be delegated (default is false)
-     * This is useful if an external system (like Symfony stack in eZ Publish 5) handles the session as a whole.
-     * It will basically avoids session_start() calls from eZSession.
+     * Starts the session.
+     * Override this method if you need to delegate session start to an external system (e.g. Symfony stack in eZ Publish 5)
      *
      * @since 5.0
      * @return bool
      */
-    public function delegateSessionStart()
+    public function sessionStart()
     {
-        return false;
+        return session_start();
     }
 }
 ?>

--- a/lib/ezsession/classes/ezpsessionhandlersymfony.php
+++ b/lib/ezsession/classes/ezpsessionhandlersymfony.php
@@ -121,7 +121,12 @@ class ezpSessionHandlerSymfony extends ezpSessionHandler
         $this->storage = $storage;
     }
 
-    public function delegateSessionStart()
+    /**
+     * Let Symfony start the session
+     *
+     * @return bool
+     */
+    public function sessionStart()
     {
         return true;
     }

--- a/lib/ezsession/classes/ezsession.php
+++ b/lib/ezsession/classes/ezsession.php
@@ -434,15 +434,16 @@ class eZSession
     /**
      * See {@link eZSession::start()}
      *
+     * @see ezpSessionHandler::sessionStart()
      * @since 4.4
      * @return true
      */
     static protected function forceStart()
     {
-        $delegateSessionStart = self::$handlerInstance instanceof ezpSessionHandler ? self::$handlerInstance->delegateSessionStart() : false;
-        if ( session_id() === '' && $delegateSessionStart === false )
-            session_start();
+        if ( self::$handlerInstance instanceof ezpSessionHandler )
+            return self::$hasStarted = self::$handlerInstance->sessionStart();
 
+        session_start();
         return self::$hasStarted = true;
     }
 


### PR DESCRIPTION
The following notice appears when working through the Symfony stack and trying to log in the admin interface with no session cookie yet:

```
Notice: A session had already been started - ignoring session_start()
```

This patch workarounds it by delegating session start to the Symfony stack.
