### PR TITLE
array_unique() on 2-dimensional array produces PHP notices and/or alters the array in unwanted ways

### DIFF
--- a/kernel/content/history.php
+++ b/kernel/content/history.php
@@ -333,7 +333,7 @@ if( $section )
     $res->setKeys( array( array( 'section_identifier', $section->attribute( 'identifier' ) ) ) );
 }
 
-$versionArray =( isset( $versionArray ) && is_array( $versionArray ) ) ? array_map( 'unserialize', array_unique( array_map( 'serialize', $versionArray ) ) ) : array();
+$versionArray =( isset( $versionArray ) && is_array( $versionArray ) ) ? array_unique( $versionArray, SORT_REGULAR ) : array();
 $LastAccessesVersionURI = $http->hasSessionVariable( 'LastAccessesVersionURI' ) ? $http->sessionVariable( 'LastAccessesVersionURI' ) : null;
 $explodedURI = $LastAccessesVersionURI ? explode ( '/', $LastAccessesVersionURI ) : null;
 if ( $LastAccessesVersionURI and is_array( $versionArray ) and !in_array( $explodedURI[3], $versionArray ) )


### PR DESCRIPTION
When accessing /content/history/<node_id> with PHP Notices display enabled, an error `Array to string conversion` is shown for each displayed version.

This is because of the usage of `array_unique()` which is not intended to be used on multi-dimensional array (see http://php.net/array_unique in the "Notes" section).

This fix uses the approach proposed at http://stackoverflow.com/a/946300/284325 to enable the wanted behaviour for the versionArray

The public issue in JIRA: https://jira.ez.no/browse/EZP-19938
