### PR TITLE
EZP-20673: Database check shows eznode_assignment error after 5.1 upgrade

### DIFF
--- a/kernel/sql/mysql/kernel_schema.sql
+++ b/kernel/sql/mysql/kernel_schema.sql
@@ -858,7 +858,7 @@ CREATE TABLE eznode_assignment (
   op_code int(11) NOT NULL default '0',
   parent_node int(11) default NULL,
   parent_remote_id varchar(100) NOT NULL default '',
-  remote_id int(11) NOT NULL default '0',
+  remote_id varchar(100) NOT NULL default '0',
   sort_field int(11) default '1',
   sort_order int(11) default '1',
   PRIMARY KEY  (id),

--- a/kernel/sql/postgresql/kernel_schema.sql
+++ b/kernel/sql/postgresql/kernel_schema.sql
@@ -2016,7 +2016,7 @@ CREATE TABLE eznode_assignment (
     op_code integer DEFAULT 0 NOT NULL,
     parent_node integer,
     parent_remote_id character varying(100) DEFAULT ''::character varying NOT NULL,
-    remote_id integer DEFAULT 0 NOT NULL,
+    remote_id character varying(100) DEFAULT '0'::character varying NOT NULL,
     sort_field integer DEFAULT 1,
     sort_order integer DEFAULT 1
 );

--- a/update/database/mysql/5.1/dbupdate-5.0.0-to-5.1.0.sql
+++ b/update/database/mysql/5.1/dbupdate-5.0.0-to-5.1.0.sql
@@ -36,3 +36,6 @@ ALTER TABLE ezcontentobject_link DROP COLUMN op_code;
 
 -- See https://jira.ez.no/browse/EZP-20527
 UPDATE ezcobj_state_group_language SET real_language_id = language_id & ~1;
+
+-- See https://jira.ez.no/browse/EZP-20673
+ALTER TABLE eznode_assignment CHANGE COLUMN remote_id remote_id varchar(100) NOT NULL DEFAULT '0';

--- a/update/database/postgresql/5.1/dbupdate-5.0.0-to-5.1.0.sql
+++ b/update/database/postgresql/5.1/dbupdate-5.0.0-to-5.1.0.sql
@@ -33,3 +33,6 @@ ALTER TABLE ezcontentobject_link DROP COLUMN op_code;
 
 -- See https://jira.ez.no/browse/EZP-20527
 UPDATE ezcobj_state_group_language SET real_language_id = language_id & ~1
+
+-- See https://jira.ez.no/browse/EZP-20673
+ALTER TABLE eznode_assignment ALTER COLUMN remote_id TYPE character varying(100);


### PR DESCRIPTION
This PR fixes issue https://jira.ez.no/browse/EZP-20673

This adds update queries to `dbupdate-5.0.0-to-5.1.0.sql` upgrade script that were omitted from `dbupdate-4.7.0-to-5.0.0.sql` for MySQL and PostgreSQL. Oracle is fine as those were added there.

Related:
https://github.com/ezsystems/ezpublish-legacy/pull/502
https://github.com/ezsystems/ezoracle/pull/8
