### PR TITLE
Fixed EZP-20002: Bug in eZJSCore's ezjscajaxcontent.php - Attribute 'creator_id' does not exist

### DIFF
--- a/extension/ezjscore/classes/ezjscajaxcontent.php
+++ b/extension/ezjscore/classes/ezjscajaxcontent.php
@@ -262,7 +262,7 @@ class ezjscAjaxContent
             }
             else
             {
-                $ret['creator'] = array( 'id'   => $contentObject->attribute( 'creator_id' ),
+                $ret['creator'] = array( 'id'   => $contentObject->attribute( 'current' )->attribute('creator_id'),
                                          'name' => null );// user has been deleted
             }
         }


### PR DESCRIPTION
Suppresses the error in log. The $contentObject had no creator_id in this context.
