### PR TITLE
Allows for $UserParameters in content/search

### DIFF
--- a/kernel/content/search.php
+++ b/kernel/content/search.php
@@ -123,7 +123,17 @@ if ( $searchSectionID != -1 )
     $res->setKeys( $keyArray );
 }
 
+if ( isset( $Params['UserParameters'] ) )
+{
+    $UserParameters = $Params['UserParameters'];
+}
+else
+{
+    $UserParameters = array();
+}
+
 $viewParameters = array( 'offset' => $Offset );
+$viewParameters = array_merge( $viewParameters, $UserParameters );
 
 $searchData = false;
 $tpl->setVariable( "search_data", $searchData );


### PR DESCRIPTION
Custom `$view_parameters` are not currently allowed Search, this update allows for custom view parameters by checking for `$Params['UserParameters']` and merging the array with the existing `$view_parameters` array.
