### PR TITLE
Changed: avoid calling method on objects using the static call syntax

### DIFF
--- a/kernel/classes/datatypes/ezbinaryfile/ezbinaryfile.php
+++ b/kernel/classes/datatypes/ezbinaryfile/ezbinaryfile.php
@@ -86,13 +86,13 @@ class eZBinaryFile extends eZPersistentObject
 
     function mimeTypeCategory()
     {
-        $types = explode( '/', eZPersistentObject::attribute( 'mime_type' ) );
+        $types = explode( '/', $this->attribute( 'mime_type' ) );
         return $types[0];
     }
 
     function mimeTypePart()
     {
-        $types = explode( '/', eZPersistentObject::attribute( 'mime_type' ) );
+        $types = explode( '/', $this->attribute( 'mime_type' ) );
         return $types[1];
     }
 

--- a/kernel/classes/datatypes/ezmedia/ezmedia.php
+++ b/kernel/classes/datatypes/ezmedia/ezmedia.php
@@ -115,13 +115,13 @@ class eZMedia extends eZPersistentObject
 
     function mimeTypeCategory()
     {
-        $types = explode( "/", eZPersistentObject::attribute( "mime_type" ) );
+        $types = explode( "/", $this->attribute( "mime_type" ) );
         return $types[0];
     }
 
     function mimeTypePart()
     {
-        $types = explode( "/", eZPersistentObject::attribute( "mime_type" ) );
+        $types = explode( "/", $this->attribute( "mime_type" ) );
         return $types[1];
     }
 

--- a/kernel/classes/datatypes/ezuser/ezuser.php
+++ b/kernel/classes/datatypes/ezuser/ezuser.php
@@ -196,7 +196,7 @@ class eZUser extends eZPersistentObject
         unset( $GLOBALS['eZUserObject_' . $userID] );
         $GLOBALS['eZUserObject_' . $userID] = $this;
         self::purgeUserCacheByUserId( $userID );
-        eZPersistentObject::store( $fieldFilters );
+        parent::store( $fieldFilters );
     }
 
     function originalPassword()

--- a/kernel/classes/datatypes/ezuser/ezusersetting.php
+++ b/kernel/classes/datatypes/ezuser/ezusersetting.php
@@ -73,7 +73,7 @@ class eZUserSetting extends eZPersistentObject
             } break;
         }
 
-        eZPersistentObject::setAttribute( $attr, $val );
+        parent::setAttribute( $attr, $val );
     }
 
     /*!

--- a/kernel/classes/ezcollaborationitemstatus.php
+++ b/kernel/classes/ezcollaborationitemstatus.php
@@ -72,7 +72,7 @@ class eZCollaborationItemStatus extends eZPersistentObject
 
     function store( $fieldFilters = null )
     {
-        eZPersistentObject::store( $fieldFilters );
+        parent::store( $fieldFilters );
         $this->updateCache();
         return true;
     }

--- a/kernel/classes/ezcontentclass.php
+++ b/kernel/classes/ezcontentclass.php
@@ -737,13 +737,13 @@ class eZContentClass extends eZPersistentObject
     */
     function remoteID()
     {
-        $remoteID = eZPersistentObject::attribute( 'remote_id', true );
+        $remoteID = $this->attribute( 'remote_id', true );
         if ( !$remoteID &&
              $this->Version == eZContentClass::VERSION_STATUS_DEFINED )
         {
             $this->setAttribute( 'remote_id', eZRemoteIdUtility::generate( 'class' ) );
             $this->sync( array( 'remote_id' ) );
-            $remoteID = eZPersistentObject::attribute( 'remote_id', true );
+            $remoteID = $this->attribute( 'remote_id', true );
         }
 
         return $remoteID;
@@ -763,7 +763,7 @@ class eZContentClass extends eZPersistentObject
             $this->removeAttributes( $removeAttributes );
 
         $this->NameList->remove( $this );
-        eZPersistentObject::remove();
+        parent::remove();
     }
 
     /*!
@@ -919,7 +919,7 @@ You will need to change the class of the node by using the swap functionality.' 
         $this->setAttribute( 'serialized_name_list', $this->NameList->serializeNames() );
         $this->setAttribute( 'serialized_description_list', $this->DescriptionList->serializeNames() );
 
-        eZPersistentObject::store( $fieldFilters );
+        parent::store( $fieldFilters );
 
         $this->NameList->store( $this );
 
@@ -1043,7 +1043,7 @@ You will need to change the class of the node by using the swap functionality.' 
 
         $this->setAttribute( 'serialized_name_list', $this->NameList->serializeNames() );
         $this->setAttribute( 'serialized_description_list', $this->DescriptionList->serializeNames() );
-        eZPersistentObject::store();
+        parent::store();
         $this->NameList->store( $this );
 
         $db->commit();

--- a/kernel/classes/ezcontentclassattribute.php
+++ b/kernel/classes/ezcontentclassattribute.php
@@ -293,7 +293,7 @@ class eZContentClassAttribute extends eZPersistentObject
         $this->setAttribute( 'serialized_description_list', $this->DescriptionList->serializeNames() );
         $this->setAttribute( 'serialized_data_text', $this->DataTextI18nList->serializeNames() );
 
-        $stored = eZPersistentObject::store( $fieldFilters );
+        $stored = parent::store( $fieldFilters );
 
         // store the content data for this attribute
         $dataType->storeClassAttribute( $this, $this->attribute( 'version' ) );
@@ -342,7 +342,7 @@ class eZContentClassAttribute extends eZPersistentObject
         $this->setAttribute( 'serialized_description_list', $this->DescriptionList->serializeNames() );
         $this->setAttribute( 'serialized_data_text', $this->DataTextI18nList->serializeNames() );
 
-        eZPersistentObject::store();
+        parent::store();
 
         // store the content data for this attribute
         $dataType->storeVersionedClassAttribute( $this, $version );
@@ -363,7 +363,7 @@ class eZContentClassAttribute extends eZPersistentObject
             $db = eZDB::instance();
             $db->begin();
             $dataType->deleteStoredClassAttribute( $this, $this->Version );
-            eZPersistentObject::remove();
+            $this->remove();
             $db->commit();
             return true;
         }

--- a/kernel/classes/ezcontentlanguage.php
+++ b/kernel/classes/ezcontentlanguage.php
@@ -155,7 +155,7 @@ class eZContentLanguage extends eZPersistentObject
             return false;
         }
 
-        eZPersistentObject::remove();
+        $this->remove();
 
         eZContentCacheManager::clearAllContentCache();
 

--- a/kernel/classes/ezcontentobject.php
+++ b/kernel/classes/ezcontentobject.php
@@ -242,7 +242,7 @@ class eZContentObject extends eZPersistentObject
         $db = eZDB::instance();
         $db->begin();
         $this->storeNodeModified();
-        eZPersistentObject::store( $fieldFilters );
+        parent::store( $fieldFilters );
         $db->commit();
     }
 
@@ -750,7 +750,7 @@ class eZContentObject extends eZPersistentObject
     */
     function remoteID()
     {
-        $remoteID = eZPersistentObject::attribute( 'remote_id', true );
+        $remoteID = $this->attribute( 'remote_id', true );
 
         // Ensures that we provide the correct remote_id if we have one in the database
         if ( $remoteID === null and $this->attribute( 'id' ) )
@@ -769,7 +769,7 @@ class eZContentObject extends eZPersistentObject
             $this->setAttribute( 'remote_id', eZRemoteIdUtility::generate( 'object' ) );
             if ( $this->attribute( 'id' ) !== null )
                 $this->sync( array( 'remote_id' ) );
-            $remoteID = eZPersistentObject::attribute( 'remote_id', true );
+            $remoteID = $this->attribute( 'remote_id', true );
         }
 
         return $remoteID;

--- a/kernel/classes/ezcontentobjectattribute.php
+++ b/kernel/classes/ezcontentobjectattribute.php
@@ -274,7 +274,7 @@ class eZContentObjectAttribute extends eZPersistentObject
             // store the content data for this attribute
             $dataType->storeObjectAttribute( $this );
 
-            eZPersistentObject::store( $fieldFilters );
+            parent::store( $fieldFilters );
             $dataType->postStore( $this );
             $db->commit();
         }
@@ -301,7 +301,7 @@ class eZContentObjectAttribute extends eZPersistentObject
         $this->setAttribute( 'data_type_string', $classAttribute->attribute( 'data_type_string' ) );
         $this->updateSortKey( false );
 
-        eZPersistentObject::store();
+        parent::store();
     }
 
     /*!
@@ -338,7 +338,7 @@ class eZContentObjectAttribute extends eZPersistentObject
             if ( $storeData )
             {
                 $dataType->storeObjectAttribute( $this );
-                $return = eZPersistentObject::store();
+                $return = parent::store();
             }
         }
 
@@ -352,7 +352,7 @@ class eZContentObjectAttribute extends eZPersistentObject
     */
     function storeNewRow()
     {
-        return eZPersistentObject::store();
+        return parent::store();
     }
 
     /*!

--- a/kernel/classes/ezcontentobjecttreenode.php
+++ b/kernel/classes/ezcontentobjecttreenode.php
@@ -262,12 +262,12 @@ class eZContentObjectTreeNode extends eZPersistentObject
     */
     function remoteID()
     {
-        $remoteID = eZPersistentObject::attribute( 'remote_id', true );
+        $remoteID = $this->attribute( 'remote_id', true );
         if ( !$remoteID )
         {
             $this->setAttribute( 'remote_id', eZRemoteIdUtility::generate( 'node' ) );
             $this->sync( array( 'remote_id' ) );
-            $remoteID = eZPersistentObject::attribute( 'remote_id', true );
+            $remoteID = $this->attribute( 'remote_id', true );
         }
 
         return $remoteID;
@@ -5582,7 +5582,7 @@ class eZContentObjectTreeNode extends eZPersistentObject
         $db = eZDB::instance();
 
         $db->begin();
-        eZPersistentObject::store( $fieldFilters );
+        parent::store( $fieldFilters );
         $this->updateAndStoreModified();
         $db->commit();
     }

--- a/kernel/classes/ezdiscountsubrule.php
+++ b/kernel/classes/ezdiscountsubrule.php
@@ -68,12 +68,12 @@ class eZDiscountSubRule extends eZPersistentObject
                     $val = 0.0;
                 if ( $val > 100.0 )
                     $val = 100.0;
-                eZPersistentObject::setAttribute( $attr, $val );
+                parent::setAttribute( $attr, $val );
             } break;
 
             default:
             {
-                eZPersistentObject::setAttribute( $attr, $val );
+                parent::setAttribute( $attr, $val );
             } break;
         }
     }

--- a/kernel/classes/ezpdfexport.php
+++ b/kernel/classes/ezpdfexport.php
@@ -163,7 +163,7 @@ class eZPDFExport extends eZPersistentObject
 
         $db = eZDB::instance();
         $db->begin();
-        eZPersistentObject::store();
+        parent::store();
         if ( $publish )
         {
             $this->setAttribute( 'version', eZPDFExport::VERSION_DRAFT );
@@ -205,7 +205,7 @@ class eZPDFExport extends eZPersistentObject
                 unlink( $filename );
             }
         }
-        eZPersistentObject::remove( $conditions, $extraConditions);
+        parent::remove( $conditions, $extraConditions);
     }
 
     /*!
@@ -251,7 +251,7 @@ class eZPDFExport extends eZPersistentObject
 
     function exportClassesArray()
     {
-        return explode( ':',  eZPersistentObject::attribute( 'export_classes' ) );
+        return explode( ':',  $this->attribute( 'export_classes' ) );
     }
 
     function countGeneratingOnceExports( $filename = '' )

--- a/kernel/classes/ezpolicy.php
+++ b/kernel/classes/ezpolicy.php
@@ -108,7 +108,7 @@ class eZPolicy extends eZPersistentObject
 
             default:
             {
-                eZPersistentObject::setAttribute( $attr, $val );
+                parent::setAttribute( $attr, $val );
             } break;
         }
     }

--- a/kernel/classes/ezpolicylimitation.php
+++ b/kernel/classes/ezpolicylimitation.php
@@ -80,7 +80,7 @@ class eZPolicyLimitation extends eZPersistentObject
 
             default:
             {
-                eZPersistentObject::setAttribute( $attr, $val );
+                parent::setAttribute( $attr, $val );
             } break;
         }
     }

--- a/kernel/classes/ezproductcollectionitem.php
+++ b/kernel/classes/ezproductcollectionitem.php
@@ -184,7 +184,7 @@ class eZProductCollectionItem extends eZPersistentObject
         {
             $itemOption->remove();
         }
-        eZPersistentObject::remove();
+        $this->remove();
         $db->commit();
     }
 

--- a/kernel/classes/ezrssexport.php
+++ b/kernel/classes/ezrssexport.php
@@ -156,7 +156,7 @@ class eZRSSExport extends eZPersistentObject
         $user = eZUser::currentUser();
         if (  $this->ID == null )
         {
-            eZPersistentObject::store();
+            parent::store();
             return;
         }
 
@@ -169,7 +169,7 @@ class eZRSSExport extends eZPersistentObject
         }
         $this->setAttribute( 'modified', $dateTime );
         $this->setAttribute( 'modifier_id', $user->attribute( "contentobject_id" ) );
-        eZPersistentObject::store();
+        parent::store();
         $db->commit();
         if ( $storeAsValid )
         {
@@ -192,7 +192,7 @@ class eZRSSExport extends eZPersistentObject
         {
             $item->remove();
         }
-        eZPersistentObject::remove();
+        $this->remove();
         $db->commit();
     }
 

--- a/kernel/classes/ezrssimport.php
+++ b/kernel/classes/ezrssimport.php
@@ -169,7 +169,7 @@ class eZRSSImport extends eZPersistentObject
 
         $this->setAttribute( 'modifier_id', $user->attribute( 'contentobject_id' ) );
         $this->setAttribute( 'modified', $dateTime );
-        eZPersistentObject::store( $fieldFilters );
+        parent::store( $fieldFilters );
     }
 
     /*!

--- a/kernel/classes/ezsection.php
+++ b/kernel/classes/ezsection.php
@@ -172,7 +172,7 @@ class eZSection extends eZPersistentObject
     */
     function removeThis( $conditions = null, $extraConditions = null )
     {
-        eZPersistentObject::remove( array( "id" => $this->ID ), $extraConditions );
+        $this->remove( array( "id" => $this->ID ), $extraConditions );
     }
 
     /*

--- a/kernel/classes/ezurlaliasml.php
+++ b/kernel/classes/ezurlaliasml.php
@@ -194,7 +194,7 @@ class eZURLAliasML extends eZPersistentObject
      */
     function setAttribute( $name, $value )
     {
-        eZPersistentObject::setAttribute( $name, $value );
+        parent::setAttribute( $name, $value );
         if ( $name == 'text' )
         {
             $this->TextMD5 = md5( eZURLAliasML::strtolower( $value ) );
@@ -237,7 +237,7 @@ class eZURLAliasML extends eZPersistentObject
                 $this->ActionType = 'nop';
         }
 
-        eZPersistentObject::store( $fieldFilters );
+        parent::store( $fieldFilters );
     }
 
     /*!

--- a/kernel/classes/ezuserdiscountrule.php
+++ b/kernel/classes/ezuserdiscountrule.php
@@ -67,7 +67,7 @@ class eZUserDiscountRule extends eZPersistentObject
             $handler->setTimestamp( 'user-discountrules-cache', time() );
             $handler->store();
         }
-        eZPersistentObject::store( $fieldFilters );
+        parent::store( $fieldFilters );
     }
 
     static function fetch( $id, $asObject = true )

--- a/kernel/classes/ezvatrule.php
+++ b/kernel/classes/ezvatrule.php
@@ -63,7 +63,7 @@ class eZVatRule extends eZPersistentObject
 
             default:
             {
-                eZPersistentObject::setAttribute( $attr, $val );
+                parent::setAttribute( $attr, $val );
             } break;
         }
     }
@@ -181,7 +181,7 @@ class eZVatRule extends eZPersistentObject
         $db->begin();
 
         // Store the rule itself.
-        eZPersistentObject::store( $fieldFilters );
+        parent::store( $fieldFilters );
 
         // Store product categories associated with the rule,
         $this->removeProductCategories();

--- a/kernel/classes/ezworkflow.php
+++ b/kernel/classes/ezworkflow.php
@@ -162,7 +162,7 @@ class eZWorkflow extends eZPersistentObject
                                                      "version" => $this->Version ) );
         }
 
-        eZPersistentObject::remove();
+        $this->remove();
         $db->commit();
     }
 
@@ -254,7 +254,7 @@ class eZWorkflow extends eZPersistentObject
                 $event->store();
             }
         }
-        eZPersistentObject::store();
+        parent::store();
         $db->commit();
     }
     /*!
@@ -280,7 +280,7 @@ class eZWorkflow extends eZPersistentObject
                 $event->storeDefined();
             }
         }
-        eZPersistentObject::store();
+        parent::store();
         $db->commit();
     }
 
@@ -301,7 +301,7 @@ class eZWorkflow extends eZPersistentObject
                 $event->setAttribute( "version", $version );
             }
         }
-        eZPersistentObject::setAttribute( "version", $version );
+        $this->setAttribute( "version", $version );
     }
 
     static function fetch( $id, $asObject = true, $version = 0 )

--- a/kernel/classes/ezworkflowevent.php
+++ b/kernel/classes/ezworkflowevent.php
@@ -175,13 +175,13 @@ class eZWorkflowEvent extends eZPersistentObject
 
     function attributes()
     {
-        return array_merge( eZPersistentObject::attributes(), $this->eventType()->typeFunctionalAttributes() );
+        return array_merge( parent::attributes(), $this->eventType()->typeFunctionalAttributes() );
     }
 
     function hasAttribute( $attr )
     {
         $eventType = $this->eventType();
-        return eZPersistentObject::hasAttribute( $attr ) or
+        return parent::hasAttribute( $attr ) or
                in_array( $attr, $eventType->typeFunctionalAttributes() );
     }
 
@@ -193,7 +193,7 @@ class eZWorkflowEvent extends eZPersistentObject
             return $eventType->attributeDecoder( $this, $attr );
         }
 
-        return eZPersistentObject::attribute( $attr );
+        return parent::attribute( $attr );
     }
 
     function eventType()
@@ -245,7 +245,7 @@ class eZWorkflowEvent extends eZPersistentObject
     {
         $db = eZDB::instance();
         $db->begin();
-        $stored = eZPersistentObject::store( $fieldFilters );
+        $stored = parent::store( $fieldFilters );
 
         $eventType = $this->eventType();
         if ( $eventType instanceof eZWorkflowEventType )
@@ -269,7 +269,7 @@ class eZWorkflowEvent extends eZPersistentObject
     {
         $db = eZDB::instance();
         $db->begin();
-        $stored = eZPersistentObject::store( $fieldFilters );
+        $stored = parent::store( $fieldFilters );
 
         $eventType = $this->eventType();
         if ( $eventType instanceof eZWorkflowEventType )

--- a/kernel/private/classes/ezcontentobjectstate.php
+++ b/kernel/private/classes/ezcontentobjectstate.php
@@ -391,7 +391,7 @@ class eZContentObjectState extends eZPersistentObject
         }
         else
         {
-            eZPersistentObject::store( $fieldFilters );
+            parent::store( $fieldFilters );
         }
     }
 

--- a/kernel/shop/classes/ezcurrencydata.php
+++ b/kernel/shop/classes/ezcurrencydata.php
@@ -309,7 +309,7 @@ class eZCurrencyData extends eZPersistentObject
     {
         // data changed => reset RateValue
         $this->invalidateRateValue();
-        eZPersistentObject::store( $fieldFilters );
+        parent::store( $fieldFilters );
     }
 
     function isActive()


### PR DESCRIPTION
When calling the parent, it's also cleaner to use `parent::` than the
name of the parent class.
