### PR TITLE
Fixed EZP-19671 - DFS cluster: expiryXYZtmp.php with 0 byte size

### DIFF
--- a/kernel/classes/ezclusterfilefailure.php
+++ b/kernel/classes/ezclusterfilefailure.php
@@ -18,9 +18,14 @@
  */
 class eZClusterFileFailure
 {
+    const FILE_EXPIRED = 1,
+          FILE_CONTENT_GENERATE = 2,
+          FILE_RETRIEVAL_FAILED = 3;
+
     // Error codes:
     // 1 - file expired
     // 2 - file contents must be manually generated
+    // 3 - Failed to retrieve file from DFS
     function eZClusterFileFailure( $errno, $message = false )
     {
         $this->Errno = $errno;

--- a/kernel/private/classes/clusterfilehandlers/dfsbackends/dfs.php
+++ b/kernel/private/classes/clusterfilehandlers/dfsbackends/dfs.php
@@ -95,19 +95,41 @@ class eZDFSFileHandlerDFSBackend
      * if specified
      *
      * @param string $srcFilePath Local file path to copy from
-     * @param string $dstFilePath
+     * @param bool|string $dstFilePath
      *        Optional path to copy to. If not specified, $srcFilePath is used
+     * @return bool
      */
     public function copyToDFS( $srcFilePath, $dstFilePath = false )
     {
         $this->accumulatorStart();
 
+        $srcFileContents = file_get_contents( $srcFilePath );
+        if ( $srcFileContents === false )
+        {
+            $this->accumulatorStop();
+            eZDebug::writeError( "Error getting contents of file FS://'$srcFilePath'.", __METHOD__ );
+            return false;
+        }
+
         if ( $dstFilePath === false )
         {
             $dstFilePath = $srcFilePath;
         }
+
         $dstFilePath = $this->makeDFSPath( $dstFilePath );
-        $ret = $this->createFile( $dstFilePath, file_get_contents( $srcFilePath ), true );
+        $ret = $this->createFile( $dstFilePath, $srcFileContents, true );
+        if ( $ret )
+        {
+            // Double checking if the file has been correctly created
+            $srcFileSize = strlen( $srcFileContents );
+            clearstatcache( true, $dstFilePath );
+            $dstFileSize = filesize( $dstFilePath );
+            if ( $dstFileSize != $srcFileSize )
+            {
+                eZDebug::writeError( "Size ($dstFileSize) of written data for file FS://$dstFilePath does not match expected size of original DFS file ($srcFileSize)", __METHOD__ );
+                return false;
+            }
+        }
 
         $this->accumulatorStop();
 
@@ -282,12 +304,27 @@ class eZDFSFileHandlerDFSBackend
 
     protected function createFile( $filePath, $contents, $atomic = true )
     {
+        // $contents can result from a failed file_get_contents(). In this case
+        if ( !$contents )
+            return false;
+
         $createResult = eZFile::create( basename( $filePath ), dirname( $filePath ), $contents, $atomic );
 
         if ( $createResult )
             $this->fixPermissions( $filePath );
 
         return $createResult;
+    }
+
+    /**
+     * Returns size of a file in the DFS backend, from a relative path.
+     *
+     * @param string $filePath The relative file path we want to get size of
+     * @return int
+     */
+    public function getDfsFileSize( $filePath )
+    {
+        return filesize( $this->makeDFSPath( $filePath ) );
     }
 
     /**

--- a/kernel/private/classes/clusterfilehandlers/dfsbackends/mysqli.php
+++ b/kernel/private/classes/clusterfilehandlers/dfsbackends/mysqli.php
@@ -32,9 +32,22 @@ CREATE TABLE ezdfsfile (
 
 class eZDFSFileHandlerMySQLiBackend implements eZClusterEventNotifier
 {
+    /**
+     * Wait for n microseconds until retry if copy fails, to avoid DFS overload.
+     */
+    const TIME_UNTIL_RETRY = 100;
+
+    /**
+     * Max number of times a dfs file is tried to be copied.
+     *
+     * @var int
+     */
+    protected $maxCopyTries;
+
     public function __construct()
     {
         $this->eventHandler = ezpEvent::getInstance();
+        $this->maxCopyTries = (int)eZINI::instance( 'file.ini' )->variable( 'eZDFSClusteringSettings', 'MaxCopyRetries' );
     }
 
     /**
@@ -587,7 +600,7 @@ class eZDFSFileHandlerMySQLiBackend implements eZClusterEventNotifier
      * Saving $filePath locally with its original name, or $uniqueName if given
      *
      * @param string $filePath
-     * @param string $uniqueName Alternative name to save the file to
+     * @param bool|string $uniqueName Alternative name to save the file to
      * @return string|bool the file physical path, or false if fetch failed
      */
     public function _fetch( $filePath, $uniqueName = false )
@@ -600,41 +613,54 @@ class eZDFSFileHandlerMySQLiBackend implements eZClusterEventNotifier
             return false;
         }
 
-        // create temporary file
-        if ( strrpos( $filePath, '.' ) > 0 )
-            $tmpFilePath = substr_replace( $filePath, getmypid().'tmp', strrpos( $filePath, '.' ), 0  );
-        else
-            $tmpFilePath = $filePath . '.' . getmypid().'tmp';
-        $this->__mkdir_p( dirname( $tmpFilePath ) );
+        $dfsFileSize = $this->dfsbackend->getDfsFileSize( $filePath );
+        $loopCount = 0;
 
-        // copy DFS file to temporary FS path
-        // @todo Throw an exception
-        if ( !$this->dfsbackend->copyFromDFS( $filePath, $tmpFilePath ) )
+        do
         {
-            eZDebug::writeError("Failed copying DFS://$filePath to FS://$tmpFilePath ");
-            return false;
-        }
+            // create temporary file
+            $tmpid = getmypid() . '-' . mt_rand() .'tmp';
+            if ( strrpos( $filePath, '.' ) > 0 )
+                $tmpFilePath = substr_replace( $filePath, $tmpid, strrpos( $filePath, '.' ), 0  );
+            else
+                $tmpFilePath = $filePath . '.' . $tmpid;
+            $this->__mkdir_p( dirname( $tmpFilePath ) );
+            eZDebugSetting::writeDebug( 'kernel-clustering', "copying DFS://$filePath to FS://$tmpFilePath on try: $loopCount " );
 
-        // Make sure all data is written correctly
-        clearstatcache();
-        $tmpSize = filesize( $tmpFilePath );
-        // @todo Throw an exception
-        if ( $tmpSize != $metaData['size'] )
-        {
-            eZDebug::writeError( "Size ($tmpSize) of written data for file '$tmpFilePath' does not match expected size " . $metaData['size'], __METHOD__ );
-            return false;
-        }
+            // copy DFS file to temporary FS path
+            // @todo Throw an exception
+            if ( !$this->dfsbackend->copyFromDFS( $filePath, $tmpFilePath ) )
+            {
+                eZDebug::writeError("Failed copying DFS://$filePath to FS://$tmpFilePath ");
+                usleep( self::TIME_UNTIL_RETRY );
+                ++$loopCount;
+                continue;
+            }
 
-        if ( $uniqueName !== true )
-        {
-            eZFile::rename( $tmpFilePath, $filePath, false, eZFile::CLEAN_ON_FAILURE | eZFile::APPEND_DEBUG_ON_FAILURE );
-        }
-        else
-        {
-            $filePath = $tmpFilePath;
-        }
+            if ( $uniqueName !== true )
+            {
+                eZFile::rename( $tmpFilePath, $filePath, false, eZFile::CLEAN_ON_FAILURE | eZFile::APPEND_DEBUG_ON_FAILURE );
+            }
+            $filePath = ($uniqueName) ? $tmpFilePath : $filePath ;
 
-        return $filePath;
+            // If all data has been written correctly, return the filepath.
+            // Otherwise let the loop continue
+            clearstatcache( true, $filePath );
+            $localFileSize = filesize( $filePath );
+            if ( $dfsFileSize == $localFileSize )
+            {
+                return $filePath;
+            }
+
+            usleep( self::TIME_UNTIL_RETRY );
+            ++$loopCount;
+        }
+        while ( $dfsFileSize > $localFileSize && $loopCount < $this->maxCopyTries );
+
+        // Copy from DFS has failed :-(
+        eZDebug::writeError( "Size ($localFileSize) of written data for file '$tmpFilePath' does not match expected size {$metaData['size']}", __METHOD__ );
+        unlink( $tmpFilePath );
+        return false;
     }
 
     public function _fetchContents( $filePath, $fname = false )
@@ -834,7 +860,7 @@ class eZDFSFileHandlerMySQLiBackend implements eZClusterEventNotifier
     function _storeInner( $filePath, $datatype, $scope, $fname )
     {
         // Insert file metadata.
-        clearstatcache();
+        clearstatcache( true, $filePath );
         $fileMTime = filemtime( $filePath );
         $contentLength = filesize( $filePath );
         $filePathHash = md5( $filePath );

--- a/kernel/private/classes/clusterfilehandlers/ezdfsfilehandler.php
+++ b/kernel/private/classes/clusterfilehandlers/ezdfsfilehandler.php
@@ -586,7 +586,10 @@ class eZDFSFileHandler implements eZClusterFileHandlerInterface, ezpDatabaseBase
                         eZDebugSetting::writeDebug( 'kernel-clustering', "Callback from DB file {$this->filePath}", __METHOD__ );
                         if ( self::LOCAL_CACHE )
                         {
-                            $this->fetch();
+                            if ( $this->fetch() === false )
+                            {
+                                return new eZClusterFileFailure( eZClusterFileFailure::FILE_RETRIEVAL_FAILED, "Failed retrieving file $this->filePath from DFS." );
+                            }
 
                             // Figure out which mtime to use for new file, must be larger than
                             // mtime in DB at least.

--- a/lib/ezutils/classes/ezexpiryhandler.php
+++ b/lib/ezutils/classes/ezexpiryhandler.php
@@ -35,6 +35,13 @@ class eZExpiryHandler
     function restore()
     {
         $Timestamps = $this->CacheFile->processFile( array( $this, 'fetchData' ) );
+        if ( $Timestamps === false )
+        {
+            $errMsg = 'Fatal error - could not restore expiry.php file.';
+            eZDebug::writeError( $errMsg, __METHOD__ );
+            trigger_error( $errMsg, E_USER_ERROR );
+        }
+
         $this->Timestamps = $Timestamps;
         $this->IsModified = false;
     }

--- a/settings/file.ini
+++ b/settings/file.ini
@@ -103,6 +103,9 @@ DBUser=root
 DBPassword=
 DBConnectRetries=3
 DBExecuteRetries=20
+# Max number of times a dfs file is tried to be copied.
+# Increase this value if you find files like expiryXYZtmp.php with 0 byte size
+MaxCopyRetries=5
 
 [PassThroughSettings]
 # The default value for mime types not specified using ContentDisposition


### PR DESCRIPTION
# Description

OK, this is a tough one :neckbeard: .
As the issue says, it only happens under high load pressure and there is no easy way to reproduce it in real conditions. The only possible thing is to fake the issue is to do some xdebug magic :trollface: .
The origin of this issue is mysterious, but is most likely due to NFS performance issues under high load.

The idea is that, if a file like `expiry.php` is not correctly copied from the DFS to the local FS for any reason, the copy process is retried until we manage to copy the file correctly.
# Testing

Manual tests painfully made...
# Credits

This patch is greatly inspired by the one made by @pbras and @joaoiniacio (see #404)
