### PR TITLE
Fixed EZP-20766: Wrong default value for CLUSTER_HEADER_X_POWERED_BY

### DIFF
--- a/config.php-RECOMMENDED
+++ b/config.php-RECOMMENDED
@@ -237,9 +237,11 @@
 
 /**
  * Enable usage of "X-Powered-By" headers.
- * Optional. Defaults to true.
+ * Optional. Defaults: eZ Publish.
+ * Setting it to false will disable the custom header, but you still need to set expose_php to off
+ * in the php configuration to get rid of the X-Powered-By header completely.
  */
-// define( 'CLUSTER_HEADER_X_POWERED_BY', true );
+// define( 'CLUSTER_HEADER_X_POWERED_BY', 'eZ Publish' );
 
 /*
    LOG HANDLING

--- a/doc/bc/5.2/changes-5.2.txt
+++ b/doc/bc/5.2/changes-5.2.txt
@@ -31,6 +31,11 @@ Change of behavior
   * Returns "ezcontentobject.remote_id" under the "object_remote_id" key,
   "remote_id" key still contains "ezcontentobject_tree.remote_id".
 
+- Fixed EZP-20766: Wrong default value for CLUSTER_HEADER_X_POWERED_BY in index_cluster.php
+
+  The previous default value (true) led to X-Powered-By being set to 1 (true cast to integer).
+  From 5.2, the default value will be set to "eZ Publish".
+
 Removed features
 ----------------
 
@@ -45,4 +50,3 @@ Removed globals
 
 Deprecated
 ----------
-

--- a/index_cluster.php
+++ b/index_cluster.php
@@ -43,7 +43,7 @@ EOF;
 // default values
 if ( !defined( 'CLUSTER_ENABLE_HTTP_RANGE' ) )     define( 'CLUSTER_ENABLE_HTTP_RANGE', true );
 if ( !defined( 'CLUSTER_ENABLE_HTTP_CACHE' ) )     define( 'CLUSTER_ENABLE_HTTP_CACHE', true );
-if ( !defined( 'CLUSTER_HEADER_X_POWERED_BY' ) )   define( 'CLUSTER_HEADER_X_POWERED_BY', true );
+if ( !defined( 'CLUSTER_HEADER_X_POWERED_BY' ) )   define( 'CLUSTER_HEADER_X_POWERED_BY', 'eZ Publish' );
 if ( !defined( 'CLUSTER_ENABLE_DEBUG' ) )          define( 'CLUSTER_ENABLE_DEBUG', false );
 if ( !defined( 'CLUSTER_PERSISTENT_CONNECTION' ) ) define( 'CLUSTER_PERSISTENT_CONNECTION', false );
 if ( !defined( 'CLUSTER_STORAGE_USER' ) )          define( 'CLUSTER_STORAGE_USER', '' );


### PR DESCRIPTION
See https://jira.ez.no/browse/EZP-20766.

The new default value is "eZ Publish". Setting the constant to false still disables
the custom header, but will still send the one generated by PHP.

The PR also updates the various pieces of doc related to this.
