### PR TITLE
FIX EZP-20373: ezcontentobject_tree.path_identification_string is not updated upon move or rename

### DIFF
--- a/kernel/classes/ezcontentobjecttreenode.php
+++ b/kernel/classes/ezcontentobjecttreenode.php
@@ -3588,7 +3588,6 @@ class eZContentObjectTreeNode extends eZPersistentObject
         if ( $this->attribute( 'path_identification_string' ) != $pathIdentificationString )
         {
             $db = eZDB::instance();
-            $db->begin();
             
             $updQuery = "UPDATE
                               ezcontentobject_tree
@@ -3596,9 +3595,7 @@ class eZContentObjectTreeNode extends eZPersistentObject
                               path_identification_string = replace(path_identification_string, '{$this->attribute( 'path_identification_string' )}', '$pathIdentificationString')
                          WHERE
                               path_string LIKE '{$this->attribute( 'path_string' )}%'";
-            $db->begin();
             $db->query( $updQuery );
-            $db->commit();
 
             $this->setAttribute( 'path_identification_string', $pathIdentificationString );
             $this->sync();


### PR DESCRIPTION
This patch is composed of two commits
1. Addresses the issue upon move
2. Addresses the issue upon rename (save where path_identification_string is updated)

Both cases use string replace function (available in sqlite, mysql and oracle)  
