### PR TITLE
Fix EZP-20658: Wrongly redirected to mobile SA when booting the legacy kernel

### DIFF
--- a/kernel/private/classes/ezpkernelweb.php
+++ b/kernel/private/classes/ezpkernelweb.php
@@ -276,14 +276,6 @@ class ezpKernelWeb implements ezpKernelHandler
         ezpEvent::getInstance()->registerEventListeners();
 
         $this->mobileDeviceDetect = new ezpMobileDeviceDetect( ezpMobileDeviceDetectFilter::getFilter() );
-        if ( $this->mobileDeviceDetect->isEnabled() )
-        {
-            $this->mobileDeviceDetect->process();
-
-            if ( $this->mobileDeviceDetect->isMobileDevice() )
-                $this->mobileDeviceDetect->redirect();
-        }
-
         // eZSession::setSessionArray( $mainRequest->session );
 
         /**
@@ -298,6 +290,14 @@ class ezpKernelWeb implements ezpKernelHandler
      */
     public function run()
     {
+        if ( $this->mobileDeviceDetect->isEnabled() )
+        {
+            $this->mobileDeviceDetect->process();
+
+            if ( $this->mobileDeviceDetect->isMobileDevice() )
+                $this->mobileDeviceDetect->redirect();
+        }
+
         ob_start();
         $this->requestInit();
 


### PR DESCRIPTION
JIRA issue: https://jira.ez.no/browse/EZP-20658
# Description

If the mobile redirector is enabled, the instantiation of the legacy kernel might generate a redirection depending on the user-agent.
This happens for instance when using the REST API v2 if the user agent string contains http and this is due to the introduction of the legacy IO handler that needs the legacy kernel to be instantiated.
# Tests

Manual tests
