### PR TITLE
Fixed EZP-18195: $result.object is not correctly created

### DIFF
--- a/doc/bc/5.2/changes-5.2.txt
+++ b/doc/bc/5.2/changes-5.2.txt
@@ -1,0 +1,48 @@
+Changes to BC and behavior in version 5.2
+=========================================
+
+INI setting changes
+-------------------
+
+
+Change of behavior
+------------------
+
+- Fixed EZP-18195: $result.object is not correctly created
+
+  eZContentObject->assignedNodes( false ):
+  * Does not return columns "id" and "contentobject_id" anymore.
+  * Returns "ezcontentobject.remote_id" under the "object_remote_id" key,
+  "remote_id" key still contains "ezcontentobject_tree.remote_id".
+
+  eZContentObjectTreeNode::subTreeByNodeID() and
+  eZContentObjectTreeNode::subTreeMultiPaths() does not internally use columns
+  "ezcontentobject_tree.contentobject_id" and "ezcontentobject.name" anymore.
+  If you relied on those with extended attribute filtering using an "HAVING"
+  clause, replaces "ezcontentobject_tree.contentobject_id" by
+  "ezcontentobject.id" and add "ezcontentobject.name" to the additional
+  columns to be retrieved if you used it.
+
+  eZContentObjectTreeNode::findMainNodeArray( [...], false ),
+  eZContentObjectTreeNode::fetch( [...], [...], false ) and:
+  eZContentObjectTreeNode::fetchNodesByPathString( [...], [...], false ):
+  * Does not return key "contentobject_id" in addition to "id" anymore, use
+  the "id" key instead.
+  * Returns "ezcontentobject.remote_id" under the "object_remote_id" key,
+  "remote_id" key still contains "ezcontentobject_tree.remote_id".
+
+Removed features
+----------------
+
+
+Removed constants
+-----------------
+
+
+Removed globals
+---------------
+
+
+Deprecated
+----------
+

--- a/kernel/classes/ezcontentobject.php
+++ b/kernel/classes/ezcontentobject.php
@@ -50,7 +50,15 @@ class eZContentObject extends eZPersistentObject
         $this->ClassIdentifier = false;
         if ( isset( $row['contentclass_identifier'] ) )
             $this->ClassIdentifier = $row['contentclass_identifier'];
+        if ( isset( $row['class_identifier'] ) )
+            $this->ClassIdentifier = $row['class_identifier'];
         $this->ClassName = false;
+        // Depending on how the information is retrieved, the "serialized_name_list" is sometimes available in "class_serialized_name_list" key
+        if ( isset( $row['class_serialized_name_list'] ) )
+            $row['serialized_name_list'] = $row['class_serialized_name_list'];
+        // Depending on how the information is retrieved, the "contentclass_name" is sometimes available in "class_name" key
+        if ( isset( $row['class_name'] ) )
+            $row['contentclass_name'] = $row['class_name'];
         if ( isset( $row['contentclass_name'] ) )
             $this->ClassName = $row['contentclass_name'];
         if ( isset( $row['serialized_name_list'] ) )
@@ -73,6 +81,9 @@ class eZContentObject extends eZPersistentObject
                $this->CurrentLanguage = $topPriorityLanguage->attribute( 'locale' );
             }
         }
+
+        // Initialize the permission array cache
+        $this->Permissions = array();
     }
 
     static function definition()
@@ -751,18 +762,6 @@ class eZContentObject extends eZPersistentObject
     function remoteID()
     {
         $remoteID = eZPersistentObject::attribute( 'remote_id', true );
-
-        // Ensures that we provide the correct remote_id if we have one in the database
-        if ( $remoteID === null and $this->attribute( 'id' ) )
-        {
-            $db = eZDB::instance();
-            $resultArray = $db->arrayQuery( "SELECT remote_id FROM ezcontentobject WHERE id = '" . $this->attribute( 'id' ) . "'" );
-            if ( count( $resultArray ) == 1 )
-            {
-                $remoteID = $resultArray[0]['remote_id'];
-                $this->setAttribute( 'remote_id',  $remoteID );
-            }
-        }
 
         if ( !$remoteID )
         {
@@ -3377,28 +3376,27 @@ class eZContentObject extends eZPersistentObject
         $contentobjectID = $this->attribute( 'id' );
         if ( $contentobjectID == null )
         {
-            $retValue = array();
-            return $retValue;
+            return array();
         }
-        $query = "SELECT ezcontentobject.*,
-             ezcontentobject_tree.*,
-             ezcontentclass.serialized_name_list as class_serialized_name_list,
-             ezcontentclass.identifier as class_identifier,
-             ezcontentclass.is_container as is_container
-          FROM   ezcontentobject_tree,
-             ezcontentobject,
-             ezcontentclass
-          WHERE  contentobject_id=$contentobjectID AND
-             ezcontentobject_tree.contentobject_id=ezcontentobject.id  AND
-             ezcontentclass.version=0 AND
-             ezcontentclass.id = ezcontentobject.contentclass_id
-          ORDER BY path_string";
-        $db = eZDB::instance();
-        $nodesListArray = $db->arrayQuery( $query );
+        $nodesListArray = eZDB::instance()->arrayQuery(
+            "SELECT " .
+            "ezcontentobject.contentclass_id, ezcontentobject.current_version, ezcontentobject.initial_language_id, ezcontentobject.language_mask, " .
+            "ezcontentobject.modified, ezcontentobject.name, ezcontentobject.owner_id, ezcontentobject.published, ezcontentobject.remote_id AS object_remote_id, ezcontentobject.section_id, " .
+            "ezcontentobject.status, ezcontentobject_tree.contentobject_is_published, ezcontentobject_tree.contentobject_version, ezcontentobject_tree.depth, " .
+            "ezcontentobject_tree.is_hidden, ezcontentobject_tree.is_invisible, ezcontentobject_tree.main_node_id, ezcontentobject_tree.modified_subnode, ezcontentobject_tree.node_id, " .
+            "ezcontentobject_tree.parent_node_id, ezcontentobject_tree.path_identification_string, ezcontentobject_tree.path_string, ezcontentobject_tree.priority, ezcontentobject_tree.remote_id, " .
+            "ezcontentobject_tree.sort_field, ezcontentobject_tree.sort_order, ezcontentclass.serialized_name_list as class_serialized_name_list, " .
+            "ezcontentclass.identifier as class_identifier, " .
+            "ezcontentclass.is_container as is_container " .
+            "FROM ezcontentobject_tree " .
+            "INNER JOIN ezcontentobject ON (ezcontentobject_tree.contentobject_id = ezcontentobject.id) " .
+            "INNER JOIN ezcontentclass ON (ezcontentclass.version = 0 AND ezcontentclass.id = ezcontentobject.contentclass_id) " .
+            "WHERE contentobject_id = $contentobjectID " .
+            "ORDER BY path_string"
+        );
         if ( $asObject == true )
         {
-            $nodes = eZContentObjectTreeNode::makeObjectsArray( $nodesListArray );
-            return $nodes;
+            return eZContentObjectTreeNode::makeObjectsArray( $nodesListArray, true, array( "id" => $contentobjectID ) );
         }
         else
             return $nodesListArray;

--- a/kernel/classes/ezcontentobjecttreenode.php
+++ b/kernel/classes/ezcontentobjecttreenode.php
@@ -1944,43 +1944,38 @@ class eZContentObjectTreeNode extends eZPersistentObject
         // Determine whether we should show invisible nodes.
         $showInvisibleNodesCond = eZContentObjectTreeNode::createShowInvisibleSQLString( !$ignoreVisibility );
 
-        $query = "SELECT DISTINCT
-                       ezcontentobject.*,
-                       ezcontentobject_tree.*,
-                       ezcontentclass.serialized_name_list as class_serialized_name_list,
-                       ezcontentclass.identifier as class_identifier,
-                       ezcontentclass.is_container as is_container
-                       $groupBySelectText,
-                       ezcontentobject_name.name as name,
-                       ezcontentobject_name.real_translation
-                       $sortingInfo[attributeTargetSQL]
-                       $extendedAttributeFilter[columns]
-                   FROM
-                      ezcontentobject_tree
-                      INNER JOIN ezcontentobject ON (ezcontentobject_tree.contentobject_id = ezcontentobject.id)
-                      INNER JOIN ezcontentclass ON (ezcontentclass.version = 0 AND ezcontentclass.id = ezcontentobject.contentclass_id)
-                      INNER JOIN ezcontentobject_name ON (
-                          ezcontentobject_tree.contentobject_id = ezcontentobject_name.contentobject_id AND
-                          ezcontentobject_tree.contentobject_version = ezcontentobject_name.content_version
-                      )
-                      $sortingInfo[attributeFromSQL]
-                      $attributeFilter[from]
-                      $extendedAttributeFilter[tables]
-                      $sqlPermissionChecking[from]
-                   WHERE
-                      $pathStringCond
-                      $extendedAttributeFilter[joins]
-                      $sortingInfo[attributeWhereSQL]
-                      $attributeFilter[where]
-                      $notEqParentString
-                      $mainNodeOnlyCond
-                      $classCondition
-                      $objectNameLanguageFilter
-                      $showInvisibleNodesCond
-                      $sqlPermissionChecking[where]
-                      $objectNameFilterSQL AND
-                      $languageFilter
-                $groupBySQL";
+        $query = "SELECT DISTINCT " .
+            "ezcontentobject.contentclass_id, ezcontentobject.current_version, ezcontentobject.id, ezcontentobject.initial_language_id, ezcontentobject.language_mask, " .
+            "ezcontentobject.modified, ezcontentobject.owner_id, ezcontentobject.published, ezcontentobject.remote_id AS object_remote_id, ezcontentobject.section_id, ezcontentobject.status, " .
+            "ezcontentobject_tree.contentobject_is_published, ezcontentobject_tree.contentobject_version, ezcontentobject_tree.depth, " .
+            "ezcontentobject_tree.is_hidden, ezcontentobject_tree.is_invisible, ezcontentobject_tree.main_node_id, ezcontentobject_tree.modified_subnode, ezcontentobject_tree.node_id, " .
+            "ezcontentobject_tree.parent_node_id, ezcontentobject_tree.path_identification_string, ezcontentobject_tree.path_string, ezcontentobject_tree.priority, " .
+            "ezcontentobject_tree.remote_id, ezcontentobject_tree.sort_field, ezcontentobject_tree.sort_order, ezcontentclass.serialized_name_list as class_serialized_name_list, " .
+            "ezcontentclass.identifier as class_identifier, ezcontentclass.is_container as is_container $groupBySelectText, ezcontentobject_name.name, ezcontentobject_name.real_translation " .
+            $sortingInfo["attributeTargetSQL"] . " " . $extendedAttributeFilter["columns"] . " " .
+            "FROM " .
+            "ezcontentobject_tree " .
+            "INNER JOIN ezcontentobject ON (ezcontentobject_tree.contentobject_id = ezcontentobject.id) " .
+            "INNER JOIN ezcontentclass ON (ezcontentclass.version = 0 AND ezcontentclass.id = ezcontentobject.contentclass_id) " .
+            "INNER JOIN ezcontentobject_name ON ( " .
+            "    ezcontentobject_tree.contentobject_id = ezcontentobject_name.contentobject_id AND " .
+            "    ezcontentobject_tree.contentobject_version = ezcontentobject_name.content_version " .
+            ") " .
+            "$sortingInfo[attributeFromSQL] $attributeFilter[from] $extendedAttributeFilter[tables] $sqlPermissionChecking[from] " .
+            "WHERE " .
+            "$pathStringCond " .
+            "$extendedAttributeFilter[joins] " .
+            "$sortingInfo[attributeWhereSQL] " .
+            "$attributeFilter[where] " .
+            "$notEqParentString " .
+            "$mainNodeOnlyCond " .
+            "$classCondition " .
+            "$objectNameLanguageFilter " .
+            "$showInvisibleNodesCond " .
+            "$sqlPermissionChecking[where] " .
+            "$objectNameFilterSQL AND " .
+            "$languageFilter " .
+            $groupBySQL;
 
         if ( $sortingInfo['sortingFields'] )
             $query .= " ORDER BY $sortingInfo[sortingFields]";
@@ -2182,32 +2177,29 @@ class eZContentObjectTreeNode extends eZPersistentObject
             eZDebug::writeError( "Cannot use group_by parameter together with extended attribute filter which sets group_by!", __METHOD__ );
         }
 
-        $query = "SELECT DISTINCT
-                       ezcontentobject.*,
-                       ezcontentobject_tree.*,
-                       ezcontentclass.serialized_name_list as class_serialized_name_list,
-                       ezcontentclass.identifier as class_identifier,
-                       ezcontentclass.is_container as is_container
-                       $groupBySelectText,
-                       ezcontentobject_name.name as name,
-                       ezcontentobject_name.real_translation
-                       $sortingInfo[attributeTargetSQL]
-                       , ".$nodeParams['ResultID']." AS resultid
-                   FROM
-                      ezcontentobject_tree
-                      INNER JOIN ezcontentobject ON (ezcontentobject.id = ezcontentobject_tree.contentobject_id)
-                      INNER JOIN ezcontentclass ON (ezcontentclass.id = ezcontentobject.contentclass_id)
-                      INNER JOIN ezcontentobject_name ON (
-                          ezcontentobject_name.contentobject_id = ezcontentobject_tree.contentobject_id AND
-                          ezcontentobject_name.content_version = ezcontentobject_tree.contentobject_version
-                      )
-                      $sortingInfo[attributeFromSQL]
-                      $attributeFilter[from]
-                      $extendedAttributeFilter[tables]
-                      $sqlPermissionChecking[from]
-                   WHERE
-                      ".substr($queryNodes, 0, -2)."
-                $groupBySQL";
+        $query = "SELECT DISTINCT " .
+            "ezcontentobject.contentclass_id, ezcontentobject.current_version, ezcontentobject.id, ezcontentobject.initial_language_id, ezcontentobject.language_mask, " .
+            "ezcontentobject.modified, ezcontentobject.owner_id, ezcontentobject.published, ezcontentobject.remote_id AS object_remote_id, " .
+            "ezcontentobject.section_id, ezcontentobject.status, ezcontentobject_tree.contentobject_is_published, ezcontentobject_tree.contentobject_version, " .
+            "ezcontentobject_tree.depth, ezcontentobject_tree.is_hidden, ezcontentobject_tree.is_invisible, ezcontentobject_tree.main_node_id, ezcontentobject_tree.modified_subnode, " .
+            "ezcontentobject_tree.node_id, ezcontentobject_tree.parent_node_id, ezcontentobject_tree.path_identification_string, ezcontentobject_tree.path_string, " .
+            "ezcontentobject_tree.priority, ezcontentobject_tree.remote_id, ezcontentobject_tree.sort_field, ezcontentobject_tree.sort_order, ezcontentclass.serialized_name_list as class_serialized_name_list, " .
+            "ezcontentclass.identifier as class_identifier, ezcontentclass.is_container $groupBySelectText, ezcontentobject_name.name, ezcontentobject_name.real_translation " .
+            "$sortingInfo[attributeTargetSQL], $nodeParams[ResultID] AS resultid " .
+            "FROM ezcontentobject_tree " .
+            "INNER JOIN ezcontentobject ON (ezcontentobject.id = ezcontentobject_tree.contentobject_id) " .
+            "INNER JOIN ezcontentclass ON (ezcontentclass.id = ezcontentobject.contentclass_id) " .
+            "INNER JOIN ezcontentobject_name ON ( " .
+            "    ezcontentobject_name.contentobject_id = ezcontentobject_tree.contentobject_id AND " .
+            "    ezcontentobject_name.content_version = ezcontentobject_tree.contentobject_version " .
+            ") " .
+            "$sortingInfo[attributeFromSQL] " .
+            "$attributeFilter[from] " .
+            "$extendedAttributeFilter[tables] " .
+            "$sqlPermissionChecking[from] " .
+            "WHERE " .
+            substr( $queryNodes, 0, -2 ) . " " .
+            $groupBySQL;
 
         if ( $sortingInfo['sortingFields'] )
         {
@@ -2558,44 +2550,28 @@ class eZContentObjectTreeNode extends eZPersistentObject
     */
     function childrenByName( $name )
     {
-        $nodeID = $this->attribute( 'node_id' );
-
-        $fromNode = $nodeID ;
-
-        $nodePath = $this->attribute( 'path_string' );
-        $nodeDepth = $this->attribute( 'depth' );
-
-        $childrensPath = $nodePath ;
-
-        $db = eZDB::instance();
-        $pathString = " path_string like '$childrensPath%' and ";
-        $depthCond = '';
-        $nodeDepth = $this->Depth + 1;
-        $depthCond = ' depth <= ' . $nodeDepth . ' and ';
-
-        $ini = eZINI::instance();
         $db = eZDB::instance();
 
-        $name = $db->escapeString( $name );
-        $query = "SELECT ezcontentobject.*,
-                             ezcontentobject_tree.*,
-                             ezcontentclass.serialized_name_list as class_serialized_name_list,
-                             ezcontentclass.identifier as class_identifier,
-                             ezcontentclass.is_container as is_container
-                      FROM
-                            ezcontentobject_tree,
-                            ezcontentobject,ezcontentclass
-                      WHERE $pathString
-                            $depthCond
-                            ezcontentobject.name = '$name' AND
-                            ezcontentclass.version=0 AND
-                            node_id != $fromNode AND
-                            ezcontentobject_tree.contentobject_id = ezcontentobject.id  AND
-                            ezcontentclass.id = ezcontentobject.contentclass_id";
-
-        $nodeListArray = $db->arrayQuery( $query );
-
-        return eZContentObjectTreeNode::makeObjectsArray( $nodeListArray );
+        return eZContentObjectTreeNode::makeObjectsArray(
+            $db->arrayQuery(
+                "SELECT " .
+                "ezcontentobject.contentclass_id, ezcontentobject.current_version, ezcontentobject.id, ezcontentobject.initial_language_id, ezcontentobject.language_mask, " .
+                "ezcontentobject.modified, ezcontentobject.owner_id, ezcontentobject.published, ezcontentobject.remote_id AS object_remote_id, " .
+                "ezcontentobject.section_id, ezcontentobject.status, ezcontentobject_tree.contentobject_is_published, ezcontentobject_tree.contentobject_version, " .
+                "ezcontentobject_tree.depth, ezcontentobject_tree.is_hidden, ezcontentobject_tree.is_invisible, ezcontentobject_tree.main_node_id, ezcontentobject_tree.modified_subnode, " .
+                "ezcontentobject_tree.node_id, ezcontentobject_tree.parent_node_id, ezcontentobject_tree.path_identification_string, ezcontentobject_tree.path_string, " .
+                "ezcontentobject_tree.priority, ezcontentobject_tree.remote_id, ezcontentobject_tree.sort_field, ezcontentobject_tree.sort_order, " .
+                "ezcontentclass.serialized_name_list as class_serialized_name_list,ezcontentclass.identifier as class_identifier, ezcontentclass.is_container as is_container " .
+                "FROM ezcontentobject_tree " .
+                "INNER JOIN ezcontentobject ON (ezcontentobject.id = ezcontentobject_tree.contentobject_id) " .
+                "INNER JOIN ezcontentclass ON (ezcontentclass.id = ezcontentobject.contentclass_id) " .
+                "WHERE path_string LIKE '" . $this->attribute( "path_string" ) . "%' AND " .
+                "depth <= " . ( $this->Depth + 1 ) . " AND " .
+                "ezcontentobject.name = '" . $db->escapeString( $name ) . "' AND " .
+                "ezcontentclass.version = 0 AND " .
+                "node_id != " . $this->attribute( "node_id" )
+            ), true, array( "name" => $name )
+        );
     }
 
     /*!
@@ -2941,38 +2917,33 @@ class eZContentObjectTreeNode extends eZPersistentObject
      */
     static function findMainNodeArray( $objectIDArray, $asObject = true )
     {
-        if ( count( $objectIDArray ) )
+        if ( empty( $objectIDArray ) )
+            return null;
+
+        $db = eZDB::instance();
+        $nodeListArray = $db->arrayQuery(
+            "SELECT " .
+            "ezcontentobject.contentclass_id, ezcontentobject.current_version, ezcontentobject.id, ezcontentobject.initial_language_id, ezcontentobject.language_mask, " .
+            "ezcontentobject.modified, ezcontentobject.name, ezcontentobject.owner_id, ezcontentobject.published, ezcontentobject.remote_id AS object_remote_id, ezcontentobject.section_id, " .
+            "ezcontentobject.status, ezcontentobject_tree.contentobject_is_published, ezcontentobject_tree.contentobject_version, ezcontentobject_tree.depth, ezcontentobject_tree.is_hidden, " .
+            "ezcontentobject_tree.is_invisible, ezcontentobject_tree.main_node_id, ezcontentobject_tree.modified_subnode, ezcontentobject_tree.node_id, ezcontentobject_tree.parent_node_id, " .
+            "ezcontentobject_tree.path_identification_string, ezcontentobject_tree.path_string, ezcontentobject_tree.priority, ezcontentobject_tree.remote_id, ezcontentobject_tree.sort_field, " .
+            "ezcontentobject_tree.sort_order, ezcontentclass.serialized_name_list as class_serialized_name_list, ezcontentclass.identifier as class_identifier, ezcontentclass.is_container " .
+            "FROM ezcontentobject_tree " .
+            "INNER JOIN ezcontentobject ON (ezcontentobject.id = ezcontentobject_tree.contentobject_id) " .
+            "INNER JOIN ezcontentclass ON (ezcontentclass.id = ezcontentobject.contentclass_id) " .
+            "WHERE " . $db->generateSQLINStatement( $objectIDArray, 'ezcontentobject_tree.contentobject_id', false, false, 'int' ) . " AND " .
+            "ezcontentobject_tree.main_node_id = ezcontentobject_tree.node_id AND " .
+            "ezcontentclass.version = 0"
+        );
+
+        if ( $asObject )
         {
-            $db = eZDB::instance();
-            $objectIDINSQL = $db->generateSQLINStatement( $objectIDArray, 'ezcontentobject_tree.contentobject_id', false, false, 'int' );
-            $query="SELECT ezcontentobject.*,
-                           ezcontentobject_tree.*,
-                           ezcontentclass.serialized_name_list as class_serialized_name_list,
-                           ezcontentclass.identifier as class_identifier,
-                           ezcontentclass.is_container as is_container
-                    FROM ezcontentobject_tree,
-                         ezcontentobject,
-                         ezcontentclass
-                    WHERE $objectIDINSQL AND
-                          ezcontentobject_tree.main_node_id = ezcontentobject_tree.node_id AND
-                          ezcontentobject_tree.contentobject_id=ezcontentobject.id AND
-                          ezcontentclass.version=0  AND
-                          ezcontentclass.id = ezcontentobject.contentclass_id";
-
-            $nodeListArray = $db->arrayQuery( $query );
-            if ( $asObject )
-            {
-                $retNodeArray = eZContentObjectTreeNode::makeObjectsArray( $nodeListArray );
-                return $retNodeArray;
-            }
-            else
-            {
-                return $nodeListArray;
-            }
+            return eZContentObjectTreeNode::makeObjectsArray( $nodeListArray );
         }
-        return null;
-    }
 
+        return $nodeListArray;
+    }
 
     /**
      * Fetches a node by ID
@@ -3033,7 +3004,7 @@ class eZContentObjectTreeNode extends eZPersistentObject
 
             if ( is_array( $conditions ) )
             {
-                foreach( $conditions as $key => $condition )
+                foreach ( $conditions as $key => $condition )
                 {
                     if ( is_string( $condition ) )
                     {
@@ -3051,29 +3022,29 @@ class eZContentObjectTreeNode extends eZPersistentObject
                 return $returnValue;
             }
 
-            $query="SELECT ezcontentobject.*,
-                       ezcontentobject_tree.*,
-                       ezcontentclass.serialized_name_list as class_serialized_name_list,
-                       ezcontentclass.identifier as class_identifier,
-                       ezcontentclass.is_container as is_container,
-                       ezcontentobject_name.name as name,
-                       ezcontentobject_name.real_translation
-                FROM ezcontentobject_tree
-                     INNER JOIN ezcontentobject ON (ezcontentobject.id = ezcontentobject_tree.contentobject_id)
-                     INNER JOIN ezcontentclass ON (ezcontentclass.id = ezcontentobject.contentclass_id)
-                     INNER JOIN ezcontentobject_name ON (
-                         ezcontentobject_name.contentobject_id = ezcontentobject_tree.contentobject_id AND
-                         ezcontentobject_name.content_version = ezcontentobject_tree.contentobject_version
-                     )
-
-                WHERE $sqlCondition
-                      ezcontentclass.version = 0
-                      $languageFilter
-                      $versionNameJoins";
+            $query = "SELECT " .
+                "ezcontentobject.contentclass_id, ezcontentobject.current_version, ezcontentobject.id, ezcontentobject.initial_language_id, ezcontentobject.language_mask, " .
+                "ezcontentobject.modified, ezcontentobject.owner_id, ezcontentobject.published, ezcontentobject.remote_id AS object_remote_id, ezcontentobject.section_id, " .
+                "ezcontentobject.status, ezcontentobject_tree.contentobject_is_published, ezcontentobject_tree.contentobject_version, " .
+                "ezcontentobject_tree.depth, ezcontentobject_tree.is_hidden, ezcontentobject_tree.is_invisible, ezcontentobject_tree.main_node_id, ezcontentobject_tree.modified_subnode, " .
+                "ezcontentobject_tree.node_id, ezcontentobject_tree.parent_node_id, ezcontentobject_tree.path_identification_string, ezcontentobject_tree.path_string, ezcontentobject_tree.priority, " .
+                "ezcontentobject_tree.remote_id, ezcontentobject_tree.sort_field, ezcontentobject_tree.sort_order, ezcontentclass.serialized_name_list as class_serialized_name_list, " .
+                "ezcontentclass.identifier as class_identifier, ezcontentclass.is_container, ezcontentobject_name.name, ezcontentobject_name.real_translation " .
+                "FROM ezcontentobject_tree " .
+                "INNER JOIN ezcontentobject ON (ezcontentobject.id = ezcontentobject_tree.contentobject_id) " .
+                "INNER JOIN ezcontentclass ON (ezcontentclass.id = ezcontentobject.contentclass_id) " .
+                "INNER JOIN ezcontentobject_name ON ( " .
+                "    ezcontentobject_name.contentobject_id = ezcontentobject_tree.contentobject_id AND " .
+                "    ezcontentobject_name.content_version = ezcontentobject_tree.contentobject_version " .
+                ") " .
+                "WHERE $sqlCondition " .
+                "ezcontentclass.version = 0 " .
+                "$languageFilter " .
+                $versionNameJoins;
         }
         $nodeListArray = $db->arrayQuery( $query );
 
-        if ( is_array( $nodeListArray ) && count( $nodeListArray ) > 0 )
+        if ( is_array( $nodeListArray ) && !empty( $nodeListArray ) )
         {
             if ( $asObject )
             {
@@ -3169,27 +3140,25 @@ class eZContentObjectTreeNode extends eZPersistentObject
 
         if ( $pathString  )
         {
-            $query = "SELECT ezcontentobject.*,
-                             ezcontentobject_tree.*,
-                             ezcontentclass.serialized_name_list as class_serialized_name_list,
-                             ezcontentclass.identifier as class_identifier,
-                             ezcontentclass.is_container as is_container,
-                             ezcontentobject_name.name as name,
-                             ezcontentobject_name.real_translation
-                      FROM ezcontentobject_tree
-                           INNER JOIN ezcontentobject ON (ezcontentobject.id = ezcontentobject_tree.contentobject_id)
-                           INNER JOIN ezcontentclass ON (ezcontentclass.id = ezcontentobject.contentclass_id)
-                           INNER JOIN ezcontentobject_name ON (
-                               ezcontentobject_name.contentobject_id = ezcontentobject_tree.contentobject_id AND
-                               ezcontentobject_name.content_version = ezcontentobject_tree.contentobject_version
-                           )
-                      WHERE $pathString
-                            ezcontentclass.version = 0 AND
-                            " . eZContentLanguage::sqlFilter( 'ezcontentobject_name', 'ezcontentobject' ) . "
-                      ORDER BY path_string";
-
-            $db = eZDB::instance();
-            $nodesListArray = $db->arrayQuery( $query );
+            $nodesListArray = eZDB::instance()->arrayQuery(
+                "SELECT " .
+                "ezcontentobject.contentclass_id, ezcontentobject.current_version, ezcontentobject.id, ezcontentobject.initial_language_id, ezcontentobject.language_mask, " .
+                "ezcontentobject.modified, ezcontentobject.owner_id, ezcontentobject.published, ezcontentobject.remote_id AS object_remote_id, ezcontentobject.section_id, " .
+                "ezcontentobject.status, ezcontentobject_tree.contentobject_is_published, ezcontentobject_tree.contentobject_version, ezcontentobject_tree.depth, " .
+                "ezcontentobject_tree.is_hidden, ezcontentobject_tree.is_invisible, ezcontentobject_tree.main_node_id, ezcontentobject_tree.modified_subnode, ezcontentobject_tree.node_id, " .
+                "ezcontentobject_tree.parent_node_id, ezcontentobject_tree.path_identification_string, ezcontentobject_tree.path_string, ezcontentobject_tree.priority, ezcontentobject_tree.remote_id, " .
+                "ezcontentobject_tree.sort_field, ezcontentobject_tree.sort_order, ezcontentclass.serialized_name_list as class_serialized_name_list, ezcontentclass.identifier as class_identifier, " .
+                "ezcontentclass.is_container as is_container, ezcontentobject_name.name, ezcontentobject_name.real_translation " .
+                "FROM ezcontentobject_tree " .
+                "INNER JOIN ezcontentobject ON (ezcontentobject.id = ezcontentobject_tree.contentobject_id) " .
+                "INNER JOIN ezcontentclass ON (ezcontentclass.id = ezcontentobject.contentclass_id) " .
+                "INNER JOIN ezcontentobject_name ON ( " .
+                "    ezcontentobject_name.contentobject_id = ezcontentobject_tree.contentobject_id AND " .
+                "    ezcontentobject_name.content_version = ezcontentobject_tree.contentobject_version " .
+                ") " .
+                "WHERE $pathString ezcontentclass.version = 0 AND " .  eZContentLanguage::sqlFilter( 'ezcontentobject_name', 'ezcontentobject' ) . " " .
+                "ORDER BY path_string"
+            );
         }
 
         if ( $asObjects )
@@ -3198,7 +3167,6 @@ class eZContentObjectTreeNode extends eZPersistentObject
         }
         return $nodesListArray;
     }
-
 
     /*!
      \static
@@ -5114,7 +5082,7 @@ class eZContentObjectTreeNode extends eZPersistentObject
     // This code is automatically generated from templates/classcreatelist.ctpl
     // code-template::auto-generated:END can-instantiate-class-list
 
-    static function makeObjectsArray( $array , $with_contentobject = true )
+    static public function makeObjectsArray( $array , $with_contentobject = true, array $propertiesOverride = null )
     {
         $retNodes = array();
         if ( !is_array( $array ) )
@@ -5122,15 +5090,36 @@ class eZContentObjectTreeNode extends eZPersistentObject
 
         foreach ( $array as $node )
         {
-            unset( $object );
-
-            if( $node['node_id'] == 1 )
+            if ( $propertiesOverride !== null )
             {
-                if( !array_key_exists( 'name', $node ) || !$node['name'] )
-                    $node['name'] = ezpI18n::tr( 'kernel/content', 'Top Level Nodes' );
+                $node = $propertiesOverride + $node;
             }
 
-            $object = new eZContentObjectTreeNode( $node );
+            if ( $node['node_id'] == 1 && (!array_key_exists( 'name', $node ) || !$node['name'] ) )
+            {
+                $node['name'] = ezpI18n::tr( 'kernel/content', 'Top Level Nodes' );
+            }
+
+            $object = new eZContentObjectTreeNode(
+                array(
+                    "node_id" => $node["node_id"],
+                    "parent_node_id" => $node["parent_node_id"],
+                    "main_node_id" => $node["main_node_id"],
+                    "contentobject_id" => isset( $node["id"] ) ? $node["id"] : $node["contentobject_id"],
+                    "contentobject_version" => $node["contentobject_version"],
+                    "contentobject_is_published" => $node["contentobject_is_published"],
+                    "depth" => $node["depth"],
+                    "sort_field" => $node["sort_field"],
+                    "sort_order" => $node["sort_order"],
+                    "priority" => $node["priority"],
+                    "modified_subnode" => $node["modified_subnode"],
+                    "path_string" => $node["path_string"],
+                    "path_identification_string" => $node["path_identification_string"],
+                    "remote_id" => $node["remote_id"],
+                    "is_hidden" => $node["is_hidden"],
+                    "is_invisible" => $node["is_invisible"],
+                )
+            );
             // If the name is not set it will be fetched later on when
             // getName()/attribute( 'name' ) is accessed.
             if ( isset( $node['name'] ) )
@@ -5153,19 +5142,30 @@ class eZContentObjectTreeNode extends eZPersistentObject
             {
                 if ( isset( $node['class_name'] ) )
                 {
-                    unset( $node['remote_id'] );
-                    $contentObject = new eZContentObject( $node );
+                    $row = array(
+                        "id" => $node["id"],
+                        "section_id" => $node["section_id"],
+                        "owner_id" => $node["owner_id"],
+                        "contentclass_id" => $node["contentclass_id"],
+                        "name" => $node["name"],
+                        "published" => $node["published"],
+                        "modified" => $node["modified"],
+                        "current_version" => $node["current_version"],
+                        "status" => $node["status"],
+                        "remote_id" => $node["object_remote_id"],
+                        "language_mask" => $node["language_mask"],
+                        "initial_language_id" => $node["initial_language_id"],
+                        "class_name" => $node["class_name"],
+                    );
 
-                    $permissions = array();
-                    $contentObject->setPermissions( $permissions );
-                    $contentObject->setClassName( $node['class_name'] );
                     if ( isset( $node['class_identifier'] ) )
-                        $contentObject->ClassIdentifier = $node['class_identifier'];
+                        $row['class_identifier'] = $node['class_identifier'];
 
+                    $contentObject = new eZContentObject( $row );
                 }
                 else
                 {
-                    $contentObject = new eZContentObject( array());
+                    $contentObject = new eZContentObject( array() );
                     if ( isset( $node['name'] ) )
                          $contentObject->setCachedName( $node['name'] );
                 }
@@ -5278,37 +5278,45 @@ class eZContentObjectTreeNode extends eZPersistentObject
         {
             $parentNode = 2;
         }
-        $parentNode =(int) $parentNode;
+        $propertiesOverride = array( "parent_node_id" => $parentNode = (int) $parentNode );
         $db = eZDB::instance();
-        if( $asObject )
+        if ( $asObject )
         {
             if ( $remoteID )
             {
-                $objectIDFilter = 'ezcontentobject.remote_id = ' . (string) $id;
+                $objectIDFilter = "ezcontentobject.remote_id = '" . $db->escapeString( $id ) . "'";
+                $propertiesOverride["object_remote_id"] = $id;
             }
             else
             {
                 $objectIDFilter = 'contentobject_id = ' . (int) $id;
+                $propertiesOverride["id"] = $id;
             }
 
-            $query="SELECT ezcontentobject.*,
-                       ezcontentobject_tree.*,
-                       ezcontentclass.serialized_name_list as class_serialized_name_list,
-                       ezcontentclass.identifier as class_identifier,
-                       ezcontentclass.is_container as is_container
-                FROM ezcontentobject_tree,
-                     ezcontentobject,
-                     ezcontentclass
-                WHERE parent_node_id = $parentNode AND
-                      $objectIDFilter AND
-                      ezcontentobject_tree.contentobject_id=ezcontentobject.id AND
-                      ezcontentclass.version=0  AND
-                      ezcontentclass.id = ezcontentobject.contentclass_id ";
+            $retNodeArray = eZContentObjectTreeNode::makeObjectsArray(
+                $db->arrayQuery(
+                    "SELECT " .
+                    "ezcontentobject.contentclass_id, ezcontentobject.current_version, " .
+                    ( !isset( $propertiesOverride["id"] ) ? "ezcontentobject.id, " : "" ) .
+                    "ezcontentobject.initial_language_id, ezcontentobject.language_mask, ezcontentobject.modified, " .
+                    "ezcontentobject.name, ezcontentobject.owner_id, ezcontentobject.published, " .
+                    ( !isset( $propertiesOverride["object_remote_id"] ) ? "ezcontentobject.remote_id AS object_remote_id, " : "" ) .
+                    "ezcontentobject.section_id, ezcontentobject.status, " .
+                    "ezcontentobject_tree.contentobject_is_published, ezcontentobject_tree.contentobject_version, ezcontentobject_tree.depth, ezcontentobject_tree.is_hidden, " .
+                    "ezcontentobject_tree.is_invisible, ezcontentobject_tree.main_node_id, ezcontentobject_tree.modified_subnode, ezcontentobject_tree.node_id, " .
+                    "ezcontentobject_tree.path_identification_string, ezcontentobject_tree.path_string, ezcontentobject_tree.priority, ezcontentobject_tree.remote_id, ezcontentobject_tree.sort_field, " .
+                    "ezcontentobject_tree.sort_order, ezcontentclass.serialized_name_list as class_serialized_name_list, ezcontentclass.identifier as class_identifier, ezcontentclass.is_container " .
+                    "FROM ezcontentobject_tree " .
+                    "INNER JOIN ezcontentobject ON (ezcontentobject.id = ezcontentobject_tree.contentobject_id) " .
+                    "INNER JOIN ezcontentclass ON (ezcontentclass.id = ezcontentobject.contentclass_id AND ezcontentclass.version = 0) " .
+                    "WHERE parent_node_id = $parentNode AND " .
+                    $objectIDFilter
+                ),
+                true,
+                $propertiesOverride
+            );
 
-            $nodeListArray = $db->arrayQuery( $query );
-            $retNodeArray = eZContentObjectTreeNode::makeObjectsArray( $nodeListArray );
-
-            if ( count( $retNodeArray ) > 0 )
+            if ( !empty( $retNodeArray ) )
             {
                 return $retNodeArray[0];
             }

--- a/kernel/search/plugins/ezsearchengine/ezsearchengine.php
+++ b/kernel/search/plugins/ezsearchengine/ezsearchengine.php
@@ -1015,29 +1015,33 @@ class eZSearchEngine implements ezpSearchEngine
             $sortSelectSQL = $orderBySQLArray['selectSQL'];
 
             // Fetch data from table
-            $searchQuery ='';
-            $searchQuery = "SELECT DISTINCT ezcontentobject.*, ezcontentclass.serialized_name_list as class_serialized_name_list,
-                ezcontentobject_tree.*, ezcontentobject_name.name as name,
-                ezcontentobject_name.real_translation $sortSelectSQL
-                FROM
-                   $tmpTablesFrom $tmpTablesSeparator
-                   ezcontentobject
-                   INNER JOIN ezcontentclass ON (ezcontentclass.id = ezcontentobject.contentclass_id )
-                   INNER JOIN ezcontentobject_tree ON (ezcontentobject_tree.contentobject_id = ezcontentobject.id)
-                   INNER JOIN ezcontentobject_name ON (
-                       ezcontentobject_name.contentobject_id = ezcontentobject_tree.contentobject_id AND
-                       ezcontentobject_name.content_version = ezcontentobject_tree.contentobject_version
-                   )
-                   $sortFromSQL
-                WHERE
-                $tmpTablesWhere $and
-                $tmpTablesWhereExtra
-                ezcontentclass.version = '0' AND
-                ezcontentobject_tree.node_id = ezcontentobject_tree.main_node_id AND
-                " . eZContentLanguage::sqlFilter( 'ezcontentobject_name', 'ezcontentobject' ) . "
-                $showInvisibleNodesCond
-                $sortWhereSQL
-                ORDER BY $orderByFieldsSQL";
+            $searchQuery = "SELECT DISTINCT " .
+            "ezcontentobject.contentclass_id, ezcontentobject.current_version, ezcontentobject.id, ezcontentobject.initial_language_id, ezcontentobject.language_mask, " .
+            "ezcontentobject.modified, ezcontentobject.name, ezcontentobject.owner_id, ezcontentobject.published, ezcontentobject.remote_id AS object_remote_id, ezcontentobject.section_id, " .
+            "ezcontentobject.status, ezcontentobject_tree.contentobject_is_published, ezcontentobject_tree.contentobject_version, ezcontentobject_tree.depth, ezcontentobject_tree.is_hidden, " .
+            "ezcontentobject_tree.is_invisible, ezcontentobject_tree.main_node_id, ezcontentobject_tree.modified_subnode, ezcontentobject_tree.node_id, ezcontentobject_tree.parent_node_id, " .
+            "ezcontentobject_tree.path_identification_string, ezcontentobject_tree.path_string, ezcontentobject_tree.priority, ezcontentobject_tree.remote_id, ezcontentobject_tree.sort_field, " .
+            "ezcontentobject_tree.sort_order, ezcontentclass.serialized_name_list as class_serialized_name_list, ezcontentobject_name.name as name, " .
+            "ezcontentobject_name.real_translation $sortSelectSQL " .
+            "FROM " .
+            "$tmpTablesFrom $tmpTablesSeparator " .
+            "ezcontentobject " .
+            "INNER JOIN ezcontentclass ON (ezcontentclass.id = ezcontentobject.contentclass_id ) " .
+            "INNER JOIN ezcontentobject_tree ON (ezcontentobject_tree.contentobject_id = ezcontentobject.id) " .
+            "INNER JOIN ezcontentobject_name ON ( " .
+            "    ezcontentobject_name.contentobject_id = ezcontentobject_tree.contentobject_id AND " .
+            "    ezcontentobject_name.content_version = ezcontentobject_tree.contentobject_version " .
+            ") " .
+            $sortFromSQL . " " .
+            "WHERE " .
+            "$tmpTablesWhere $and " .
+            $tmpTablesWhereExtra . " " .
+            "ezcontentclass.version = '0' AND " .
+            "ezcontentobject_tree.node_id = ezcontentobject_tree.main_node_id AND " .
+            "" . eZContentLanguage::sqlFilter( 'ezcontentobject_name', 'ezcontentobject' ) . " " .
+            $showInvisibleNodesCond . " " .
+            $sortWhereSQL . " " .
+            "ORDER BY $orderByFieldsSQL";
 
             // Count query
             $languageCond = eZContentLanguage::languagesSQLFilter( 'ezcontentobject' );


### PR DESCRIPTION
EZP-18195 duplicates in fact EZP-6838 which has been fixed in an
inappropriate way in cb8ef8f8b66dafbc302fa9c10dae5293b2d95634.

This fix reverts the previous work around. Only relevant columns are
returned and `object remote_id` is returned as `object_remote_id`.

The `remote_id` key still contains the one of the node to ensure BC.

The `eZContentObject` constructor has been revised to additionally
handle information that are frequently given to him and not exploited
especially when created from `eZContentObjectTreeNode`.

This fix improves performance when `remote_id` or content class
information of an `eZContentObject` contained in an
`eZContentObjectTreeNode` are accessed by avoiding additional SQL
queries.

It should also improves the usage of the DBMS query cache mechanism
since fewer columns are retrieved by the modified SQL queries.
