### PR TITLE
Updates spellchecker wiki url comment in ezoe.ini

### DIFF
--- a/extension/ezoe/settings/ezoe.ini
+++ b/extension/ezoe/settings/ezoe.ini
@@ -198,7 +198,7 @@ PathLocation=none
 [SpellChecker]
 # Settings for TinyMCE SpellChecker
 # You need to enable the spellchecker plugin before these settings have any effect
-# Wiki: http://wiki.moxiecode.com/index.php/TinyMCE:Plugins/spellchecker
+# Wiki: http://www.tinymce.com/wiki.php/Plugin:spellchecker
 config[]
 config[general.engine]=GoogleSpell
 


### PR DESCRIPTION
The Wiki link for the spellchecker TinyMCE plugin was broken. This update replaces the link with a working one.
