### PR TITLE
Changed cache purge function to use a depth-first search instead of a breadth-first search

### DIFF
--- a/kernel/classes/clusterfilehandlers/ezfsfilehandler.php
+++ b/kernel/classes/clusterfilehandlers/ezfsfilehandler.php
@@ -789,7 +789,7 @@ class eZFSFileHandler
                 $globResult = glob( $file . "/*" );
                 if ( is_array( $globResult ) )
                 {
-                    $list = array_merge( $list, $globResult );
+                    $list = array_merge( $globResult, $list );
                 }
             }
 


### PR DESCRIPTION
Very small change to the cache purge function to use a depth-first search instead of a breadth-first search when scanning the file system for cache files to delete.

This will make the code use much less memory and run faster if there are a large number of files. Before it tried to store all files found in an array, that caused php to crash with a memory allocation error and the cache clearing job to fail leading to an even larger number of old cache files over time.

Now it appends all new files found to the beginning instead of the end of the array, that way the new files in each directory will be handled first and the array will not grow exponentially.

See:
http://en.wikipedia.org/wiki/Depth-first_search
http://en.wikipedia.org/wiki/Breadth-first_search
