### PR TITLE
Fix EZP-20390: eZ OE text becomes smaller if backspaced pressed

### DIFF
--- a/extension/ezoe/design/standard/stylesheets/skins/default/content.css
+++ b/extension/ezoe/design/standard/stylesheets/skins/default/content.css
@@ -1,4 +1,4 @@
-body, td, pre {color:#000; font-family: Arial, Helvetica, sans-serif; font-size:0.8em; margin:8px;}
+body, td, pre {color:#000; font-family: Arial, Helvetica, sans-serif; font-size:80%; margin:8px;}
 body {background:#FFF;}
 body.mceForceColors {background:#FFF; color:#000;}
 body.mceBrowserDefaults {background:transparent; color:inherit; font-size:inherit; font-family:inherit;}

--- a/extension/ezoe/design/standard/stylesheets/skins/o2k7/content.css
+++ b/extension/ezoe/design/standard/stylesheets/skins/o2k7/content.css
@@ -1,4 +1,4 @@
-body, td, pre {color:#000; font-family:Verdana, Arial, Helvetica, sans-serif; font-size:0.8em; margin:8px;}
+body, td, pre {color:#000; font-family:Verdana, Arial, Helvetica, sans-serif; font-size:80%; margin:8px;}
 body {background:#FFF;}
 body.mceForceColors {background:#FFF; color:#000;}
 h1, h2, h3, h4, h5, h6 /* Set general styles for all headings; some may be overridden later */


### PR DESCRIPTION
# Description

Using Chrome in ezoe. If deleting from the middle of a paragraph to the beginning of the paragraph above, the size of the font is changed.
The line causing the problem has been identified. The problem was solved using % instead of em. Leading to think it is caused by a webkit bug.
# Tests

Manual tests on firefox and chrome.
