### PR TITLE
Fix EZP-14921: 'small' size hardcoded in ezoe code

### DIFF
--- a/extension/ezoe/FAQ
+++ b/extension/ezoe/FAQ
@@ -149,9 +149,5 @@ be re done to work with one of these ezxml extensions.
 After upgrading / updating or changing image settings you cannot select images anymore
 when you browse / search for images.
 
-This is most likely caused by missing image alias size 'small', witch is used by ezoe to
-preview images, as well as some templates in eZ Publish / ezwebin uses it as well.
-A Future version of eZ Publish will maybe add a setting to control this, but until then
-you'll need to add the 'small' image alias.
-More info: http://issues.ez.no/IssueView.php?Id=14921&activeItem=18
- 
+This is most likely because the image alias set in
+ezoe.ini/[EditorSettings]/BrowseImageAlias ('small' by default) does not exist.

--- a/extension/ezoe/classes/ezoeserverfunctions.php
+++ b/extension/ezoe/classes/ezoeserverfunctions.php
@@ -516,7 +516,17 @@ class ezoeServerFunctions extends ezjscServerFunctions
         // generate json response from node list
         if ( $nodeArray )
         {
-            $list = ezjscAjaxContent::nodeEncode( $nodeArray, array( 'fetchChildrenCount' => true, 'loadImages' => true ), 'raw' );
+            $list = ezjscAjaxContent::nodeEncode(
+                $nodeArray,
+                array(
+                    'fetchChildrenCount' => true,
+                    'loadImages' => true,
+                    'imagePreGenerateSizes' => array(
+                        eZINI::instance( 'ezoe.ini' )->variable( 'EditorSettings', 'BrowseImageAlias' )
+                    )
+                ),
+                'raw'
+            );
         }
         else
         {

--- a/extension/ezoe/design/standard/javascript/ezoe/popup_utils.js
+++ b/extension/ezoe/design/standard/javascript/ezoe/popup_utils.js
@@ -59,7 +59,9 @@ var eZOEPopupUtils = {
         // custom save function pr custom attribute
         customAttributeSaveHandler: [],
         // Title text to set on tilte tag and h2#tag-edit-title tag in tag edit / create dialogs
-        tagEditTitleText: ''
+        tagEditTitleText: '',
+        // the default image alias to use while browsing
+        browseImageAlias: 'small'
     },
 
     /**
@@ -823,12 +825,12 @@ var eZOEPopupUtils = {
                    tr.appendChild( td );
                    
                    td = document.createElement("td");
-                   var imageIndex = eZOEPopupUtils.indexOfImage( n, 'small' );
+                   var imageIndex = eZOEPopupUtils.indexOfImage( n, eZOEPopupUtils.settings.browseImageAlias );
                    if ( imageIndex !== -1 )
                    {
                        tag = document.createElement("span");
                        tag.className = 'image_preview';
-                       tag.innerHTML += ' <a href="#">' + ed.getLang('preview.preview_desc')  + '<img src="' + ed.settings.ez_root_url + n.data_map[ n.image_attributes[imageIndex] ].content['small'].url + '" /></a>';
+                       tag.innerHTML += ' <a href="#">' + ed.getLang('preview.preview_desc')  + '<img src="' + ed.settings.ez_root_url + n.data_map[ n.image_attributes[imageIndex] ].content[eZOEPopupUtils.settings.browseImageAlias].url + '" /></a>';
                        td.appendChild( tag );
                        hasImage = true;
                    }
@@ -900,7 +902,7 @@ var eZOEPopupUtils = {
 
     indexOfImage: function( jsonNode, alias )
     {
-        if ( !alias ) alias = 'small';
+        if ( !alias ) alias = eZOEPopupUtils.settings.browseImageAlias;
         var index = -1;
         jQuery.each( jsonNode.image_attributes, function( i, attr )
         {

--- a/extension/ezoe/design/standard/templates/ezoe/upload_images.tpl
+++ b/extension/ezoe/design/standard/templates/ezoe/upload_images.tpl
@@ -12,6 +12,7 @@ var contentType = '{$content_type}', classFilter = [];
     classFilter.push('{$class_filter}');
 {/foreach}
 
+eZOEPopupUtils.settings.browseImageAlias = "{ezini( 'EditorSettings', 'BrowseImageAlias', 'ezoe.ini' )|wash( 'javascript' )}";
 {literal}
 
 tinyMCEPopup.onInit.add( function(){

--- a/extension/ezoe/settings/ezoe.ini
+++ b/extension/ezoe/settings/ezoe.ini
@@ -55,6 +55,8 @@ ValidateEmbedObjects=disabled
 # Makes it possible to get default TinyMCE behavior when clicking tag name by disabling
 TagPathOpenDialog=enabled
 
+# Image alias to use for the preview while browsing
+BrowseImageAlias=small
 
 # Map custom attribute names to style values so they are previewed in the editor.
 # Supported styles are limited to the following types:


### PR DESCRIPTION
Issue: https://jira.ez.no/browse/EZP-14921
## Description

The image alias used in ezoe while browsing is hardcoded at several places. As a result, it's not possible to customize ezoe's behaviour on this. This patch adds a new setting in ezoe.ini that allows to define which alias to use in this context.
## Tests

Manual tests
