### PR TITLE
Use jQuery no-conflict selections in Online Editor

### DIFF
--- a/extension/ezoe/design/standard/javascript/themes/ez/editor_template.js
+++ b/extension/ezoe/design/standard/javascript/themes/ez/editor_template.js
@@ -353,19 +353,19 @@
             // eZ: custom cleanup code to only affect the content of the textarea,
             // not the visible text in the editor
             ed.onSaveContent.add(function(ed, o) {
-                var $f = $('<div>' + o.content + '</div>', null);
+                var $f = jQuery('<div>' + o.content + '</div>', null);
 
                 // Replace the content of the embed tags that are just there for oe preview
                 // by 'ezembed'. This is to avoid that the ez xml parsers in some cases
                 // duplicates the embed tag and to avoid that TinyMCE strips too much the HTML code
                 // see http://issues.ez.no/18264
                 $f.find('div.ezoeItemNonEditable').each(function(i, node) {
-                    $(node).html('ezembed');
+                    jQuery(node).html('ezembed');
                 });
 
                 $f.find('span').each(function(i, node) {
                     if ( node && node.className.indexOf('ezoeItemNonEditable') !== -1 )
-                        $(node).html('ezembed');
+                        jQuery(node).html('ezembed');
                     else if ( node && node.className.indexOf('ezoeItemTempSpan') !== -1 && node.innerHTML.indexOf('&nbsp;') === 0 )
                         node.firstChild.replaceData( 0, 1, ' ' );
                 });


### PR DESCRIPTION
If the front-end siteaccess is using jQuery noConflict() and you are using the Website Toolbar for front-end editing, the JavaScript for the Online Editor will break.
