### PR TITLE
Fix EZP-20355: Insert table row in ezoe with embed elements

### DIFF
--- a/extension/ezoe/design/standard/javascript/plugins/eztable/editor_plugin.js
+++ b/extension/ezoe/design/standard/javascript/plugins/eztable/editor_plugin.js
@@ -157,7 +157,40 @@
 				var curNode;
 
 				if (node.nodeType == 3) {
-					each(dom.getParents(node.parentNode, null, cell).reverse(), function(node) {
+
+					// eZ: don't clone literal, embed and block custom tag
+					// see https://jira.ez.no/browse/EZP-20355
+
+					// checks whether the elt is contained in an element
+					// that must not be cloned when cloning a cell.
+					var cloneFilter = function (elt) {
+
+						// returns false for the elements that should be filtered out
+						// when cloning a cell.
+						var cloneCheck = function (n) {
+								if ( n.nodeName && n.nodeName.toLowerCase() === 'pre' ) {
+									// literal
+									return false;
+								} else if ( dom.hasClass(n, 'ezoeItemNonEditable') ) {
+									// embed
+									return false;
+								} else if ( dom.is(n, 'div.ezoeItemCustomTag') ) {
+									// block custom tag
+									return false;
+								}
+								return true;
+							};
+
+							while ( elt !== cell ) {
+								if ( cloneCheck(elt) === false ) {
+									return false;
+								}
+								elt = elt.parentNode;
+							}
+							return true;
+						};
+					each(dom.getParents(node.parentNode, cloneFilter, cell).reverse(), function(node) {
+						// end eZ
 						node = cloneNode(node, false);
 
 						if (!formatNode)


### PR DESCRIPTION
# Description

When inserting a new row in a table, the TinyMCE's table plugin (and thus eztable, our fork) tries to keep the formatting of the currently selected row. For instance, if a cell contains only a bold text, the corresponding cell in the new row will also get the HTML code to get its text in bold.

This feature does not play well with some of our tags used to structure content or inject higher level components like embed, the block custom tags or literal. This patch makes sure those custom elements are not cloned in a new cell even if the original cell has one of them.

(Note: the code is indented with tabs to keep consistency with the rest of the file)
# Tests

manual tests in IE[6-9], Firefox and Chrome.
