### PR TITLE
EZP-19852: eZPersistentObject::attribute() - usage of undefined variable $functions

### DIFF
--- a/kernel/classes/ezpersistentobject.php
+++ b/kernel/classes/ezpersistentobject.php
@@ -1300,7 +1300,7 @@ class eZPersistentObject
 
         if ( isset( $def["functions"][$attr] ) )
         {
-            return $this->$functions[$attr]();
+            return $this->$def["functions"][$attr]();
         }
 
         eZDebug::writeError( "Attribute '$attr' does not exist", $def['class_name'] . '::attribute' );


### PR DESCRIPTION
[This commit](https://github.com/ezsystems/ezpublish/commit/89df0ee91a5de4e0134632dbe6dd286fd128d20e) removes the variable $functions in line 1278 which is still used in line 1303

Line 1303 should be changed to

```
return $this->$def["functions"][$attr]();
```

... which this pull request does :).
