### PR TITLE
Fixed EZP-19904 Admin interface redirection to raw treemenu JSON output

### DIFF
--- a/kernel/content/module.php
+++ b/kernel/content/module.php
@@ -472,6 +472,7 @@ $ViewList['translation'] = array(
 
 $ViewList['treemenu'] = array(
     'functions' => array( 'read' ),
+    'ui_context' => 'ajax',
     'script' => 'treemenu.php',
     'default_navigation_part' => 'ezmynavigationpart',
     'params' => array( 'NodeID', 'Modified', 'Expiry', 'Perm' ) );

--- a/kernel/private/classes/ezpkernelweb.php
+++ b/kernel/private/classes/ezpkernelweb.php
@@ -364,6 +364,8 @@ class ezpKernelWeb implements ezpKernelHandler
             $this->redirect();
         }
 
+        $uiContextName = $this->module->uiContextName();
+
         // Store the last URI for access history for login redirection
         // Only if user has session and only if there was no error or no redirects happen
         if ( eZSession::hasStarted() && $this->module->exitStatus() == eZModule::STATUS_OK )
@@ -389,13 +391,13 @@ class ezpKernelWeb implements ezpKernelHandler
 
             // Update last accessed view page
             if ( $currentURI != $lastAccessedViewURI &&
-                 !in_array( $this->module->uiContextName(), array( 'edit', 'administration', 'browse', 'authentication' ) ) )
+                 !in_array( $uiContextName, array( 'edit', 'administration', 'browse', 'authentication' ) ) )
             {
                 $http->setSessionVariable( "LastAccessesURI", $currentURI );
             }
 
             // Update last accessed non-view page
-            if ( $currentURI != $lastAccessedURI )
+            if ( $currentURI != $lastAccessedURI && $uiContextName != 'ajax' )
             {
                 $http->setSessionVariable( "LastAccessedModifyingURI", $currentURI );
             }
@@ -411,7 +413,7 @@ class ezpKernelWeb implements ezpKernelHandler
 
         if ( !isset( $moduleResult['ui_context'] ) )
         {
-            $moduleResult['ui_context'] = $this->module->uiContextName();
+            $moduleResult['ui_context'] = $uiContextName;
         }
         $moduleResult['ui_component'] = $this->module->uiComponentName();
         $moduleResult['is_mobile_device'] = $this->mobileDeviceDetect->isMobileDevice();


### PR DESCRIPTION
Without going through `index_treemenu.php` via rewrite rule, new treemenu handling with `ezpKernelWeb` and `ezpKernelTreeMenu` removed raw exit of `content/treemenu` module which used to prevent its URIs to be stored as `LastAccessedModifyingURI`.

This PR fixes the issue by introducing a new _ajax_ UI Context which prevents this behavior.
