### PR TITLE
Fix EZP-19650: move to trash and trashpurge.php can hit the memory limit

### DIFF
--- a/kernel/classes/ezcontentobject.php
+++ b/kernel/classes/ezcontentobject.php
@@ -1614,14 +1614,22 @@ class eZContentObject extends eZPersistentObject
 
         $db->begin();
 
-        $contentobjectAttributes = $this->allContentObjectAttributes( $delID );
-
-        foreach ( $contentobjectAttributes as $contentobjectAttribute )
+        $attrOffset = 0;
+        $attrLimit = 20;
+        while (
+            $contentobjectAttributes = $this->allContentObjectAttributes(
+                $delID, true, array( 'limit' => $attrLimit, 'offset' => $attrOffset )
+            )
+        )
         {
-            $dataType = $contentobjectAttribute->dataType();
-            if ( !$dataType )
-                continue;
-            $dataType->deleteStoredObjectAttribute( $contentobjectAttribute );
+            foreach ( $contentobjectAttributes as $contentobjectAttribute )
+            {
+                $dataType = $contentobjectAttribute->dataType();
+                if ( !$dataType )
+                    continue;
+                $dataType->deleteStoredObjectAttribute( $contentobjectAttribute );
+            }
+            $attrOffset += $attrLimit;
         }
 
         eZInformationCollection::removeContentObject( $delID );
@@ -1871,16 +1879,22 @@ class eZContentObject extends eZPersistentObject
         }
     }
 
-    /*
-     Fetch all attributes of all versions belongs to a contentObject.
-    */
-    function allContentObjectAttributes( $contentObjectID, $asObject = true )
+    /**
+     * Fetches all attributes from any versions of the content object
+     *
+     * @param int $contentObjectID
+     * @param bool $asObject
+     * @param array|null $limit the limit array passed to
+     *        eZPersistentObject::fetchObjectList
+     * @return eZContentObjectAttribute[]|array|null
+     */
+    function allContentObjectAttributes( $contentObjectID, $asObject = true, $limit = null )
     {
         return eZPersistentObject::fetchObjectList( eZContentObjectAttribute::definition(),
                                                     null,
                                                     array("contentobject_id" => $contentObjectID ),
                                                     null,
-                                                    null,
+                                                    $limit,
                                                     $asObject );
     }
 

--- a/kernel/classes/ezcontentobjecttrashnode.php
+++ b/kernel/classes/ezcontentobjecttrashnode.php
@@ -147,13 +147,23 @@ class eZContentObjectTrashNode extends eZContentObjectTreeNode
         $db->begin();
 
         $contentObject = $this->attribute( 'object' );
-        $contentobjectAttributes = $contentObject->allContentObjectAttributes( $contentObject->attribute( 'id' ) );
-        foreach ( $contentobjectAttributes as $contentobjectAttribute )
+        $offset = 0;
+        $limit = 20;
+        while (
+            $contentobjectAttributes = $contentObject->allContentObjectAttributes(
+                $contentObject->attribute( 'id' ), true,
+                array( 'limit' => $limit, 'offset' => $offset )
+            )
+        )
         {
-            $dataType = $contentobjectAttribute->dataType();
-            if ( !$dataType )
-                continue;
-            $dataType->trashStoredObjectAttribute( $contentobjectAttribute );
+            foreach ( $contentobjectAttributes as $contentobjectAttribute )
+            {
+                $dataType = $contentobjectAttribute->dataType();
+                if ( !$dataType )
+                    continue;
+                $dataType->trashStoredObjectAttribute( $contentobjectAttribute );
+            }
+            $offset += $limit;
         }
 
         $db->commit();


### PR DESCRIPTION
Bug: https://jira.ez.no/browse/EZP-19650
_DO NOT MERGE YET, WAITING FOR FEEDBACK FROM THE CUSTOMER_
# Description

While purging the trash (or putting a content object in the trash), `eZContentObject::allContentObjectAttributes` is used to load all content object attributes from all versions of the content object that is being removed. If this content object has a lots of attributes and/or attributes with a lots of data (big eztext, ezxmltext, ...) and/or versions, this might required too much memory.

This patch changes the way the content attributes are loaded to not load all of them in one go.
# Test

Manual tests
