### PR TITLE
Fixed EZP-20699: Running ezcache with purge in symfony cli genates a php fatal error

### DIFF
--- a/autoload/ezp_kernel.php
+++ b/autoload/ezp_kernel.php
@@ -31,6 +31,7 @@ return array(
       'eZBorkTranslator'                                   => 'lib/ezi18n/classes/ezborktranslator.php',
       'eZCLI'                                              => 'lib/ezutils/classes/ezcli.php',
       'eZCache'                                            => 'kernel/classes/ezcache.php',
+      'eZCacheHelper'                                      => 'lib/ezutils/classes/ezcachehelper.php',
       'eZCharTransform'                                    => 'lib/ezi18n/classes/ezchartransform.php',
       'eZCharsetInfo'                                      => 'lib/ezi18n/classes/ezcharsetinfo.php',
       'eZClassFunctionCollection'                          => 'kernel/class/ezclassfunctioncollection.php',

--- a/bin/php/ezcache.php
+++ b/bin/php/ezcache.php
@@ -11,14 +11,20 @@
 
 require 'autoload.php';
 
-$cli = eZCLI::instance();
-$script = eZScript::instance( array( 'description' => ( "eZ Publish Cache Handler\n" .
-                                                        "Allows for easy clearing of Cache files\n" .
-                                                        "\n" .
-                                                        "./bin/php/ezcache.php --clear-tag=content" ),
-                                     'use-session' => false,
-                                     'use-modules' => false,
-                                     'use-extensions' => true ) );
+$helper = new eZCacheHelper(
+    $cli = eZCLI::instance(),
+    $script = eZScript::instance(
+        array(
+            'description' => "eZ Publish Cache Handler\n" .
+                             "Allows for easy clearing of Cache files\n" .
+                             "\n" .
+                             "./bin/php/ezcache.php --clear-tag=content",
+            'use-session' => false,
+            'use-modules' => false,
+            'use-extensions' => true
+        )
+    )
+);
 
 $script->startup();
 
@@ -131,153 +137,19 @@ if ( $options['list-ids'] )
     }
     else
     {
-        $idList = eZCache::fetchIDList( $cacheList );
         $cli->output( "The following ids are defined: (use --verbose for more details)" );
-        $cli->output( $cli->stylize( 'emphasize', implode( ', ', $idList ) ) );
+        $cli->output( $cli->stylize( 'emphasize', implode( ', ', eZCache::fetchIDList( $cacheList ) ) ) );
     }
     $script->shutdown( 0 );
-}
-
-function clearItems( $cacheEntries, $cli, $name )
-{
-    if ( !$name )
-        $name = 'All cache';
-    $name = $cli->stylize( 'emphasize', $name );
-    $cli->output( 'Clearing ' . $name . ': ' );
-
-    checkPaths( $cacheEntries, false );
-
-    $i = 0;
-    foreach ( $cacheEntries as $cacheEntry )
-    {
-        if ( $i > 0 )
-            $cli->output( ', ', false );
-        $cli->output( $cli->stylize( 'emphasize', $cacheEntry['name'] ), false );
-        eZCache::clearItem( $cacheEntry );
-        ++$i;
-    }
-    $cli->output();
-}
-
-function purgeItems( $cacheEntries, $cli, $name )
-{
-    global $purgeSleep, $purgeMax, $purgeExpiry;
-    if ( !$name )
-        $name = 'All cache';
-    $name = $cli->stylize( 'emphasize', $name );
-    $cli->output( 'Purging ' . $name . ': ' );
-
-    checkPaths( $cacheEntries, true );
-
-    $i = 0;
-    foreach ( $cacheEntries as $cacheEntry )
-    {
-        if ( $i > 0 )
-            $cli->output( ', ', false );
-        $cli->output( $cli->stylize( 'emphasize', $cacheEntry['name'] ), false );
-        eZCache::clearItem( $cacheEntry, true, 'reportProgress', $purgeSleep, $purgeMax, $purgeExpiry );
-        ++$i;
-    }
-    $cli->output();
-}
-
-function checkPaths( $cacheEntries, $purge )
-{
-    global $cli, $script;
-
-    $warnPaths = array();
-    foreach ( $cacheEntries as $cacheEntry )
-    {
-        $absPath = realpath( eZSys::cacheDirectory() . DIRECTORY_SEPARATOR . $cacheEntry['path'] );
-        $absPathElementCount = count( explode( DIRECTORY_SEPARATOR, rtrim( $absPath, DIRECTORY_SEPARATOR ) ) );
-        // Refuse to delete root directory ('/' or 'C:\')
-        if ( $absPath &&
-             $absPathElementCount < 2 ) // 2, since one path element ('/foo') produces two exploded elements
-        {
-            $cli->error( 'Refusing to delete root directory! Please check your cache settings. Path: ' . $absPath );
-            $script->shutdown( 1 );
-            exit();
-        }
-
-        // Warn if the cache entry is not function based, and the path is outside ezp root, and the path has less than 2 elements
-        if ( $absPath &&
-             ( !$purge || !isset( $cacheEntry['purge-function'] ) ) &&
-             !isset( $cacheEntry['function'] ) &&
-             $absPathElementCount < 3 && /* 3, since two path elements ('/foo/bar') produce three exploded elements */
-             strpos( dirname( $absPath ) . DIRECTORY_SEPARATOR, realpath( eZSys::rootDir() ) . DIRECTORY_SEPARATOR ) === false )
-        {
-            $warnPaths[] = $absPath;
-        }
-    }
-
-    if ( count( $warnPaths ) > 0 )
-    {
-        $cli->warning( 'The following cache paths are outside of the eZ Publish root directory, and have less than 2 path elements. ' .
-                       'Are you sure you want to ' . ( $purge ? 'purge' : 'clear' ) . ' them?' );
-        foreach ( $warnPaths as $warnPath )
-        {
-            $cli->output( $warnPath );
-        }
-        $input = getUserInput( ( $purge ? 'Purge' : 'Clear' ) . '? yes/no:', array( 'yes', 'no' ) );
-
-        if ( $input == 'no' )
-        {
-            $script->shutdown();
-            exit();
-        }
-    }
-}
-
-if ( !function_exists( 'readline' ) )
-{
-    function readline( $prompt = '' )
-        {
-            echo $prompt . ' ';
-            return trim( fgets( STDIN ) );
-        }
-}
-
-if ( !function_exists( 'getUserInput' ) )
-{
-    function getUserInput( $query, $acceptValues )
-    {
-        $validInput = false;
-        while( !$validInput )
-        {
-            $input = readline( $query );
-            if ( $acceptValues === false ||
-                 in_array( $input, $acceptValues ) )
-            {
-                $validInput = true;
-            }
-        }
-        return $input;
-    }
-}
-
-function reportProgress( $filename, $count )
-{
-    global $cli;
-    static $progress = array( '|', '/', '-', '\\' );
-    if ( $count == 0 )
-    {
-        $cli->output( $cli->storePosition() . " " . $cli->restorePosition(), false );
-    }
-    else
-    {
-        $text = array_shift( $progress );
-        $cli->output( $cli->storePosition() . $text . $cli->restorePosition(), false );
-        $progress[] = $text;
-    }
 }
 
 if ( $options['clear-all'] )
 {
     $noAction = false;
     if ( $purge )
-        purgeItems( $cacheList, $cli, false );
+        $helper->purgeItems( $cacheList, false, $purgeSleep, $purgeMax, $purgeExpiry );
     else
-        clearItems( $cacheList, $cli, false );
+        $helper->clearItems( $cacheList, false );
     $script->shutdown( 0 );
 }
 
@@ -287,24 +159,18 @@ if ( $options['clear-tag'] )
     $tagName = $options['clear-tag'];
     $cacheEntries = eZCache::fetchByTag( $tagName, $cacheList );
     if ( $purge )
-        purgeItems( $cacheEntries, $cli, $tagName );
+        $helper->purgeItems( $cacheEntries, $tagName, $purgeSleep, $purgeMax, $purgeExpiry );
     else
-        clearItems( $cacheEntries, $cli, $tagName );
+        $helper->clearItems( $cacheEntries, $tagName );
 }
 
-$idName = false;
 if ( $options['clear-id'] )
 {
     $noAction = false;
     $idName = $options['clear-id'];
-}
-
-if ( $idName )
-{
-    $idList = explode( ',', $idName );
     $missingIDList = array();
     $cacheEntries = array();
-    foreach ( $idList as $id )
+    foreach ( explode( ',', $idName ) as $id )
     {
         $cacheEntry = eZCache::fetchByID( $id, $cacheList );
         if ( $cacheEntry )
@@ -324,9 +190,9 @@ if ( $idName )
     if ( $options['clear-id'] )
     {
         if ( $purge )
-            purgeItems( $cacheEntries, $cli, $idName );
+            $helper->purgeItems( $cacheEntries, $idName, $purgeSleep, $purgeMax, $purgeExpiry );
         else
-            clearItems( $cacheEntries, $cli, $idName );
+            $helper->clearItems( $cacheEntries, $idName );
     }
     else
     {
@@ -340,5 +206,3 @@ if ( $noAction )
 }
 
 $script->shutdown();
-
-?>

--- a/lib/ezutils/classes/ezcachehelper.php
+++ b/lib/ezutils/classes/ezcachehelper.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * File containing the eZCacheHelper class
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ * @package kernel
+ */
+
+class eZCacheHelper
+{
+    /**
+     * @var eZCLI
+     */
+    private $cli;
+
+    /**
+     * @var eZScript
+     */
+    private $script;
+
+    public function __construct( eZCLI $cli, eZScript $script )
+    {
+        $this->cli = $cli;
+        $this->script = $script;
+    }
+
+    public function clearItems( $cacheEntries, $name )
+    {
+        $this->internalClear( false, $cacheEntries, $name );
+    }
+
+    public function purgeItems( $cacheEntries, $name, $purgeSleep, $purgeMax, $purgeExpiry )
+    {
+        $this->internalClear( true, $cacheEntries, $name, $purgeSleep, $purgeMax, $purgeExpiry );
+    }
+
+    private function internalClear( $purge, $cacheEntries, $name, $purgeSleep = null, $purgeMax = null, $purgeExpiry = null )
+    {
+        $this->cli->output(
+            ( $purge ? 'Purging ' : 'Clearing ' ) . $this->cli->stylize( 'emphasize', $name ? $name : 'All cache' ) . ': '
+        );
+
+        $warnPaths = array();
+        foreach ( $cacheEntries as $cacheEntry )
+        {
+            $absPath = realpath( eZSys::cacheDirectory() . DIRECTORY_SEPARATOR . $cacheEntry['path'] );
+            $absPathElementCount = count( explode( DIRECTORY_SEPARATOR, rtrim( $absPath, DIRECTORY_SEPARATOR ) ) );
+            // Refuse to delete root directory ('/' or 'C:\')
+            // 2 => since one path element ('/foo') produces two exploded elements
+            if ( $absPath && $absPathElementCount < 2 )
+            {
+                $this->cli->error( 'Refusing to delete root directory! Please check your cache settings. Path: ' . $absPath );
+                $this->script->shutdown( 1 );
+                exit();
+            }
+
+            // Warn if the cache entry is not function based, and the path is outside ezp root, and the path has less than 2 elements
+            if (
+                $absPath
+                && ( !$purge || !isset( $cacheEntry['purge-function'] ) )
+                && !isset( $cacheEntry['function'] )
+                // 3 => since two path elements ('/foo/bar') produce three exploded elements
+                && $absPathElementCount < 3
+                && strpos( dirname( $absPath ) . DIRECTORY_SEPARATOR, realpath( eZSys::rootDir() ) . DIRECTORY_SEPARATOR ) === false
+            )
+            {
+                $warnPaths[] = $absPath;
+            }
+        }
+
+        if ( !empty( $warnPaths ) )
+        {
+            $this->cli->warning(
+                'The following cache paths are outside of the eZ Publish root directory, and have less than 2 path elements. ' .
+                'Are you sure you want to ' . ( $purge ? 'purge' : 'clear' ) . ' them?'
+            );
+
+            foreach ( $warnPaths as $warnPath )
+            {
+                $this->cli->output( $warnPath );
+            }
+
+            if ( function_exists( "getUserInput" ) )
+            {
+                $input = getUserInput( ( $purge ? 'Purge' : 'Clear' ) . '? yes/no:', array( 'yes', 'no' ) );
+            }
+            else
+            {
+                $validInput = false;
+                $readlineExists = function_exists( "readline" );
+                while ( !$validInput )
+                {
+                    if ( $readlineExists )
+                    {
+                        $input = readline( $query );
+                    }
+                    else
+                    {
+                        echo $prompt . ' ';
+                        $input = trim( fgets( STDIN ) );
+                    }
+                    if ( $acceptValues === false || in_array( $input, $acceptValues ) )
+                    {
+                        $validInput = true;
+                    }
+                }
+            }
+
+            if ( $input === 'no' )
+            {
+                $this->script->shutdown();
+                exit();
+            }
+        }
+
+        $firstItem = true;
+        foreach ( $cacheEntries as $cacheEntry )
+        {
+            if ( $firstItem )
+                $firstItem = false;
+            else
+                $this->cli->output( ', ', false );
+
+            $this->cli->output( $this->cli->stylize( 'emphasize', $cacheEntry['name'] ), false );
+
+            if ( $purge )
+                eZCache::clearItem( $cacheEntry, true, array( $this, 'reportProgress'), $purgeSleep, $purgeMax, $purgeExpiry );
+            else
+                eZCache::clearItem( $cacheEntry );
+        }
+        $this->cli->output();
+    }
+
+    public function reportProgress( $filename, $count )
+    {
+        static $progress = array( '|', '/', '-', '\\' );
+
+        if ( $count == 0 )
+        {
+            $this->cli->output( $this->cli->storePosition() . " " . $this->cli->restorePosition(), false );
+        }
+        else
+        {
+            $text = array_shift( $progress );
+            $this->cli->output( $this->cli->storePosition() . $text . $this->cli->restorePosition(), false );
+            $progress[] = $text;
+        }
+    }
+}


### PR DESCRIPTION
This Pull Request fixes the problem that the use of the `global` keyword does not enable access to the direct parent namespace in the call stack. Since `bin/php/ezcache.php` uses the `global` keyword, it doesn't work from inside a closure which is used by `php ezpublish/console ezpublish:legacy:script`.
