### PR TITLE
Fixed EZP-20302: eZContentObjectTreeNode::getLimitationList() cannot be called by SSO Handler methods without infinite recursion

### DIFF
--- a/kernel/classes/ezcontentobjecttreenode.php
+++ b/kernel/classes/ezcontentobjecttreenode.php
@@ -1791,7 +1791,7 @@ class eZContentObjectTreeNode extends eZPersistentObject
     static function getLimitationList( &$limitation )
     {
         // do not check currentUser if limitation is disabled
-        if ( empty( $limitation ) and is_array( $limitation ) )
+        if ( empty( $limitation ) && is_array( $limitation ) )
         {
             return $limitation;
         }


### PR DESCRIPTION
eZContentObjectTreeNode::getLimitationList() does not need to know the user permissions when policy limitations are disabled, so don't check it.  This enables using methods like eZContentObjectTreeNode::subTreeByNodeID() to be used in SSO handler functions without an infinite loop.
