### PR TITLE
Implemented EZP-20787: fiximagesoutsidevardir improvements

### DIFF
--- a/update/common/scripts/5.1/fiximagesoutsidevardir.php
+++ b/update/common/scripts/5.1/fiximagesoutsidevardir.php
@@ -91,7 +91,6 @@ foreach ( $rows as $row )
     }
     else
     {
-        $moveFiles = true;
         $cli->output( "  Moving file to $newPath" );
     }
 


### PR DESCRIPTION
See https://jira.ez.no/browse/EZP-20787.

Makes the update script support the use-case where both the setting AND the vardir were changed, but existing images references haven't been updated.
