### PR TITLE
Fixed EZP-19857: First login for a new user has the content tabs disabled

### DIFF
--- a/design/admin/override/templates/window_controls_user.tpl
+++ b/design/admin/override/templates/window_controls_user.tpl
@@ -3,7 +3,12 @@
 <div class="menu-block">
 <ul>
     {* Content preview. *}
-    {if ezpreference( 'admin_navigation_content' )}
+    {* Display content tabs by default, unless admin_navigation_content preference is set *}
+    {def $admin_navigation_content = 1
+         $admin_navigation_content_pref = ezpreference( 'admin_navigation_content' )}
+    {* Preference is always a string. Result of ezpreference() can be false if demanded preference doesn't exist for current user. *}
+    {if $admin_navigation_content_pref|is_string}{set $admin_navigation_content = $admin_navigation_content_pref}{/if}
+    {if $admin_navigation_content}
     <li class="enabled">
     <div class="button-bc"><div class="button-tl"><div class="button-tr"><div class="button-br">
         <a href={'/user/preferences/set/admin_navigation_content/0'|ezurl} title="{'Hide preview of content.'|i18n( 'design/admin/node/view/full' )}">{'Preview'|i18n( 'design/admin/node/view/full' )}</a>
@@ -16,6 +21,8 @@
     </div></div></div></div>
     </li>
     {/if}
+    {undef $admin_navigation_content
+           $admin_navigation_content_pref}
 
     {* Details. *}
     {if ezpreference( 'admin_navigation_details' )}

--- a/design/admin/templates/window_controls.tpl
+++ b/design/admin/templates/window_controls.tpl
@@ -1,6 +1,7 @@
 {* Window controls *}
 {def $node_url_alias      = $node.url_alias
-     $tabs_disabled       = ezpreference( 'admin_navigation_content' )|not
+     $tabs_disabled       = false()
+     $admin_navigation_content_pref = ezpreference( 'admin_navigation_content' )
      $default_tab         = 'view'
      $node_tab_index      = first_set( $view_parameters.tab, $default_tab )
      $read_open_tab_by_cookie = true()
@@ -16,6 +17,8 @@
      $valid_tabs = array( $default_tab, 'details', 'translations', 'locations', 'relations', 'states' )
      $navigation_part_name = fetch( 'section', 'object', hash( 'section_id', $node.object.section_id ) ).navigation_part_identifier
 }
+
+{if $admin_navigation_content_pref|is_string}{set $tabs_disabled = $admin_navigation_content_pref|not}{/if}
 
 {if eq( $navigation_part_name, 'ezusernavigationpart' )}
 {def $assigned_policies   = fetch( 'user', 'user_role', hash( 'user_id', $node.contentobject_id ) )


### PR DESCRIPTION
Replacement of #500.

This fix changes the default behaviour of content tabs display in admin. They are now displayed by default, unless a preference is set.
