### PR TITLE
Fixed EZP-20602 - Order appear reversed in the admin interface

### DIFF
--- a/design/admin/stylesheets/theme/yui_datatable.css
+++ b/design/admin/stylesheets/theme/yui_datatable.css
@@ -232,11 +232,11 @@ th.yui-dt-sortable .yui-dt-label {
     margin-right: 10px;
 }
 
-th.yui-dt-asc .yui-dt-liner {
+th.yui-dt-desc .yui-dt-liner {
    background:url(../../images/3/sprite.png) no-repeat right -170px;
 }
 
-th.yui-dt-desc .yui-dt-liner {
+th.yui-dt-asc .yui-dt-liner {
     background:url(../../images/3/sprite.png) no-repeat right -224px;
 }
 


### PR DESCRIPTION
When you order your object by order, the icon pointing up, or pointing down, is switched. When the arrow is pointing up the objects should be order from bottom to top.
