### PR TITLE
Fixed EZP-20090 - Cluster: images with name containing quotes disappear ...

### DIFF
--- a/index_cluster.php
+++ b/index_cluster.php
@@ -87,7 +87,8 @@ EOF;
 require_once $clusterGatewayFile;
 $gateway = ezpClusterGateway::getGateway();
 
-$filename = ltrim( $_SERVER['REQUEST_URI'], '/' );
+// Use rawurldecode() because if the file contains " characters, they are url encoded.
+$filename = rawurldecode( ltrim( $_SERVER['REQUEST_URI'], '/' ) );
 if ( ( $queryPos = strpos( $filename, '?' ) ) !== false )
     $filename = substr( $filename, 0, $queryPos );
 

--- a/kernel/classes/datatypes/ezimage/ezimagefile.php
+++ b/kernel/classes/datatypes/ezimage/ezimagefile.php
@@ -104,7 +104,17 @@ class eZImageFile extends eZPersistentObject
 
         $contentObjectID = (int)( $rows[0]['contentobject_id'] );
         $contentClassAttributeID = (int)( $rows[0]['contentclassattribute_id'] );
-        $filepath = $db->escapeString( $filepath );
+        // Transform ", &, < and > to entities since they are being transformed in entities by DOM
+        // See eZImageAliasHandler::initialize()
+        // Ref https://jira.ez.no/browse/EZP-20090
+        $filepath = $db->escapeString(
+            htmlspecialchars(
+                $filepath,
+                // Forcing default flags to be able to specify encoding. See http://php.net/htmlspecialchars
+                version_compare( PHP_VERSION, '5.4.0', '>=' ) ? ENT_COMPAT | ENT_HTML401 : ENT_COMPAT,
+                'UTF-8'
+            )
+        );
         // Escape _ in like to avoid it to act as a wildcard !
         $filepath = addcslashes( $filepath, "_" );
         $query = "SELECT id, version


### PR DESCRIPTION
...after discarding a draft of a published object
## Context
- Cluster (DFS or DB)

**Note:** You must activate `url_alias_iri` to be able to reproduce.

``` ini
# settings/override/site.ini.append.php
[URLTranslator]
TransformationGroup=urlalias_iri
```
## Testing

Manual tests
