### PR TITLE
Fixed issue EZP-19851 - The footer div is inside of columns div in the webshop

### DIFF
--- a/design/admin/templates/shop/archivelist.tpl
+++ b/design/admin/templates/shop/archivelist.tpl
@@ -119,6 +119,6 @@
 
 {* DESIGN: Control bar END *}</div></div>
 </div>
-
+</div>
 </form>
 {/let}

--- a/design/admin/templates/shop/orderlist.tpl
+++ b/design/admin/templates/shop/orderlist.tpl
@@ -148,6 +148,6 @@
 
 {* DESIGN: Control bar END *}</div></div>
 </div>
-
+</div>
 </form>
 {/let}


### PR DESCRIPTION
When creating the new design for admin2 interface apparently there were missing two </div> in the shop section.
