### PR TITLE
Fixed EZP-19834: Workflow error when a class is defined in ezmultiplexer event

### DIFF
--- a/kernel/content/ezcontentoperationcollection.php
+++ b/kernel/content/ezcontentoperationcollection.php
@@ -589,6 +589,10 @@ class eZContentOperationCollection
     static public function copyTranslations( $objectID, $versionNum )
     {
         $object = eZContentObject::fetch( $objectID );
+        if ( !$object )
+        {
+            return array( 'status' => eZModuleOperationInfo::STATUS_CANCELLED );
+        }
         $publishedVersionNum = $object->attribute( 'current_version' );
         if ( !$publishedVersionNum )
         {


### PR DESCRIPTION
I am unsure if all other operations should not patched, but in all my tests, verifying on copyTranslations alone seem to fixed the problem
