### PR TITLE
EZP-21513 : Remove PathPrefix if applicable in ezpLanguageSwitcher

### DIFF
--- a/kernel/private/classes/ezplanguageswitcher.php
+++ b/kernel/private/classes/ezplanguageswitcher.php
@@ -154,6 +154,23 @@ class ezpLanguageSwitcher implements ezpLanguageSwitcherCapable
             $siteLanguageList = $saIni->variable( 'RegionalSettings', 'SiteLanguageList' );
 
             $urlAlias = $destinationElement[0]->getPath( $this->destinationLocale, $siteLanguageList );
+
+            //Remove PathPrefix if applicable
+            if ( $saIni->hasVariable( 'SiteAccessSettings', 'PathPrefix' ) )
+            {
+                $pathPrefix = $saIni->variable( 'SiteAccessSettings', 'PathPrefix' );
+                if( $pathPrefix )
+                {
+                    $pathIdenStr = substr( $pathPrefix, strlen( $pathPrefix ) -1 ) == '/'
+                                    ? $urlAlias . '/'
+                                    : $urlAlias;
+                    if ( strncasecmp( $pathIdenStr, $pathPrefix, strlen( $pathPrefix ) ) == 0 )
+                    {
+                        $urlAlias = eZURLAliasML::cleanURL( substr( $urlAlias, strlen( $pathPrefix ) ) );
+                    }
+                }
+            }
+
             $urlAlias .= $this->userParamString;
         }
 


### PR DESCRIPTION
Obviously `PathPrefix` should not change between 2 translations but as language switcher basically works as a SiteAccess switcher, it may be used to generate link URLs accross siteaccesses with different path prefixes.
Added code was adapted from `eZContentObjectTreeNode::urlAlias()`
