### PR TITLE
Fix EZP-20316: long attribute desc overflow in Internet Explorer

### DIFF
--- a/design/admin/stylesheets/core.css
+++ b/design/admin/stylesheets/core.css
@@ -391,6 +391,23 @@ legend
     font-size:1.1em;
 }
 
+/* Make sure long legend texts do not overflow */
+/* https://jira.ez.no/browse/EZP-20316 */
+/* IE8, IE9 */
+fieldset legend 
+{
+    white-space:normal;
+    display:table;
+}
+/* IE7/ IE6 */
+legend span.long-legend-wrap
+{
+    white-space:normal;
+    display:block;
+    width:100%;
+}
+/* end: overflow workaroud */
+
 fieldset label
 {
     color: #000000;

--- a/design/admin/templates/content/edit_attribute.tpl
+++ b/design/admin/templates/content/edit_attribute.tpl
@@ -50,10 +50,11 @@
     {else}
         {if $attribute.display_info.edit.grouped_input}
             <fieldset>
-            <legend{if $attribute.has_validation_error} class="message-error"{/if}>{first_set( $contentclass_attribute.nameList[$content_language], $contentclass_attribute.name )|wash}
+            <legend{if $attribute.has_validation_error} class="message-error"{/if}><span class="long-legend-wrap">{first_set( $contentclass_attribute.nameList[$content_language], $contentclass_attribute.name )|wash}
                 {if $attribute.is_required} <span class="required">({'required'|i18n( 'design/admin/content/edit_attribute' )})</span>{/if}
                 {if $attribute.is_information_collector} <span class="collector">({'information collector'|i18n( 'design/admin/content/edit_attribute' )})</span>{/if}
                 {if $contentclass_attribute.description} <span class="classattribute-description">{first_set( $contentclass_attribute.descriptionList[$content_language], $contentclass_attribute.description)|wash}</span>{/if}
+                </span>
             </legend>
             {attribute_edit_gui attribute_base=$attribute_base attribute=$attribute view_parameters=$view_parameters}
             <input type="hidden" name="ContentObjectAttribute_id[]" value="{$attribute.id}" />


### PR DESCRIPTION
# Description

![before](https://f.cloud.github.com/assets/305563/191435/dbcc23ea-7f36-11e2-9134-495a87de412c.png)
# Tests

Manual tests in IE 6, 7, 8, 9, Firefox and Chrome.

![after](https://f.cloud.github.com/assets/305563/191434/dbd1a586-7f36-11e2-8e84-b76c974c99d8.png)
