### PR TITLE
Add the possibility to disable content cache for all items belonging to a specific section

### DIFF
--- a/kernel/content/view.php
+++ b/kernel/content/view.php
@@ -75,6 +75,19 @@ if ( $viewCacheEnabled && $ini->hasVariable( 'ContentSettings', 'ViewCacheTweaks
     }
 }
 
+if ( $viewCacheEnabled && $ini->hasVariable( 'ContentSettings', 'ViewCacheIgnoreSection' ) )
+{
+    $ignoredSectionIds = $ini->variable( 'ContentSettings', 'ViewCacheIgnoreSection' );
+    $contentObjectMetadata = eZContentObject::fetchByNodeID( $NodeID, false );
+    if ( isset( $contentObjectMetadata['section_id'] ) )
+    {
+        if ( in_array( $contentObjectMetadata['section_id'], $ignoredSectionIds ) )
+        {
+            $viewCacheEnabled = false;
+        }
+    }
+}
+
 $collectionAttributes = false;
 if ( isset( $Params['CollectionAttributes'] ) )
     $collectionAttributes = $Params['CollectionAttributes'];

--- a/settings/site.ini
+++ b/settings/site.ini
@@ -1127,6 +1127,11 @@ CachedViewModes=full;sitemap;pdf
 # ignore_siteaccess_type do not include siteaccess type in cache hash
 # Note: you can also set 'global' as <node_id> to set tweaks globally for all tweaks but 'disabled' as you have other settings for that
 ViewCacheTweaks[]
+# View cache tweak for cache strategy based on sections
+# ViewCacheIgnoreSection[]=<section_id> will disable view cache for all objects belonging to this section
+# <section_id> must be numeric
+# Commented by default to avoid useless queries
+# ViewCacheIgnoreSection[]
 # A semicolon separated list of the user preferences (possibly with the default value after the '=' sign)
 # on which the viewmode, determined by an array key, dependes.
 # Ex.: CachedViewPreferences[full]=show_more_info=0;show_right_menu


### PR DESCRIPTION
This functionality is used to disable content cache on a logged-in section of our site.
