### PR TITLE
EZP-20455: eZUser::isLoggedIn does not correctly check user's state

### DIFF
--- a/extension/ezformtoken/event/ezxformtoken.php
+++ b/extension/ezformtoken/event/ezxformtoken.php
@@ -252,7 +252,7 @@ class ezxFormToken
         if ( !eZSession::hasStarted() )
             return false;
 
-        if ( !eZUser::currentUser()->isLoggedIn() )
+        if ( !eZUser::isCurrentUserRegistered() )
             return false;
 
         return true;

--- a/kernel/classes/datatypes/ezuser/ezuser.php
+++ b/kernel/classes/datatypes/ezuser/ezuser.php
@@ -88,7 +88,7 @@ class eZUser extends eZPersistentObject
                                                       'roles' => 'roles',
                                                       'role_id_list' => 'roleIDList',
                                                       'limited_assignment_value_list' => 'limitValueList',
-                                                      'is_logged_in' => 'isLoggedIn',
+                                                      'is_logged_in' => 'isRegistered',
                                                       'is_enabled' => 'isEnabled',
                                                       'is_locked' => 'isLocked',
                                                       'last_visit' => 'lastVisit',
@@ -1107,7 +1107,7 @@ WHERE user_id = '" . $userID . "' AND
         // - the user has not logged out,
         // - the user is not logged in,
         // - and if a automatic single sign on plugin is enabled.
-        if ( !self::$userHasLoggedOut and is_object( $currentUser ) and !$currentUser->isLoggedIn() )
+        if ( !self::$userHasLoggedOut && is_object( $currentUser ) && !$currentUser->isRegistered() )
         {
             $ssoHandlerArray = $ini->variable( 'UserSettings', 'SingleSignOnHandlerArray' );
             if ( !empty( $ssoHandlerArray ) )
@@ -2304,18 +2304,35 @@ WHERE user_id = '" . $userID . "' AND
         return eZUserAccountKey::fetchByUserID( $this->ContentObjectID );
     }
 
-    /*!
-     Returns true if it's a real user which is logged in. False if the user
-     is the default user or the fallback buildtin user.
-    */
-    function isLoggedIn()
+    /**
+     * Returns true if the user is a registered and not anonymous user.
+     *
+     * @deprecated since 5.1 Use isRegistered() / isUserLoggedIn() instead.
+     */
+    public function isLoggedIn()
     {
-        if ( $this->ContentObjectID == self::anonymousId() or
-             $this->ContentObjectID == -1 )
-        {
-            return false;
-        }
-        return true;
+        eZDebug::writeStrict( "Method " . __METHOD__ . " has been deprecated in 5.1. Use isRegistered() / isUserLoggedIn() instead.", "Deprecation" );
+        return $this->isRegistered();
+    }
+
+    /**
+     * Returns true if the user is a registered and not anonymous user.
+     *
+     * @deprecated since 5.1 Use isRegistered() / isUserLoggedIn() instead.
+     */
+    public function isRegistered()
+    {
+        return $this->ContentObjectID != self::anonymousId() && $this->ContentObjectID != -1;
+    }
+
+    /**
+     * Returns whether the current user is a registered user.
+     *
+     * @since 5.1
+     */
+    static public function isCurrentUserRegistered()
+    {
+        return self::currentUser()->isRegistered();
     }
 
     /*!

--- a/kernel/classes/ezhttpheader.php
+++ b/kernel/classes/ezhttpheader.php
@@ -39,8 +39,7 @@ class eZHTTPHeader
                  && $ini->hasVariable( 'HTTPHeaderSettings', 'OnlyForAnonymous' )
                  && $ini->variable( 'HTTPHeaderSettings', 'OnlyForAnonymous' ) === 'enabled' )
             {
-                $user = eZUser::currentUser();
-                $GLOBALS['eZHTTPHeaderCustom'] = !$user->isLoggedIn();
+                $GLOBALS['eZHTTPHeaderCustom'] = !eZUser::isCurrentUserRegistered();
             }
             else
             {

--- a/kernel/classes/ezpreferences.php
+++ b/kernel/classes/ezpreferences.php
@@ -64,8 +64,8 @@ class eZPreferences
         // We must store the database changes if:
         // a - The current user is logged in (ie. not anonymous)
         // b - We have specified a specific user (not the current).
-        //    in which case isLoggedIn() will fail.
-        if ( $storeUserID !== false or $user->isLoggedIn() )
+        //    in which case isRegistered() will fail.
+        if ( $storeUserID !== false or $user->isRegistered() )
         {
             // Only store in DB if user is logged in or we have
             // a specific user ID defined

--- a/kernel/classes/shopaccounthandlers/ezdefaultshopaccounthandler.php
+++ b/kernel/classes/shopaccounthandlers/ezdefaultshopaccounthandler.php
@@ -21,12 +21,7 @@ class eZDefaultShopAccountHandler
     */
     function verifyAccountInformation()
     {
-        // Check login
-        $user = eZUser::currentUser();
-        if ( !$user->isLoggedIn() )
-            return false;
-        else
-            return true;
+        return eZUser::isCurrentUserRegistered();
     }
 
     /*!

--- a/kernel/content/action.php
+++ b/kernel/content/action.php
@@ -1142,8 +1142,7 @@ else if ( $http->hasPostVariable( "ContentObjectID" )  )
     }
     else if ( $http->hasPostVariable( "ActionAddToWishList" ) )
     {
-        $user = eZUser::currentUser();
-        if ( !$user->isLoggedIn() )
+        if ( !eZUser::isCurrentUserRegistered() )
             return $module->handleError( eZError::KERNEL_ACCESS_DENIED, 'kernel' );
 
         $shopModule = eZModule::exists( "shop" );

--- a/kernel/content/draft.php
+++ b/kernel/content/draft.php
@@ -13,7 +13,7 @@ $Offset = $Params['Offset'];
 $viewParameters = array( 'offset' => $Offset );
 
 $user = eZUser::currentUser();
-if ( !$user->isLoggedIn() )
+if ( !$user->isRegistered() )
     return $Module->handleError( eZError::KERNEL_ACCESS_DENIED, 'kernel' );
 
 $userID = $user->id();

--- a/kernel/notification/addtonotification.php
+++ b/kernel/notification/addtonotification.php
@@ -20,7 +20,7 @@ $redirectURI = $http->postVariable( 'RedirectURI', $http->sessionVariable( 'Last
 
 $viewMode = $http->hasPostVariable( 'ViewMode' ) ? $http->postVariable( 'ViewMode' ) : 'full';
 
-if ( !$user->isLoggedIn() )
+if ( !$user->isRegistered() )
 {
     eZDebug::writeError( 'User not logged in trying to subscribe for notification, node ID: ' . $nodeID,
                          'kernel/content/action.php' );

--- a/kernel/private/classes/ezpkernelweb.php
+++ b/kernel/private/classes/ezpkernelweb.php
@@ -338,14 +338,12 @@ class ezpKernelWeb implements ezpKernelHandler
          */
         if ( $ini->variable( "SiteAccessSettings", "CheckValidity" ) !== 'true' )
         {
-            $currentUser = eZUser::currentUser();
-
             $wwwDir = eZSys::wwwDir();
             // On host based site accesses this can be empty, causing the cookie to be set for the current dir,
             // but we want it to be set for the whole eZ publish site
             $cookiePath = $wwwDir != '' ? $wwwDir : '/';
 
-            if ( $currentUser->isLoggedIn() )
+            if ( eZUser::isCurrentUserRegistered() )
             {
                 // Only set the cookie if it doesnt exist. This way we are not constantly sending the set request in the headers.
                 if ( !isset( $_COOKIE['is_logged_in'] ) || $_COOKIE['is_logged_in'] !== 'true' )

--- a/kernel/private/modules/oauth/authorize.php
+++ b/kernel/private/modules/oauth/authorize.php
@@ -63,7 +63,7 @@ if ( !$application->isEndPointValid( $pRedirectUri ) )
 $user = eZUser::currentUser();
 
 // login is like REALLY required here. But we can't use the standard policy check, as it won't redirect w/ GET parameters
-if ( !$user->isLoggedIn() )
+if ( !$user->isRegistered() )
 {
     $redirectUri = str_replace( eZSys::indexDir(), '', $_SERVER['REQUEST_URI'] );
 

--- a/kernel/private/oauth/classes/restclient.php
+++ b/kernel/private/oauth/classes/restclient.php
@@ -230,7 +230,7 @@ class ezpRestClient
         if ( $user === null )
             $user = eZUser::currentUser();
 
-        if ( !$user->isLoggedIn() )
+        if ( !$user->isRegistered() )
             throw new Exception( "Anonymous user can not authorize an application" );
 
         $authorized = ezpRestAuthorizedClient::fetchForClientUser( $this, $user );

--- a/kernel/shop/userregister.php
+++ b/kernel/shop/userregister.php
@@ -23,7 +23,7 @@ $user = eZUser::currentUser();
 $firstName = '';
 $lastName = '';
 $email = '';
-if ( $user->isLoggedIn() )
+if ( $user->isRegistered() )
 {
     $userObject = $user->attribute( 'contentobject' );
     $userMap = $userObject->dataMap();
@@ -38,7 +38,7 @@ $street1 = $street2 = $zip = $place = $state = $country = $comment = '';
 
 // Check if user has an earlier order, copy order info from that one
 $orderList = eZOrder::activeByUserID( $user->attribute( 'contentobject_id' ) );
-if ( count( $orderList ) > 0 and  $user->isLoggedIn() )
+if ( count( $orderList ) > 0 and  $user->isRegistered() )
 {
     $accountInfo = $orderList[0]->accountInformation();
     $street1 = $accountInfo['street1'];

--- a/kernel/shop/wishlist.php
+++ b/kernel/shop/wishlist.php
@@ -10,8 +10,7 @@ $http = eZHTTPTool::instance();
 $module = $Params['Module'];
 $offset = $Params['Offset'];
 
-$user = eZUser::currentUser();
-if ( !$user->isLoggedIn() )
+if ( !eZUser::isCurrentUserRegistered() )
     return $Module->handleError( eZError::KERNEL_ACCESS_DENIED, 'kernel' );
 
 if ( $http->hasPostVariable( "ActionAddToWishList" ) )

--- a/kernel/user/password.php
+++ b/kernel/user/password.php
@@ -44,7 +44,7 @@ if ( !$user )
     return $Module->handleError( eZError::KERNEL_NOT_AVAILABLE, 'kernel' );
 $currentUser = eZUser::currentUser();
 if ( $currentUser->attribute( 'contentobject_id' ) != $user->attribute( 'contentobject_id' ) or
-     !$currentUser->isLoggedIn() )
+     !$currentUser->isRegistered() )
     return $Module->handleError( eZError::KERNEL_ACCESS_DENIED, 'kernel' );
 
 if ( $http->hasPostVariable( "OKButton" ) )

--- a/tests/tests/kernel/private/ezp_api/ezpcontent_regression.php
+++ b/tests/tests/kernel/private/ezp_api/ezpcontent_regression.php
@@ -18,7 +18,7 @@ class ezpContentRegression extends ezpDatabaseTestCase
         parent::setUp();
         $currentUser = eZUser::currentUser();
         $anonymousID = eZUser::anonymousId();
-        if ( $currentUser->isLoggedIn() )
+        if ( $currentUser->isRegistered() )
         {
             self::$previousUserID = $currentUser->attribute( 'contentobject_id' );
             eZUser::setCurrentlyLoggedInUser( eZUser::fetch( $anonymousID ), $anonymousID );


### PR DESCRIPTION
Deprecate isLoggedIn() in favor of the new isRegistered() and the
existing isUserLoggedIn() methods.
