### PR TITLE
addition of autocomplete to object relation(s) attributes

### DIFF
--- a/design/admin/javascript/ezajaxrelations_jquery.js
+++ b/design/admin/javascript/ezajaxrelations_jquery.js
@@ -15,11 +15,12 @@ jQuery(function( $ )
     $('input.relation-autocomplete').each( function() {
         var box = $( this.parentNode.parentNode );
         var node = box.find("*[name*='_for_object_start_node']"), classes = box.find("input[name*='_for_object_class_constraint_list']");
+        var acURL = box.find("input[name*='autocomplete-url-']");
         var minquerylength = box.find("input[name*='autocomplete-minquerylength-']");
         var resultlimit = box.find("input[name*='autocomplete-minquerylength-']");
         $('#' + box.attr('id') + ' .ezobject-relation-search-autocomplete, #' + box.attr('id') + ' .yui-ac-content' ).css( 'width', $( this ).width() );
         var autocomplete = new eZAJAXAutoComplete({
-            url: '/ezjscore/call/ezfind::autocomplete',
+            url: acURL.val(),
             inputid: $( this ).attr('id'),
             containerid: $( '#' + box.attr('id') + ' .ezobject-relation-search-autocomplete' ).attr('id'),
             minquerylength: (minquerylength.size())?(minquerylength.val()):(''),

--- a/design/standard/templates/content/datatype/edit/ezobjectrelation.tpl
+++ b/design/standard/templates/content/datatype/edit/ezobjectrelation.tpl
@@ -82,6 +82,7 @@
         <div class="ezobject-relation-search-autocomplete" id="ezobject-relation-search-autocomplete-{$attribute.id}"></div>
         <input type="hidden" name="autocomplete-minquerylength-{$attribute.id}" value="{ezini( 'AutoCompleteSettings', 'MinQueryLength', 'ezfind.ini' )}" />
         <input type="hidden" name="autocomplete-resultlimit-{$attribute.id}" value="{ezini( 'AutoCompleteSettings', 'Limit', 'ezfind.ini' )}" />
+        <input type="hidden" name="autocomplete-url-{$attribute.id}" value="{'ezjscore/call/ezfind::autocomplete'|ezurl('no')}" />
     {/if}
 
     <input type="text" class="halfbox hide ezobject-relation-search-text {if eq( $autocomplete, 'enabled' )}relation-autocomplete{/if}" id="ezobject-relation-search-text-{$attribute.id}" autocomplete="off" />

--- a/design/standard/templates/content/datatype/edit/ezobjectrelationlist.tpl
+++ b/design/standard/templates/content/datatype/edit/ezobjectrelationlist.tpl
@@ -421,6 +421,7 @@
                 <div class="ezobject-relation-search-autocomplete" id="ezobject-relation-search-autocomplete-{$attribute.id}"></div>
                 <input type="hidden" name="autocomplete-minquerylength-{$attribute.id}" value="{ezini( 'AutoCompleteSettings', 'MinQueryLength', 'ezfind.ini' )}" />
                 <input type="hidden" name="autocomplete-resultlimit-{$attribute.id}" value="{ezini( 'AutoCompleteSettings', 'Limit', 'ezfind.ini' )}" />
+                <input type="hidden" name="autocomplete-url-{$attribute.id}" value="{'ezjscore/call/ezfind::autocomplete'|ezurl('no')}" />
             {/if}
 
             <input type="text" class="halfbox hide ezobject-relation-search-text {if eq( $autocomplete, 'enabled' )}relation-autocomplete{/if}" id="ezobject-relation-search-text-{$attribute.id}" autocomplete="off" />


### PR DESCRIPTION
This pull request is tied to this one on the eZ Find repository:
https://github.com/ezsystems/ezfind/pull/106

The changes will allows users to have an autocomplete filtered by subtree / classes on the edit form of object relation / object relations attributes.
