### PR TITLE
Fix EZP-20287: Error code in legacy not sent to the symfony stack

### DIFF
--- a/kernel/error/view.php
+++ b/kernel/error/view.php
@@ -12,6 +12,8 @@ $module = $Params['Module'];
 $errorType = $Params['Type'];
 $errorNumber = $Params['Number'];
 $extraErrorParameters = $Params['ExtraParameters'];
+$httpErrorCode = null;
+$httpErrorName = null;
 
 $tpl->setVariable( 'parameters', $extraErrorParameters );
 
@@ -178,5 +180,7 @@ $Result['path'] = array( array( 'text' => ezpI18n::tr( 'kernel/error', 'Error' )
                                 'url' => false ),
                          array( 'text' => "$errorType ($errorNumber)",
                                 'url' => false ) );
+$Result['errorCode'] = $httpErrorCode;
+$Result['errorMessage'] = $httpErrorName;
 
 ?>


### PR DESCRIPTION
# Description

When an HTTP error would happen in the legacy stack. The symfony stack would not send the HTTP error code.

This commit adds error information for the symfony stack to use.

Pull request using this fix : https://github.com/ezsystems/ezpublish-kernel/pull/302
# Test

Manual test.
