### PR TITLE
Fixed EZP-19959 Cache not working correctly with eZ Demo on eZ Publish 5

### DIFF
--- a/doc/bc/5.0/changes-5.0.txt
+++ b/doc/bc/5.0/changes-5.0.txt
@@ -37,6 +37,11 @@ Change of behavior
 
   The variable has been deprecated since 3.4.1.
 
+- View cache clear on publish can now update "modified" timestamp for respective content object (including elements matched with smart view cache)
+
+  To use this feature, put viewcache.ini/[ViewCacheSettings].UpdateModifiedDateOnClearing to "enabled".
+  Note that this setting is automatically enabled when going through the Symfony stack.
+
 Removed features
 ----------------
 

--- a/settings/viewcache.ini
+++ b/settings/viewcache.ini
@@ -46,6 +46,12 @@ SmartCacheClear=disabled
 # or disabled to not have any limit at all (default value)
 KeywordNodesCacheClearLimit=disabled
 
+# Having this setting to enabled will force the update of the "modified" field in ezcontentobject table
+# each time its view cache is cleared.
+# Allows easier HTTP cache management, especially when relying on Last-Modified header.
+# This setting is enabled by default when going through the Symfony stack.
+UpdateModifiedDateOnClearing=disabled
+
 # The smart viewcache handler will look for a group named after the
 # class identifier of the object is currently clearing caches for.
 # If the group is found it will use the information in the group


### PR DESCRIPTION
This patch enforces update of `ezcontentobject.modified` when clearing view cache from a content object, ensuring that each related content is properly considered as _outdated_ when using HTTP Cache, with `Last-Modified` header.

This behavior is disabled by default, but will automatically set to `enabled` when going through the Symfony stack.
