### PR TITLE
Remove `@method fetch` PHPDoc

### DIFF
--- a/kernel/classes/ezpersistentobject.php
+++ b/kernel/classes/ezpersistentobject.php
@@ -28,7 +28,6 @@
  * </code>
  * 
  * @package eZKernel
- * @method fetch
  */
 class eZPersistentObject
 {


### PR DESCRIPTION
This line (introduced by myself ;) ) has the effect that IDEs expect the method to be non-static. Actually, the `fetch` method _is_ static. So this PHPDoc should be removed.
