### PR TITLE
Fix EZP-20570: ezcsvimport uses the storage-dir as filename if an ezimage is empty

### DIFF
--- a/bin/php/ezcsvimport.php
+++ b/bin/php/ezcsvimport.php
@@ -114,7 +114,8 @@ while ( $objectData = fgetcsv( $fp, $csvLineLength , ';', '"' ) )
             case 'ezbinaryfile':
             case 'ezmedia':
             {
-                $dataString = $dataString ? eZDir::path( array( $storageDir, $dataString ) ) : '';
+                $dataString = trim( $dataString );
+                $dataString = !empty( $dataString ) ? eZDir::path( array( $storageDir, $dataString ) ) : '';
                 break;
             }
             default:


### PR DESCRIPTION
As discussed with @crevillo
