### PR TITLE
Fix EZP-20640: Subtree limitation for the state/assign does not work

### DIFF
--- a/kernel/classes/ezcontentobject.php
+++ b/kernel/classes/ezcontentobject.php
@@ -5755,13 +5755,12 @@ class eZContentObject extends eZPersistentObject
                         case 'User_Subtree':
                         {
                             $allowed = false;
-                            $assignedNodes = $this->attribute( 'assigned_nodes' );
-                            foreach ( $assignedNodes as $assignedNode )
+                            foreach ( $this->attribute( 'assigned_nodes' ) as $assignedNode )
                             {
                                 $path = $assignedNode->attribute( 'path_string' );
                                 foreach ( $policy['User_Subtree'] as $subtreeString )
                                 {
-                                    if ( strstr( $path, $subtreeString ) )
+                                    if ( strpos( $path, $subtreeString ) !== false )
                                     {
                                         $allowed = true;
                                         break;


### PR DESCRIPTION
# Description

When setting subtree limitation on changing the state of an object, the limitation does not work. The feature had been forgotten. The fix is based on another subtree limitation use case.
# Test

Manual test and legacy-kernel test suite.
