### PR TITLE
If $dataString is empty $dataString == $storageDir

### DIFF
--- a/bin/php/ezcsvimport.php
+++ b/bin/php/ezcsvimport.php
@@ -114,7 +114,7 @@ while ( $objectData = fgetcsv( $fp, $csvLineLength , ';', '"' ) )
             case 'ezbinaryfile':
             case 'ezmedia':
             {
-                $dataString = $dataString ? eZDir::path( array( $storageDir, $dataString ) ) : '';
+                $dataString = empty(trim($dataString)) ? '' : eZDir::path( array( $storageDir, $dataString ) );
                 break;
             }
             default:


### PR DESCRIPTION
Let's say that you exported all articles in a `myexport` folder and that the Article class contains an ezimage datatype.

Now you want to import all those articles thanks to this command line :

`php bin/php/ezcsvimport.php --class=article --creator=14 --storage-dir=myexport/images 2 myexport/article.csv`

If an article contains an image, there is no problem, the attribute will get, for instance, the file `myexport/images/my-flowers.jpg`. But if an article does not contain any image, it will set the attribute with `myexport/images` instead of nothing.
