### PR TITLE
Fixed EZP-20508 - Module redirection in legacy sometimes lead to have double siteaccess in URI

### DIFF
--- a/kernel/private/classes/ezpkernelweb.php
+++ b/kernel/private/classes/ezpkernelweb.php
@@ -935,7 +935,16 @@ class ezpKernelWeb implements ezpKernelHandler
                 $moduleRedirectUri = '/' . $moduleRedirectUri;
             else if ( $leftSlash && $rightSlash ) // Both are with a slash, so we remove one
                 $moduleRedirectUri = substr( $moduleRedirectUri, 1 );
-            $redirectURI .= $moduleRedirectUri;
+
+            // In some cases $moduleRedirectUri can already contain $redirectURI (including the siteaccess).
+            if ( strpos( $moduleRedirectUri, $redirectURI ) === 0 )
+            {
+                $redirectURI = $moduleRedirectUri;
+            }
+            else
+            {
+                $redirectURI .= $moduleRedirectUri;
+            }
         }
 
         if ( $ini->variable( 'ContentSettings', 'StaticCache' ) == 'enabled' )


### PR DESCRIPTION
This issue has been there for a long time it seems...

Manual tests
