### PR TITLE
Fix EZP-20375 by forcing servername to be resolved with its ip address

### DIFF
--- a/lib/ezdb/classes/ezmysqlidb.php
+++ b/lib/ezdb/classes/ezmysqlidb.php
@@ -89,6 +89,11 @@ class eZMySQLiDB extends eZDBInterface
         {
             ini_set( "mysqli.default_socket", $socketPath );
         }
+        elseif( $server === 'localhost' )
+        {
+            $server = gethostbyname($server);
+            eZDebug::writeDebug( "MySQL server hostname equals 'localhost' and socket mode is disabled : forcing tcp/ip connection on $server", "Database server connection" );
+        }
 
         if ( $this->UsePersistentConnection == true )
         {


### PR DESCRIPTION
See http://php.net/manual/en/mysqli.construct.php

```
Note:

Specifying the socket parameter will not explicitly determine the type of connection to be used when connecting to the MySQL server. How the connection is made to the MySQL database is determined by the host parameter.
```

site.ini.[DatabaseSettings].Server = localhost
site.ini.[DatabaseSettings].Socket = disabled

results in having in lib/ezdb/classes/ezmysqlidb.php

$socketPath = false
$server = localhost

=> meaning that `mysqli_connect( $server, $user, $password, null, (int)$port, $socketPath );` will try to connect through the default socket instead of using a tcp/ip connection.

This patch forces a tcp/ip connection by passing an ip address to `mysqli_connect()` instead of `localhost` which means more than a simple hostname in that case.
