### PR TITLE
Fixed EZP-20636 - Restoring a removed object to the original location is always unavailable

### DIFF
--- a/design/admin/templates/content/restore.tpl
+++ b/design/admin/templates/content/restore.tpl
@@ -18,7 +18,7 @@
 
 <div class="block">
 {if $location}
-<label title="{'The object will be restored at its original location.'|i18n( 'design/admin/content/restore' )|wash}"><input type="radio" name="RestoreType" value="1" checked="checked" title="{'The object will be restored at its original location.'|i18n( 'design/admin/content/restore' )|wash}" />&nbsp;{'Restore at original location (below <%nodeName>).'|i18n( 'design/admin/content/restore',, hash( '%nodeName', $location.parent_node_obj.name ) )|wash}</label>
+<label title="{'The object will be restored at its original location.'|i18n( 'design/admin/content/restore' )|wash}"><input type="radio" name="RestoreType" value="1" checked="checked" title="{'The object will be restored at its original location.'|i18n( 'design/admin/content/restore' )|wash}" />&nbsp;{'Restore at original location (below <%nodeName>).'|i18n( 'design/admin/content/restore',, hash( '%nodeName', $location.name ) )|wash}</label>
 <label title="{'The system will prompt you to specify a location by browsing the tree.'|i18n( 'design/admin/content/restore' )|wash}"><input type="radio" name="RestoreType" value="2" title="{'The system will prompt you to specify a location by browsing the tree.'|i18n( 'design/admin/content/restore' )|wash}" />&nbsp;{'Select a location.'|i18n( 'design/admin/content/restore' )}</label>
 {else}
 <label><input type="radio" disabled="disabled" name="RestoreType" value="1" />&nbsp;{'Restore at original location (unavailable).'|i18n( 'design/admin/content/restore' )}</label>

--- a/kernel/classes/ezcontentobjecttrashnode.php
+++ b/kernel/classes/ezcontentobjecttrashnode.php
@@ -282,6 +282,9 @@ class eZContentObjectTrashNode extends eZContentObjectTreeNode
         return eZContentObjectTrashNode::trashList( $params, true );
     }
 
+    /**
+     * @return eZContentObjectTreeNode|null
+     */
     function originalParent()
     {
         if ( $this->originalNodeParent === 0 )
@@ -319,6 +322,28 @@ class eZContentObjectTrashNode extends eZContentObjectTreeNode
         $path = $this->attribute( 'path_identification_string' );
         $path = substr( $path, 0, strrpos( $path, '/') );
         return $path;
+    }
+
+    /**
+     * @param $contentObjectID
+     * @param bool $asObject
+     * @param bool $contentObjectVersion
+     * @return eZContentObjectTrashNode|null
+     */
+    public static function fetchByContentObjectID( $contentObjectID, $asObject = true, $contentObjectVersion = false )
+    {
+        $conds = array( 'contentobject_id' => $contentObjectID );
+        if ( $contentObjectVersion !== false )
+        {
+            $conds['contentobject_version'] = $contentObjectVersion;
+        }
+
+        return self::fetchObject(
+            self::definition(),
+            null,
+            $conds,
+            $asObject
+        );
     }
 
     protected $originalNodeParent = 0;

--- a/kernel/content/restore.php
+++ b/kernel/content/restore.php
@@ -32,44 +32,10 @@ $class = $object->contentClass();
 $version = $object->attribute( 'current' );
 
 $location = null;
-$assignments = $version->attribute( 'node_assignments' );
-foreach ( $assignments as $assignment )
+$trashNode = eZContentObjectTrashNode::fetchByContentObjectID( $objectID );
+if ( $trashNode instanceof eZContentObjectTrashNode )
 {
-    $opCode = $assignment->attribute( 'op_code' );
-    $opCode &= ~1;
-    // We only include assignments which create or nops.
-    if ( $opCode == eZNodeAssignment::OP_CODE_CREATE_NOP ||
-         $opCode == eZNodeAssignment::OP_CODE_NOP )
-    {
-        $node = $assignment->attribute( 'parent_node_obj' );
-        if ( !$node )
-        {
-            continue;
-        }
-        if ( $assignment->attribute( 'is_main' ) )
-        {
-            $parentNode = $assignment->attribute( 'parent_node_obj' );
-            $parentNodeObject = $parentNode->attribute( 'object' );
-            $canCreate = $parentNode->checkAccess( 'create', $class->attribute( 'id' ), $parentNodeObject->attribute( 'contentclass_id' ) ) == 1;
-            if ( !$canCreate )
-            {
-                continue;
-            }
-            $location = $assignment;
-            break;
-        }
-        else if ( !$location )
-        {
-            $parentNode = $assignment->attribute( 'parent_node_obj' );
-            $parentNodeObject = $parentNode->attribute( 'object' );
-            $canCreate = $parentNode->checkAccess( 'create', $class->attribute( 'id' ), $parentNodeObject->attribute( 'contentclass_id' ) ) == 1;
-            if ( !$canCreate )
-            {
-                continue;
-            }
-            $location = $assignment;
-        }
-    }
+    $location = $trashNode->attribute( 'original_parent' );
 }
 
 if ( $module->isCurrentAction( 'Confirm' ) )
@@ -77,7 +43,7 @@ if ( $module->isCurrentAction( 'Confirm' ) )
     $type = $module->actionParameter( 'RestoreType' );
     if ( $type == 1 )
     {
-        $selectedNodeIDArray = array( $location->attribute( 'parent_node' ) );
+        $selectedNodeIDArray = array( $location->attribute( 'node_id' ) );
         $module->setCurrentAction( 'AddLocation' );
     }
     elseif ( $type == 2 )


### PR DESCRIPTION
This issue is a regression from 77c2c4d8f950730c47c75adb1b217c63f312e678 (fix for [EZP-20492](https://jira.ez.no/browse/EZP-20636)).

This patch avoids using `eznode_assignment` for restoring content objects and uses `ezcontentobject_trash` instead.
