### PR TITLE
Implemented #19831: eZClusterFileHandler::cleanupEmptyDirectories() is called too often

### DIFF
--- a/cronjobs/emptydirectories_cleanup.php
+++ b/cronjobs/emptydirectories_cleanup.php
@@ -1,0 +1,88 @@
+<?php
+//
+// Created on: <28-May-2007 17:44:41 ar>
+//
+// ## BEGIN COPYRIGHT, LICENSE AND WARRANTY NOTICE ##
+// SOFTWARE NAME: eZ Publish
+// SOFTWARE RELEASE: 4.5.0
+// COPYRIGHT NOTICE: Copyright (C) 1999-2011 eZ Systems AS
+// SOFTWARE LICENSE: eZ Proprietary Use License v1.0
+// NOTICE: >
+//   This source file is part of the eZ Publish (tm) CMS and is
+//   licensed under the terms and conditions of the eZ Proprietary
+//   Use License v1.0 (eZPUL).
+// 
+//   A copy of the eZPUL was included with the software. If the
+//   license is missing, request a copy of the license via email
+//   at eZPUL-v1.0@ez.no or via postal mail at
+//     Attn: Licensing Dept. eZ Systems AS, Klostergata 30, N-3732 Skien, Norway
+// 
+//   IMPORTANT: THE SOFTWARE IS LICENSED, NOT SOLD. ADDITIONALLY, THE
+//   SOFTWARE IS LICENSED "AS IS," WITHOUT ANY WARRANTIES WHATSOEVER.
+//   READ THE eZPUL BEFORE USING, INSTALLING OR MODIFYING THE SOFTWARE.
+// ## END COPYRIGHT, LICENSE AND WARRANTY NOTICE ##
+//
+
+/*! Cronjob to remove empty directories in result of having file.ini [CleanupEmptyDirectories] DeferToCronjob = enabled
+*/
+
+if ( !$isQuiet )
+    $cli->output( "Starting processing pending empty directories cleanups" );
+
+$db = eZDB::instance();
+
+$offset = 0;
+$limit = 20;
+
+do
+{
+    $deleteParams = array();
+
+    $rows = $db->arrayQuery( "SELECT DISTINCT param FROM ezpending_actions WHERE action = 'cleanupEmptyDirectories'",
+                                array( 'limit' => $limit,
+                                       'offset' => $offset ) );
+    if ( !$rows || ( empty( $rows ) ) )
+        break;
+
+    foreach ( $rows as $row )
+    {
+        $dir = $row['param'];
+
+        $dirElements = explode( '/', $dir );
+        if ( count( $dirElements ) == 0 )
+            continue;
+        $currentDir = $dirElements[0];
+        if ( !file_exists( $currentDir ) and $currentDir != "" )
+            continue;
+
+        for ( $i = count( $dirElements ); $i > 0; --$i )
+        {
+            $dirpath = implode( '/', array_slice( $dirElements, 0, $i ) );
+            if ( file_exists( $dirpath ) and
+                 is_dir( $dirpath ) )
+            {
+                $rmdirStatus = @rmdir( $dirpath );
+                if ( !$rmdirStatus )
+                    break;
+            }
+        }
+
+        $deleteParams[] = $dir;
+    }
+
+    if ( !empty( $deleteParams ) )
+    {
+        $db->begin();
+        $db->query( "DELETE FROM ezpending_actions WHERE action='cleanupEmptyDirectories' AND param IN ( '" . implode( "','", $deleteParams ) . "' )" );
+        $db->commit();
+    }
+    else
+    {
+        $offset += $limit;
+    }
+} while ( true );
+
+if ( !$isQuiet )
+    $cli->output( "Done" );
+
+?>

--- a/lib/ezfile/classes/ezdir.php
+++ b/lib/ezfile/classes/ezdir.php
@@ -95,6 +95,12 @@ class eZDir
     static function cleanupEmptyDirectories( $dir )
     {
         $dir = self::cleanPath( $dir, self::SEPARATOR_UNIX );
+        if ( eZINI::instance( 'file.ini' )->variable( 'CleanupEmptyDirectories', 'DeferToCronjob' ) == 'enabled' )
+        {
+           eZDebug::writeDebug( "Removal of '$dir' deferred to cronjob", 'eZDir::cleanupEmptyDirectories' ); 
+           eZDB::instance()->query( "INSERT INTO ezpending_actions( action, param ) VALUES ( 'cleanupEmptyDirectories', '$dir' )" );
+           return true;
+        }
         $dirElements = explode( '/', $dir );
         if ( count( $dirElements ) == 0 )
             return true;

--- a/settings/cronjob.ini
+++ b/settings/cronjob.ini
@@ -22,6 +22,7 @@ Scripts[]=internal_drafts_cleanup.php
 #Scripts[]=unlock.php
 #Scripts[]=staticcache_cleanup.php
 #Scripts[]=updateviewcount.php
+#Scripts[]=emptydirectories_cleanup.php
 #Extension directory for cronjobs.
 ExtensionDirectories[]
 

--- a/settings/file.ini
+++ b/settings/file.ini
@@ -123,3 +123,9 @@ ClusterEvents=disabled
 # Class to use as cluster events listener
 # This class must implement eZClusterEventListener interface
 Listener=
+
+[CleanupEmptyDirectories]
+* Enables/Disables postponing the removal of empty directories 
+* from the default hook point (everytime a file is deleted)
+* to the moment when emptydirectories_cleanup cronjob is executed
+DeferToCronjob=disabled


### PR DESCRIPTION
There are two commits within this pull request.

The first one is a generic improvement. If we're attempting to remove a subtree, why would we be interested in creating it's root, in case it does not exist?

The second one implements the improvement itself. 
If the new file.ini setting ([CleanupEmptyDirectories] DeferToCronjob  is set to enabled, eZDir::cleanupEmptyDirectories will append the dir to the list of pending actions.
The cronjob that will process the directories removal is not active by default
