### PR TITLE
Fixed EZP-20455: eZUser::isLoggedIn does not correctly check user's stat...

### DIFF
--- a/kernel/classes/datatypes/ezuser/ezuser.php
+++ b/kernel/classes/datatypes/ezuser/ezuser.php
@@ -1063,7 +1063,7 @@ WHERE user_id = '" . $userID . "' AND
     static function updateLastVisitByLogout( $userID )
     {
         $db = eZDB::instance();
-        $db->query( "UPDATE ezuservisit SET current_visit_timestamp=-current_visit_timestamp WHERE user_id=$userID" );
+        $db->query( "UPDATE ezuservisit SET current_visit_timestamp=-ABS(current_visit_timestamp) WHERE user_id=$userID" );
     }
 
     /**


### PR DESCRIPTION
Update ezuservisit when a user logout, to ensure eZUser::isUserLoggedIn getting correct status. Ref: 73ccec1d8fbf63b90f12a8c6c58228a4793541ea

It will set database ezuservisit.current_visit_timestamp to minus so the isUserLoggedIn will return false if the user already logout.
