### PR TITLE
Fix EZP-20316 - Long attribute description texts overflow fieldset legend width area

### DIFF
--- a/design/admin/stylesheets/content.css
+++ b/design/admin/stylesheets/content.css
@@ -257,6 +257,14 @@ fieldset.ezcca-collapsible.ezcca-collapsed legend a
     background: url("../images/2/yui_sprite.png") no-repeat 0 -350px;
 }
 
+fieldset legend  {
+  display: table-cell;
+}
+
+fieldset legend span.classattribute-description {
+  display: block;
+}
+
 /* OBJECTRELATIONLIST */
 
 .ezcca-edit-datatype-ezobjectrelationlist h4, .ezcca-edit-datatype-ezobjectrelation h4


### PR DESCRIPTION
IE7, IE8 & IE9 handle legend within fieldset in a way that breaks when field description is wide enough. 
Since admin / admin2 are defunct, restructure to remove the legend / span might not be worthy. 
This CSS hack seems to solves it.
Anyone spot major flaws in this?
