### PR TITLE
Adding query string to 301 redirects

### DIFF
--- a/kernel/private/classes/ezpkernelweb.php
+++ b/kernel/private/classes/ezpkernelweb.php
@@ -605,9 +605,9 @@ class ezpKernelWeb implements ezpKernelHandler
                     foreach ( $userParameters as $name => $value )
                     {
                         $objectHasMovedURI .= '/(' . $name . ')/' . $value;
-                        $objectHasMovedURI .= eZSys::queryString();
                     }
-
+                    $objectHasMovedURI .= eZSys::queryString();
+                    
                     $objectHasMovedError = true;
                 }
             }


### PR DESCRIPTION
Our use case is following:

Publish an article with headline "My great article".
We have advertisement pointing to this article with an additional query string for tracking:
http://domain.com/My-great-artcile?cmpid=123

No we rename the headline to "My great article with video".
At this point we lose all tracking because of the redirect in ezp from:
http://domain.com/My-great-artcile?cmpid=123
to
http://domain.com/My-great-artcile-with-video

Are there any downsides to adding the query string to 301 redirects in ezp?
