### PR TITLE
PHPDoc for lastSerialId()

### DIFF
--- a/lib/ezdb/classes/ezdbinterface.php
+++ b/lib/ezdb/classes/ezdbinterface.php
@@ -1255,6 +1255,7 @@ class eZDBInterface
      *
      * @param string|bool $table
      * @param string|bool $column
+     * @return int|bool The most recent value for the sequence
      */
     function lastSerialID( $table = false, $column = false )
     {

--- a/lib/ezdb/classes/ezmysqlidb.php
+++ b/lib/ezdb/classes/ezmysqlidb.php
@@ -814,6 +814,13 @@ class eZMySQLiDB extends eZDBInterface
         return mysqli_query( $this->DBWriteConnection, "ROLLBACK" );
     }
 
+    /**
+     * Returns the last serial ID generated with an auto increment field.
+     *
+     * @param string|bool $table
+     * @param string|bool $column
+     * @return int|bool The most recent value for the sequence
+     */
     function lastSerialID( $table = false, $column = false )
     {
         if ( $this->IsConnected )
@@ -821,8 +828,8 @@ class eZMySQLiDB extends eZDBInterface
             $id = mysqli_insert_id( $this->DBWriteConnection );
             return $id;
         }
-        else
-            return false;
+
+        return false;
     }
 
     function escapeString( $str )

--- a/lib/ezdb/classes/eznulldb.php
+++ b/lib/ezdb/classes/eznulldb.php
@@ -85,9 +85,13 @@ class eZNullDB extends eZDBInterface
     {
     }
 
-    /*!
-      Returns false.
-    */
+    /**
+     * Returns false
+     *
+     * @param string|bool $table
+     * @param string|bool $column
+     * @return bool
+     */
     function lastSerialID( $table = false, $column = false )
     {
         return false;

--- a/lib/ezdb/classes/ezpostgresqldb.php
+++ b/lib/ezdb/classes/ezpostgresqldb.php
@@ -561,12 +561,14 @@ class eZPostgreSQLDB extends eZDBInterface
      * In this case that means the current value of the sequence assigned
      * <var>$table</var>
      *
-     * @param string $table
-     * @param string $column
-     * @return int The most recent value for the sequence
+     * @param string|bool $table
+     * @param string|bool $column
+     * @return int|bool The most recent value for the sequence
      */
     function lastSerialID( $table = false, $column = 'id' )
     {
+        $id = false;
+
         if ( $this->isConnected() )
         {
             $sql = "SELECT currval( '" . $table . "_s')";
@@ -582,6 +584,7 @@ class eZPostgreSQLDB extends eZDBInterface
                 $id = (int)$array[0];
             }
         }
+
         return $id;
     }
 


### PR DESCRIPTION
… so that IDEs play a little bit nicer, and very small code changes:
- No `else` required in `eZMySQLiDB`
- In some cases `$id` would not be defined in `eZPostgreSQLDB`
