### PR TITLE
Fix EZP-19929: embedding images in ezoe generates PHP warning

### DIFF
--- a/extension/ezjscore/classes/ezjscajaxcontent.php
+++ b/extension/ezjscore/classes/ezjscajaxcontent.php
@@ -455,6 +455,22 @@ class ezjscAjaxContent
                     if ( !isset( $imageArray['original'] ) )
                         $imageArray['original'] = $content->attribute( 'original' );
 
+                    array_walk_recursive(
+                        $imageArray,
+                        function ( &$element, $key )
+                        {
+                            // json_encode/xmlEncode need UTF8 encoded strings
+                            // (exif) metadata might not be for instance
+                            // see https://jira.ez.no/browse/EZP-19929
+                            if ( !mb_check_encoding( $element, 'UTF-8' ) )
+                            {
+                                $element = mb_convert_encoding(
+                                    (string)$element, 'UTF-8'
+                                );
+                            }
+                        }
+                    );
+
                     $attrtibuteArray[ $key ]['content'] = $imageArray;
                 }
             }


### PR DESCRIPTION
Bug; https://jira.ez.no/browse/EZP-19929

If display_errors is disabled (yeah only disabled...), json_encode() throws a PHP warning if a string in the object we are transforming is not in UTF8 or contains control characters.
