### PR TITLE
Replaced direct access to protected class variable with setter call

### DIFF
--- a/bin/php/eztc.php
+++ b/bin/php/eztc.php
@@ -45,7 +45,7 @@ if ( $options['index-file'] )
 }
 if ( $options['access-path'] )
 {
-    $sys->AccessPath = array( $options['access-path'] );
+    $sys->setAccessPath( array( $options['access-path'] ) );
 }
 if ( $options['force'] )
 {


### PR DESCRIPTION
In `bin/php/eztc.php`

```
if ( $options['access-path'] )
{
    $sys->AccessPath = array( $options['access-path'] );
}
```

is not possible (anymore) because `AccessPath` is a protected class variable.

`$sys->setAccessPath` should be used instead.

JIRA: https://jira.ez.no/browse/EZP-20072
