### PR TITLE
EZP-20426 - Legacy cronjobs and scripts should be launchable from Symfony CLI

### DIFF
--- a/kernel/classes/ezscript.php
+++ b/kernel/classes/ezscript.php
@@ -50,37 +50,25 @@ class eZScript
     /*!
      Constructor
     */
-    function eZScript( $settings = array() )
+    function __construct( $settings = array() )
     {
-        $settings = array_merge( array( 'debug-message' => false,
-                                        'debug-output' => false,
-                                        'debug-include' => false,
-                                        'debug-levels' => false,
-                                        'debug-accumulator' => false,
-                                        'debug-timing' => false,
-                                        'use-session' => false,
-                                        'use-extensions' => true,
-                                        'use-modules' => false,
-                                        'user' => false,
-                                        'description' => 'eZ Publish script',
-                                        'site-access' => false,
-                                        'min_version' => false,
-                                        'max_version' => false ),
-                                 $settings );
-        $this->DebugMessage = $settings['debug-message'];
-        $this->UseDebugOutput = $settings['debug-output'];
-        $this->AllowedDebugLevels = $settings['debug-levels'];
-        $this->UseDebugAccumulators = $settings['debug-accumulator'];
-        $this->UseDebugTimingPoints = $settings['debug-timing'];
-        $this->UseIncludeFiles = $settings['debug-include'];
-        $this->UseSession = $settings['use-session'];
-        $this->UseModules = $settings['use-modules'];
-        $this->UseExtensions = $settings['use-extensions'];
-        $this->User = $settings['user'];
-        $this->SiteAccess = $settings['site-access'];
-        $this->Description = $settings['description'];
-        $this->MinVersion = $settings['min_version'];
-        $this->MaxVersion = $settings['max_version'];
+        $settings += array(
+            'debug-message' => false,
+            'debug-output' => false,
+            'debug-include' => false,
+            'debug-levels' => false,
+            'debug-accumulator' => false,
+            'debug-timing' => false,
+            'use-session' => false,
+            'use-extensions' => true,
+            'use-modules' => false,
+            'user' => false,
+            'description' => 'eZ Publish script',
+            'site-access' => false,
+            'min_version' => false,
+            'max_version' => false
+        );
+        $this->updateSettings( $settings );
         $this->ExitCode = false;
         $this->IsQuiet = false;
         $this->ShowVerbose = false;
@@ -100,6 +88,59 @@ class eZScript
         $this->IterationColumnMax = 70;
         $this->IterationMax = false;
         $this->InitializationErrorMessage = 'unknown error';
+    }
+
+    /**
+     * Updates settings for current script.
+     *
+     * Valid keys for $settings are :
+     * - use-session
+     * - use-modules
+     * - use-extensions
+     * - user
+     * - site-access
+     * - description
+     * - min_version
+     * - max_version
+     * - debug-message
+     * - debug-output
+     * - debug-levels
+     * - debug-accumulator
+     * - debug-timing
+     * - debug-include
+     *
+     * @param array $settings
+     */
+    private function updateSettings( array $settings = array() )
+    {
+        if ( isset( $settings['debug-message'] ) )
+            $this->DebugMessage = $settings['debug-message'];
+        if ( isset( $settings['debug-output'] ) )
+            $this->UseDebugOutput = $settings['debug-output'];
+        if ( isset( $settings['debug-levels'] ) )
+            $this->AllowedDebugLevels = $settings['debug-levels'];
+        if ( isset( $settings['debug-accumulator'] ) )
+            $this->UseDebugAccumulators = $settings['debug-accumulator'];
+        if ( isset( $settings['debug-timing'] ) )
+            $this->UseDebugTimingPoints = $settings['debug-timing'];
+        if ( isset( $settings['debug-include'] ) )
+            $this->UseIncludeFiles = $settings['debug-include'];
+        if ( isset( $settings['use-session'] ) )
+            $this->UseSession = $settings['use-session'];
+        if ( isset( $settings['use-modules'] ) )
+            $this->UseModules = $settings['use-modules'];
+        if ( isset( $settings['use-extensions'] ) )
+            $this->UseExtensions = $settings['use-extensions'];
+        if ( isset( $settings['user'] ) )
+            $this->User = $settings['user'];
+        if ( isset( $settings['site-access'] ) )
+            $this->SiteAccess = $settings['site-access'];
+        if ( isset( $settings['description'] ) )
+            $this->Description = $settings['description'];
+        if ( isset( $settings['min_version'] ) )
+            $this->MinVersion = $settings['min_version'];
+        if ( isset( $settings['max_version'] ) )
+            $this->MaxVersion = $settings['max_version'];
     }
 
     /*!
@@ -1042,11 +1083,18 @@ class eZScript
      */
     static function instance( $settings = array() )
     {
-        if ( !isset( $GLOBALS['eZScriptInstance'] ) or
-             !( $GLOBALS['eZScriptInstance'] instanceof eZScript ) )
+        if (
+            !isset( $GLOBALS['eZScriptInstance'] )
+            || !( $GLOBALS['eZScriptInstance'] instanceof eZScript )
+        )
         {
             $GLOBALS['eZScriptInstance'] = new eZScript( $settings );
         }
+        else if ( !empty( $settings ) )
+        {
+            $GLOBALS['eZScriptInstance']->updateSettings( $settings );
+        }
+
         return $GLOBALS['eZScriptInstance'];
     }
 

--- a/lib/ezsession/classes/ezsession.php
+++ b/lib/ezsession/classes/ezsession.php
@@ -505,7 +505,10 @@ class eZSession
      */
     static public function remove()
     {
-        if ( !self::$hasStarted )
+        // CLI scripts can use sessions and in that case session is forced to start.
+        // However, Symfony does not handle sessions in CLI (which seems to be normal), so session is never started.
+        // Hence check with session_id()
+        if ( !self::$hasStarted || session_id() === '' )
         {
              return false;
         }


### PR DESCRIPTION
**Work in progress, DO NOT MERGE**

Ref https://jira.ez.no/browse/EZP-20426.
Related PR : https://github.com/ezsystems/ezpublish-kernel/pull/229
## Tasks
- [x] Refactoring of eZScript allowing to update settings while recalling the singleton
- [x] Avoid `ezpAutoloader` class to be declared twice
