### PR TITLE
fix bug when ampersand is last char on line

### DIFF
--- a/kernel/classes/datatypes/ezxmltext/ezxmlinputparser.php
+++ b/kernel/classes/datatypes/ezxmltext/ezxmlinputparser.php
@@ -731,7 +731,7 @@ class eZXMLInputParser
         while ( $pos < strlen( $text ) - 1 )
         {
             $startPos = $pos;
-            while( !( $text[$pos] == '&' && $text[$pos + 1] == '#' ) && $pos < strlen( $text ) - 1 )
+            while( !( $text[$pos] == '&' && isset($text[$pos + 1]) && $text[$pos + 1] == '#' ) && $pos < strlen( $text ) - 1 )
             {
                 $pos++;
             }


### PR DESCRIPTION
when the string being checked for numerical entities has an ampersand at the end of the string, the original code throws a warning because it checks the next character, past the end of the line
