### PR TITLE
Removed unspecific error message in kernel/error/view.php

### DIFF
--- a/kernel/error/view.php
+++ b/kernel/error/view.php
@@ -83,8 +83,6 @@ $GLOBALS["eZRequestError"] = true;
         }
     }
 
-    eZDebug::writeError( "Error ocurred using URI: " . $_SERVER['REQUEST_URI'] , "error/view.php" );
-
     if ( $errorHandlerType == 'redirect' )
     {
         $errorRedirectURL = $errorINI->variable( 'ErrorSettings', 'DefaultRedirectURL' );


### PR DESCRIPTION
At the moment, every error is logged to error.log with the unspecific message "Error ocurred using URI: […]", although a more specific error message is already logged right before, e.g. "Undefined module:"

Thus, the line

``` php
eZDebug::writeError( "Error ocurred using URI: " . $_SERVER['REQUEST_URI'] , "error/view.php" );
```

should be removed from the file `kernel/error/view.php`, to avoid the flooding of the error.log file.

https://jira.ez.no/browse/EZP-20337
