### PR TITLE
Fix EZP-20022: clusterize.php generates an error in error.log

### DIFF
--- a/kernel/sql/common/cleandata.sql
+++ b/kernel/sql/common/cleandata.sql
@@ -6027,7 +6027,7 @@ INSERT INTO ezcontentobject_attribute (
   54,
   0,
   0,
-  '<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<ezimage serial_number=\"1\" is_valid=\"\" filename=\"ez_publish.\" suffix=\"\" basename=\"ez_publish\" dirpath=\"var/storage/images/setup/ez_publish/172-1-eng-GB\" url=\"var/storage/images/setup/ez_publish/172-1-eng-GB/ez_publish.\" original_filename=\"\" mime_type=\"\" width=\"\" height=\"\" alternative_text=\"\" alias_key=\"1293033771\" timestamp=\"1082016632\"><original attribute_id=\"172\" attribute_version=\"2\" attribute_language=\"eng-GB\"/></ezimage>\n',
+  '<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<ezimage serial_number=\"1\" is_valid=\"\" filename=\"\" suffix=\"\" basename=\"\" dirpath=\"\" url=\"\" original_filename=\"\" mime_type=\"\" width=\"\" height=\"\" alternative_text=\"\" alias_key=\"1293033771\" timestamp=\"1082016632\"><original attribute_id=\"172\" attribute_version=\"2\" attribute_language=\"eng-GB\"/></ezimage>\n',
   'ezimage',
   172,
   'eng-GB',
@@ -7649,16 +7649,6 @@ INSERT INTO ezcontentobject_version (
   1,
   0,
   6,
-  1
-);
-
-INSERT INTO ezimagefile (
-  contentobject_attribute_id,
-  filepath,
-  id
-) VALUES (
-  172,
-  'var/storage/images/setup/ez_publish/172-1-eng-GB/ez_publish.',
   1
 );
 

--- a/share/db_data.dba
+++ b/share/db_data.dba
@@ -3542,7 +3542,7 @@ keywords=cms, publish, e-commerce, content management, development framework',
         3 => '0',
         4 => '0',
         5 => '<?xml version="1.0" encoding="utf-8"?>
-<ezimage serial_number="1" is_valid="" filename="ez_publish." suffix="" basename="ez_publish" dirpath="var/storage/images/setup/ez_publish/172-1-eng-GB" url="var/storage/images/setup/ez_publish/172-1-eng-GB/ez_publish." original_filename="" mime_type="" width="" height="" alternative_text="" alias_key="1293033771" timestamp="1082016632"><original attribute_id="172" attribute_version="2" attribute_language="eng-GB"/></ezimage>
+<ezimage serial_number="1" is_valid="" filename="" suffix="" basename="" dirpath="" url="" original_filename="" mime_type="" width="" height="" alternative_text="" alias_key="1293033771" timestamp="1082016632"><original attribute_id="172" attribute_version="2" attribute_language="eng-GB"/></ezimage>
 ',
         6 => 'ezimage',
         7 => '172',
@@ -4518,24 +4518,6 @@ keywords=cms, publish, e-commerce, content management, development framework',
         8 => '0',
         9 => '6',
         10 => '1',
-      ),
-    ),
-  ),
-  'ezimagefile' => 
-  array (
-    'fields' => 
-    array (
-      0 => 'contentobject_attribute_id',
-      1 => 'filepath',
-      2 => 'id',
-    ),
-    'rows' => 
-    array (
-      0 => 
-      array (
-        0 => '172',
-        1 => 'var/storage/images/setup/ez_publish/172-1-eng-GB/ez_publish.',
-        2 => '1',
       ),
     ),
   ),


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-20022
# Description

clusterize.php reports one error when trying to clusterize a fresh install. This error comes from the clean data that contains a reference to a not existing image.
# Tests

Manual install of plain and ezflow package after the change.
