### PR TITLE
Fix for view cache clear on publish with many related siteaccesses.

### DIFF
--- a/kernel/classes/clusterfilehandlers/ezfsfilehandler.php
+++ b/kernel/classes/clusterfilehandlers/ezfsfilehandler.php
@@ -627,15 +627,18 @@ class eZFSFileHandler
     function fileDeleteByDirList( $dirList, $commonPath, $commonSuffix )
     {
         $dirs = implode( ',', $dirList );
-        $wildcard = $commonPath .'/{' . $dirs . '}/' . $commonSuffix . '*';
 
         eZDebugSetting::writeDebug( 'kernel-clustering', "fs::fileDeleteByDirList( '$dirs', '$commonPath', '$commonSuffix' )", __METHOD__ );
 
         eZDebug::accumulatorStart( 'dbfile', false, 'dbfile' );
-        $unlinkArray = eZSys::globBrace( $wildcard );
-        if ( $unlinkArray !== false and ( count( $unlinkArray ) > 0 ) )
+        foreach ( $dirList as $dir )
         {
-            array_map( 'unlink', $unlinkArray );
+            $wildcard = $commonPath .'/' . $dir . '/' . $commonSuffix . '*';
+            $unlinkArray = eZSys::globBrace( $wildcard );
+            if ( $unlinkArray !== false and ( count( $unlinkArray ) > 0 ) )
+            {
+                array_map( 'unlink', $unlinkArray );
+            }
         }
         eZDebug::accumulatorStop( 'dbfile' );
     }


### PR DESCRIPTION
If an eZ Publish site has too many related siteaccesses, publishing a content object does not clear the object's view cache for any siteaccess, including the siteaccess doing the publishing. This patch fixes the problem.

I ran into this problem on a site I'm working on, that has over 800 related siteaccesses (the site.ini [SiteAccessSettings] RelatedSiteAccessList[] setting). Tracking it down, I found this message in my warning.log:

glob(): Pattern exceeds the maximum allowed length of 4096 characters in /path/to/ezpublish/lib/ezutils/classes/ezsys.php on line 1086

and found out it is caused by eZFSFileHandler::fileDeleteByDirList() creating a single glob for all the directories given to it, which in this case is one directory for each related siteaccess.

This was first found on 4.1.1, which is where this fix has been tested, but it appears to still be an issue in master, hence this pull request.

(Note that there's a relatively simple workaround that I'm currently employing: I created a new cluster file handler class that extends eZFSFileHandler and just overrides that particular method.)
