### PR TITLE
Provides debug condition when playing with mobile redirection

### DIFF
--- a/kernel/private/classes/ezpmobiledeviceregexpfilter.php
+++ b/kernel/private/classes/ezpmobiledeviceregexpfilter.php
@@ -78,14 +78,21 @@ class ezpMobileDeviceRegexpFilter implements ezpMobileDeviceDetectFilterInterfac
                         || strpos( $this->httpAccept, 'application/vnd.wap.xhtml+xml' ) > 0)
         {
             $this->isMobileDevice = true;
-            eZDebugSetting::writeDebug( 'kernel-mobile-redirection', "Mobile redirection triggered : wap", __METHOD__ );
+            eZDebugSetting::writeDebug(
+                'kernel-mobile-redirection',
+                'Mobile redirection triggered : wap',
+                __METHOD__ );
         }
         else if ( in_array( $simplifiedUserAgent,
                             $mobileUserAgentCodes ) )
         {
             $this->isMobileDevice = true;
             $mobileUserAgentCodeIndex = array_search( $simplifiedUserAgent, $mobileUserAgentCodes );
-            eZDebugSetting::writeDebug( 'kernel-mobile-redirection', "Mobile redirection triggered via MobileUserAgentCodes settings : matched code '{$mobileUserAgentCodes[$mobileUserAgentCodeIndex]}'", __METHOD__ );
+            eZDebugSetting::writeDebug(
+                'kernel-mobile-redirection',
+                'Mobile redirection triggered via MobileUserAgentCodes settings : matched code '
+                . $mobileUserAgentCodes[$mobileUserAgentCodeIndex],
+                __METHOD__ );
         }
         else
         {
@@ -95,7 +102,13 @@ class ezpMobileDeviceRegexpFilter implements ezpMobileDeviceDetectFilterInterfac
                 {
                     $this->isMobileDevice = true;
                     $this->userAgentAlias = $userAgentAlias;
-                    eZDebugSetting::writeDebug( 'kernel-mobile-redirection', "Mobile redirection triggered via MobileUserAgentRegexps settings : matched regexp '{$matches[0]}' in alias '{$userAgentAlias}'", __METHOD__ );
+                    eZDebugSetting::writeDebug(
+                        'kernel-mobile-redirection',
+                        'Mobile redirection triggered via MobileUserAgentRegexps settings : matched regexp '
+                        . $matches[0]
+                        . ' in alias '
+                        . $userAgentAlias,
+                        __METHOD__ );
                     break;
                 }
             }

--- a/kernel/private/classes/ezpmobiledeviceregexpfilter.php
+++ b/kernel/private/classes/ezpmobiledeviceregexpfilter.php
@@ -85,7 +85,7 @@ class ezpMobileDeviceRegexpFilter implements ezpMobileDeviceDetectFilterInterfac
         {
             $this->isMobileDevice = true;
             $mobileUserAgentCodeIndex = array_search( $simplifiedUserAgent, $mobileUserAgentCodes );
-            eZDebugSetting::writeDebug( 'kernel-mobile-redirection', "Mobile redirection triggered via MobileUserAgentCodes settings : {$mobileUserAgentCodes[$mobileUserAgentCodeIndex]}", __METHOD__ );
+            eZDebugSetting::writeDebug( 'kernel-mobile-redirection', "Mobile redirection triggered via MobileUserAgentCodes settings : matched code '{$mobileUserAgentCodes[$mobileUserAgentCodeIndex]}'", __METHOD__ );
         }
         else
         {
@@ -95,7 +95,7 @@ class ezpMobileDeviceRegexpFilter implements ezpMobileDeviceDetectFilterInterfac
                 {
                     $this->isMobileDevice = true;
                     $this->userAgentAlias = $userAgentAlias;
-                    eZDebugSetting::writeDebug( 'kernel-mobile-redirection', "Mobile redirection triggered via MobileUserAgentRegexps settings : {$matches[0]}", __METHOD__ );
+                    eZDebugSetting::writeDebug( 'kernel-mobile-redirection', "Mobile redirection triggered via MobileUserAgentRegexps settings : matched regexp '{$matches[0]}' in alias '{$userAgentAlias}'", __METHOD__ );
                     break;
                 }
             }

--- a/settings/debug.ini
+++ b/settings/debug.ini
@@ -57,6 +57,8 @@ kernel-clustering=disabled
 
 kernel-ezpackage-store=disabled
 
+kernel-mobile-redirection=disabled
+
 
 module-run=disabled
 


### PR DESCRIPTION
In order to adjust the conditions/rules triggering a redirection to a mobile siteaccess, we need to know which one matched the UserAgent sent by the client
