### PR TITLE
 EZP-20920: Add EZP_INI_DIRECTORY_PERMISSION constant

### DIFF
--- a/config.php-RECOMMENDED
+++ b/config.php-RECOMMENDED
@@ -103,6 +103,14 @@
 //define( 'EZP_INI_FILE_PERMISSION', 0666 );
 
 
+/*
+    Set EZP_INI_DIRECTORY_PERMISSION constant to the permissions you want saved
+    ini and cache directories to have. This setting also applies to generated autoload directory.
+    Do keep an octal number as value here ( meaning it starts by a 0 ).
+*/
+//define( 'EZP_INI_DIRECTORY_PERMISSION', 0777 );
+
+
 
 /*
    CUSTOM AUTOLOAD MECHANISM

--- a/kernel/private/classes/ezautoloadgenerator.php
+++ b/kernel/private/classes/ezautoloadgenerator.php
@@ -234,9 +234,9 @@ class eZAutoloadGenerator
             }
             else if ( !file_exists( $targetBasedir ) )
             {
-                if ( defined( 'EZP_INI_FILE_PERMISSION' ) )
+                if ( defined( 'EZP_INI_DIRECTORY_PERMISSION' ) )
                 {
-                    mkdir( $targetBasedir, EZP_INI_FILE_PERMISSION, true );
+                    mkdir( $targetBasedir, EZP_INI_DIRECTORY_PERMISSION, true );
                 }
                 else
                 {

--- a/lib/ezutils/classes/ezini.php
+++ b/lib/ezutils/classes/ezini.php
@@ -85,6 +85,14 @@ class eZINI
     static protected $filePermission = null;
 
     /**
+     * set EZP_INI_DIRECTORY_PERMISSION constant to the permissions you want saved
+     * ini and cache directories to have.
+     *
+     * @var null|int
+     */
+    static protected $directoryPermission = null;
+
+    /**
      * Array of eZINI instances
      *
      * @var array(eZINI)
@@ -187,6 +195,14 @@ class eZINI
                 self::$filePermission = EZP_INI_FILE_PERMISSION;
             else
                 self::$filePermission = 0666;
+        }
+
+        if ( self::$directoryPermission === null )
+        {
+            if ( defined( 'EZP_INI_DIRECTORY_PERMISSION' ) )
+                self::$directoryPermission = EZP_INI_DIRECTORY_PERMISSION;
+            else
+                self::$directoryPermission = 0777;
         }
 
         if ( $load )
@@ -624,7 +640,7 @@ class eZINI
     {
         if ( !file_exists( $cachedDir ) )
         {
-            if ( !eZDir::mkdir( $cachedDir, 0777, true ) )
+            if ( !eZDir::mkdir( $cachedDir, self::$directoryPermission, true ) )
             {
                 eZDebug::writeError( "Couldn't create cache directory $cachedDir, perhaps wrong permissions", __METHOD__ );
                 return false;


### PR DESCRIPTION
This pull request fixes two issues I had with permissions in var folder:
- `EZP_INI_FILE_PERMISSION` was used to create the `var/autoload` directory as well as files inside of it. If we want our INI caches and autoload files to have, for example, `0660` permissions, it is not possible to enter the `var/autoload` directory by eZ Publish as no execute bit was set on it.
- eZINI class uses hardcoded `0777` value for creating `var/cache/ini` folder

With this pull request, both of those issues are resolved by using a new constant in `config.php`
