### PR TITLE
Fix EZP-19886: Wrong sort order in object relations list with ezautosave

### DIFF
--- a/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
+++ b/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
@@ -255,28 +255,23 @@ class eZObjectRelationListType extends eZDataType
             }
         }
 
-        $reorderedRelationList    = array();
-        // Contains existing priorities
-        $existsPriorities = array();
-
-        for ( $i = 0, $c = count( $content['relation_list'] ); $i < $c; ++$i )
+        // Indexing priorities by object id
+        // and make sure each priority is unique
+        $existingPriorities = array();
+        $prioritiesByContentObjectId = array();
+        foreach ( $selectedObjectIDArray as $k => $id )
         {
-            $priorities[$contentObjectAttributeID][$i] = (int) $priorities[$contentObjectAttributeID][$i];
-            $existsPriorities[$i] = $priorities[$contentObjectAttributeID][$i];
-
-            // Change objects' priorities providing their uniqueness.
-            for ( $j = 0; $j < $c; ++$j )
+            $priority = (int)$priorities[$contentObjectAttributeID][$k];
+            while ( isset( $existingPriorities[$priority] ) )
             {
-                if ( $i == $j ) continue;
-                if ( $priorities[$contentObjectAttributeID][$i] == $priorities[$contentObjectAttributeID][$j] )
-                {
-                    $index = $priorities[$contentObjectAttributeID][$i];
-                    while ( in_array( $index, $existsPriorities ) )
-                        ++$index;
-                    $priorities[$contentObjectAttributeID][$j] = $index;
-                }
+                $priority++;
             }
-            $relationItem = $content['relation_list'][$i];
+            $prioritiesByContentObjectId[$id] = $priority;
+            $existingPriorities[$priority] = $priority;
+        }
+
+        foreach ( $content['relation_list'] as &$relationItem )
+        {
             if ( $relationItem['is_modified'] )
             {
                 $subObjectID = $relationItem['contentobject_id'];
@@ -295,21 +290,23 @@ class eZObjectRelationListType extends eZDataType
                     $content['temp'][$subObjectID]['object'] = $object;
                 }
             }
-            if ( isset( $priorities[$contentObjectAttributeID][$i] ) )
-                $relationItem['priority'] = $priorities[$contentObjectAttributeID][$i];
-            $reorderedRelationList[$relationItem['priority']] = $relationItem;
+            $relationItem['priority'] = $prioritiesByContentObjectId[$relationItem['contentobject_id']];
         }
-        ksort( $reorderedRelationList );
-        unset( $content['relation_list'] );
-        $content['relation_list'] = array();
-        reset( $reorderedRelationList );
-        $i = 0;
-        while ( list( $key, $relationItem ) = each( $reorderedRelationList ) )
+
+        usort(
+            $content['relation_list'],
+            function ( $a, $b )
+            {
+                return $a['priority'] - $b['priority'];
+            }
+        );
+        $p = 1;
+        foreach ( $content['relation_list'] as &$relationItem )
         {
-            $content['relation_list'][] = $relationItem;
-            $content['relation_list'][$i]['priority'] = $i + 1;
-            ++$i;
+            $relationItem['priority'] = $p;
+            $p++;
         }
+
         $contentObjectAttribute->setContent( $content );
         return true;
     }


### PR DESCRIPTION
Issue: https://jira.ez.no/browse/EZP-19886
# Description

When a draft is autosaved, an object relation list might not be saved in the correct order. This is due to the fact the ezobjectrelationlist datatype expects the order fields to be send in the same order as the objects are currently stored in the DB which is not the case with ezautosave. This patch changes the way the order is handled by indexing internally the order by content object id. This also allows to simplify the way object relation lists are handled.

Notes:
- The pull request #375 fixes the same issue but it's more complicated
- the anonymous function will be replaced by a create_function() call in older eZ Publish versions to work with PHP 5.2.
# Tests

manual tests
