### PR TITLE
Fix EZP-20251: Unable to run functional tests if legacy stack is involved

### DIFF
--- a/kernel/private/classes/ezpkernelweb.php
+++ b/kernel/private/classes/ezpkernelweb.php
@@ -311,7 +311,7 @@ class ezpKernelWeb implements ezpKernelHandler
                 'Pragma' => 'no-cache',
                 'X-Powered-By' => eZPublishSDK::EDITION,
                 'Content-Type' => 'text/html; charset=' . $this->httpCharset,
-                'Served-by' => $_SERVER["SERVER_NAME"],
+                'Served-by' => isset( $_SERVER["SERVER_NAME"] ) ? $_SERVER['SERVER_NAME'] : null,
                 'Content-language' => $this->languageCode
               ) as $key => $value
         )

--- a/lib/ezutils/classes/ezsys.php
+++ b/lib/ezutils/classes/ezsys.php
@@ -1103,7 +1103,7 @@ class eZSys
         $instance       = self::instance();
         $server         = $instance->Params['_SERVER'];
         $phpSelf        = $server['PHP_SELF'];
-        $requestUri     = $server['REQUEST_URI'];
+        $requestUri     = isset( $server['REQUEST_URI'] ) ? $server['REQUEST_URI'] : '';
         $scriptFileName = $server['SCRIPT_FILENAME'];
         $siteDir        = rtrim( str_replace( $index, '', $scriptFileName ), '\/' ) . '/';
         $wwwDir         = '';


### PR DESCRIPTION
Just adds checks before using something in $_SERVER otherwise functional tests always fail
