### PR TITLE
Fixed EZP-19889: datatype eZSelection returns allways true in function ...

### DIFF
--- a/kernel/classes/datatypes/ezselection/ezselectiontype.php
+++ b/kernel/classes/datatypes/ezselection/ezselectiontype.php
@@ -375,7 +375,7 @@ class eZSelectionType extends eZDataType
     function hasObjectAttributeContent( $contentObjectAttribute )
     {
         $selected = $this->objectAttributeContent( $contentObjectAttribute );
-        return is_array( $selected ) && !empty( $selected ) && $selected[0] != '';
+        return isset( $selected[0] ) && $selected[0] != '';
     }
 
     function sortKey( $contentObjectAttribute )


### PR DESCRIPTION
...hasObjectAttributeContent
This patch replaces the always true behavior with a check on the content of selected[0](empty string on multiple choice eZSelect when no value has been checked)
