### PR TITLE
Converted Doxygen to PHPDoc in eZContentObject

### DIFF
--- a/kernel/classes/ezcontentobject.php
+++ b/kernel/classes/ezcontentobject.php
@@ -8,17 +8,11 @@
  * @package kernel
  */
 
-/*!
-  \class eZContentObject ezcontentobject.php
-  \ingroup eZKernel
-  \brief Handles eZ Publish content objects
-
-  It encapsulates the data for an object and provides lots of functions
-  for dealing with versions, translations and attributes.
-
-  \sa eZContentClass
-*/
-
+/**
+ * Encapsulates data about and methods to work with content objects
+ *
+ * @package kernel
+ */
 class eZContentObject extends eZPersistentObject
 {
     const STATUS_DRAFT = 0;
@@ -44,6 +38,13 @@ class eZContentObject extends eZPersistentObject
     const RELATION_LINK = 4;
     const RELATION_ATTRIBUTE = 8;
 
+    /**
+     * Initializes the object with $row.
+     *
+     * If $row is an integer, it will try to fetch it from the database using it as the unique ID.
+     *
+     * @param int|array $row
+     */
     function eZContentObject( $row )
     {
         $this->eZPersistentObject( $row );
@@ -218,11 +219,11 @@ class eZContentObject extends eZPersistentObject
         return $definition;
     }
 
-    /*!
-     Get class groups this object's class belongs to if match for class groups is enabled.
-
-     \return array of class group ids. False if match is disabled.
-    */
+    /**
+     * Get class groups this object's class belongs to if match for class groups is enabled, otherwise false
+     *
+     * @return array|bool
+     */
     function matchIngroupIDList()
     {
         $contentINI = eZINI::instance( 'content.ini' );
@@ -235,11 +236,14 @@ class eZContentObject extends eZPersistentObject
         return $inList;
     }
 
-    /*!
-     Store the object
-     \note Transaction unsafe. If you call several transaction unsafe methods you must enclose
-     the calls within a db transaction; thus within db->begin and db->commit.
-    */
+    /**
+     * Stores the object
+     *
+     * Transaction unsafe. If you call several transaction unsafe methods you must enclose
+     * the calls within a db transaction; thus within db->begin and db->commit.
+     *
+     * @param array $fieldFilters
+     */
     function store( $fieldFilters = null )
     {
         // Unset the cache
@@ -257,13 +261,13 @@ class eZContentObject extends eZPersistentObject
         $db->commit();
     }
 
-    /*!
-     Clear in-memory caches.
-     \param  $idArray  objects to clear caches for.
-
-     If the parameter is ommitted the caches are cleared for all objects.
-    */
-
+    /**
+     * Clear in-memory caches.
+     *
+     * If $idArray is ommitted, the caches are cleared for all objects.
+     *
+     * @param array $idArray Objects to clear caches for.
+     */
     static function clearCache( $idArray = array() )
     {
         if ( is_numeric( $idArray ) )
@@ -291,11 +295,12 @@ class eZContentObject extends eZPersistentObject
         }
     }
 
-    /*!
-     Update all nodes to set modified_subnode value
-     \note Transaction unsafe. If you call several transaction unsafe methods you must enclose
-     the calls within a db transaction; thus within db->begin and db->commit.
-    */
+    /**
+     * Update all nodes to set modified_subnode value
+     *
+     * Transaction unsafe. If you call several transaction unsafe methods you must enclose
+     * the calls within a db transaction; thus within db->begin and db->commit.
+     */
     function storeNodeModified()
     {
         if ( is_numeric( $this->ID ) )
@@ -312,6 +317,13 @@ class eZContentObject extends eZPersistentObject
         }
     }
 
+    /**
+     * Returns an object's name for the version given by $version in the language given by $lang
+     *
+     * @param int|bool $version If omitted, the current version will be used
+     * @param bool $lang If omitted, the initial object language will be used
+     * @return bool|string
+     */
     function name( $version = false , $lang = false )
     {
         // if the object id is null, we can't read data from the database
@@ -332,6 +344,11 @@ class eZContentObject extends eZPersistentObject
         return $this->versionLanguageName( $version, $lang );
     }
 
+    /**
+     * Returns all translations of the current object's name
+     *
+     * @return string[]
+     */
     function names()
     {
         $version = $this->attribute( 'current_version' );
@@ -348,6 +365,13 @@ class eZContentObject extends eZPersistentObject
         return $names;
     }
 
+    /**
+     * Returns the object name for version $version in the language $lang
+     *
+     * @param int $version
+     * @param string|bool $lang If omitted, the initial language of the object is used
+     * @return string|bool
+     */
     function versionLanguageName( $version, $lang = false )
     {
         $name = false;
@@ -423,19 +447,26 @@ class eZContentObject extends eZPersistentObject
         return $name;
     }
 
-    /*!
-     Sets the name of the object, in memory only. Use setName() to change it.
-    */
+    /**
+     * Sets the name of the object, in memory only. Use {@see setName()} to change it permanently
+     *
+     * @param string $name
+     */
     function setCachedName( $name )
     {
         $this->Name = $name;
     }
 
-    /*!
-     Sets the name of the object in all translations.
-     \note Transaction unsafe. If you call several transaction unsafe methods you must enclose
-     the calls within a db transaction; thus within db->begin and db->commit.
-    */
+    /**
+     * Sets the name of the object in all translations.
+     *
+     * Transaction unsafe. If you call several transaction unsafe methods you must enclose
+     * the calls within a db transaction; thus within db->begin and db->commit.
+     *
+     * @param string $objectName
+     * @param int|bool $versionNum
+     * @param int|bool $languageCode
+     */
     function setName( $objectName, $versionNum = false, $languageCode = false )
     {
         $initialLanguageCode = false;
@@ -500,10 +531,11 @@ class eZContentObject extends eZPersistentObject
         $db->commit();
     }
 
-    /*!
-     \return a map with all the content object attributes where the keys are the
-             attribute identifiers.
-    */
+    /**
+     * Return a map with all the content object attributes where the keys are the attribute identifiers.
+     *
+     * @return eZContentObjectAttribute[]
+     */
     function dataMap()
     {
         return $this->fetchDataMap();
@@ -513,7 +545,7 @@ class eZContentObject extends eZPersistentObject
      * Generates a map with all the content object attributes where the keys are
      * the attribute identifiers grouped by class attribute category.
      *
-     * @note Result is not cached, so make sure you don't call this over and over.
+     * Result is not cached, so make sure you don't call this over and over.
      *
      * @return array
      */
@@ -526,9 +558,9 @@ class eZContentObject extends eZPersistentObject
      * Generates a map with all the content object attributes where the keys are
      * the attribute identifiers grouped by class attribute category.
      *
-     * @note Result is not cached, so make sure you don't call this over and over.
+     * Result is not cached, so make sure you don't call this over and over.
      *
-     * @param array $contentObjectAttributes Array of eZContentObjectAttribute objects
+     * @param eZContentObjectAttribute[] $contentObjectAttributes Array of eZContentObjectAttribute objects
      * @return array
      */
     public static function createGroupedDataMap( $contentObjectAttributes )
@@ -554,11 +586,13 @@ class eZContentObject extends eZPersistentObject
         return $groupedDataMap;
     }
 
-    /*!
-     \return a map with all the content object attributes where the keys are the
-             attribute identifiers.
-     \sa eZContentObjectTreeNode::dataMap
-    */
+    /**
+     * Returns a map with all the content object attributes where the keys are the attribute identifiers.
+     *
+     * @param int|bool $version
+     * @param string|bool $language
+     * @return eZContentObjectAttribute[]
+     */
     function fetchDataMap( $version = false, $language = false )
     {
         // Global variable to cache datamaps
@@ -593,6 +627,7 @@ class eZContentObject extends eZPersistentObject
         if ( !isset( $this->DataMap[$version][$language] ) )
         {
             $ret = array();
+            /* @var eZContentObjectAttribute[] $data */
             foreach( $data as $key => $item )
             {
                 $identifier = $item->contentClassAttributeIdentifier();
@@ -607,6 +642,11 @@ class eZContentObject extends eZPersistentObject
         return $ret;
     }
 
+    /**
+     * Resets (empties) the current object's data map
+     *
+     * @return array
+     */
     function resetDataMap()
     {
         $this->ContentObjectAttributeArray = array();
@@ -615,9 +655,16 @@ class eZContentObject extends eZPersistentObject
         return $this->DataMap;
     }
 
-    /*!
-      Fetch a set of content object attributes by their class identifiers.
-    */
+    /**
+     * Fetches a set of content object attributes by their class identifiers.
+     *
+     * @param string[] $identifierArray
+     * @param int|bool $version
+     * @param string[]|bool $languageArray
+     * @param bool $asObject If true, returns an array of eZContentObjectAttributes, a normal array otherwise
+     *
+     * @return eZContentObjectAttribute[]|array|null
+     */
     function fetchAttributesByIdentifier( $identifierArray, $version = false, $languageArray = false, $asObject = true )
     {
         if ( count( $identifierArray ) === 0 )
@@ -700,9 +747,11 @@ class eZContentObject extends eZPersistentObject
         return null;
     }
 
-    /*!
-     Returns the owner of the object as a content object.
-    */
+    /**
+     * Returns the owner of the object as a content object.
+     *
+     * @return eZContentObject|null
+     */
     function owner()
     {
         if ( $this->OwnerID != 0 )
@@ -712,20 +761,24 @@ class eZContentObject extends eZPersistentObject
         return null;
     }
 
-    /*!
-     \return the content class group identifiers for the current content object
-    */
+    /**
+     * Returns the content class group identifiers for the current content object
+     *
+     * @return array
+     */
     function contentClassGroupIDList()
     {
         $contentClass = $this->contentClass();
         return $contentClass->attribute( 'ingroup_id_list' );
     }
 
-    /*!
-     \return the content class identifer for the current content object
-
-     \note The object will cache the class name information so multiple calls will be fast.
-    */
+    /**
+     * Returns the content class identifer for the current content object
+     *
+     * The object will cache the class name information so multiple calls will be fast.
+     *
+     * @return string|bool|null
+     */
     function contentClassIdentifier()
     {
         if ( !is_numeric( $this->ClassID ) )
@@ -742,9 +795,11 @@ class eZContentObject extends eZPersistentObject
         return $this->ClassIdentifier;
     }
 
-    /*!
-     \return the content class for the current content object
-    */
+    /**
+     * Returns the content class for the current content object
+     *
+     * @return eZContentClass|null
+     */
     function contentClass()
     {
         if ( !is_numeric( $this->ClassID ) )
@@ -756,9 +811,11 @@ class eZContentObject extends eZPersistentObject
         return eZContentClass::fetch( $this->ClassID );
     }
 
-    /*!
-     Get remote id of content object
-    */
+    /**
+     * Returns the remote id of the current content object
+     *
+     * @return string
+     */
     function remoteID()
     {
         $remoteID = $this->attribute( 'remote_id', true );
@@ -774,15 +831,24 @@ class eZContentObject extends eZPersistentObject
         return $remoteID;
     }
 
+    /**
+     * Returns the ID of the the current object's main node
+     *
+     * @return int|null
+     */
     function mainParentNodeID()
     {
         $list = eZContentObjectTreeNode::getParentNodeIdListByContentObjectID( $this->ID, false, true );
         return isset( $list[0] ) ? $list[0] : null;
     }
 
-    /*!
-     Fetches contentobject by remote ID, returns null if none exist
-    */
+    /**
+     * Returns a contentobject by remote ID
+     *
+     * @param string $remoteID
+     * @param bool $asObject
+     * @return eZContentObject|array|null
+     */
     static function fetchByRemoteID( $remoteID, $asObject = true )
     {
         $db = eZDB::instance();
@@ -797,9 +863,9 @@ class eZContentObject extends eZPersistentObject
 
     /**
      * Fetches a content object by ID
+     *
      * @param int $id ID of the content object to fetch
-     * @param bool $asObject
-     *        Return the result as an object (true) or an assoc. array (false)
+     * @param bool $asObject Return the result as an object (true) or an assoc. array (false)
      *
      * @return eZContentObject
      */
@@ -845,12 +911,12 @@ class eZContentObject extends eZPersistentObject
         }
     }
 
-    /*!
-     \static
-     Tests for the existance of a content object by using the ID \a $id.
-     \return \c true if the object exists, \c false otherwise.
-     \note Uses the static function createFetchSQLString() to generate the SQL
-    */
+    /**
+     * Returns true, if a content object with the ID $id exists, false otherwise
+     *
+     * @param int $id
+     * @return bool
+     */
     static function exists( $id )
     {
         global $eZContentObjectContentObjectCache;
@@ -873,10 +939,12 @@ class eZContentObject extends eZPersistentObject
 
     }
 
-    /*!
-      \static
-      Creates the SQL for fetching the object with ID \a $id and returns the string.
-    */
+    /**
+     * Creates the SQL for fetching the object with ID $id and returns the string.
+     *
+     * @param int $id
+     * @return string
+     */
     static function createFetchSQLString( $id )
     {
         $id = (int) $id;
@@ -900,7 +968,6 @@ class eZContentObject extends eZPersistentObject
      * Creates the SQL for filtering objects by visibility, used by IgnoreVisibility on some fetches.
      * The object is visible if 1 or more assigned nodes are visible.
      *
-     * @static
      * @since Version 4.1
      * @param bool $IgnoreVisibility ignores visibility if true
      * @param string $ezcontentobjectTable name of ezcontentobject table used in sql
@@ -915,10 +982,12 @@ class eZContentObject extends eZPersistentObject
 
     /**
      * Fetches the contentobject which has a node with ID $nodeID
+     *
      * $nodeID can also be an array of NodeIDs. In this case, an array of content objects will be returned
+     *
      * @param int|array $nodeID Single nodeID or array of NodeIDs
      * @param bool $asObject If results have to be returned as eZContentObject instances or not
-     * @return mixed Content object or array of content objects.
+     * @return eZContentObject|eZContentObject[]|array|null Content object or array of content objects.
      *               Content objects can be eZContentObject instances or array result sets
      */
     static function fetchByNodeID( $nodeID, $asObject = true )
@@ -974,7 +1043,7 @@ class eZContentObject extends eZPersistentObject
      * @param bool $asObject
      *        Wether to get the result as an array of eZContentObject or an
      *        array of associative arrays
-     * @param string $lang A language code to put at the top of the prioritized
+     * @param bool|string $lang A language code to put at the top of the prioritized
      *        languages list.
      *
      * @return array(contentObjectID => eZContentObject|array)
@@ -1025,14 +1094,15 @@ class eZContentObject extends eZPersistentObject
         return $objectRetArray;
     }
 
-    /*!
-     \return An array with content objects.
-     \param $asObject Whether to return objects or not
-     \param $conditions Optional conditions to limit the fetch, set to \c null to skip it.
-     \param $offset Where to start fetch from, set to \c false to skip it.
-     \param $limit Maximum number of objects to fetch, set \c false to skip it.
-     \sa fetchListCount
-    */
+    /**
+     * Returns an array of content objects.
+     *
+     * @param bool $asObject Whether to return objects or not
+     * @param array|null $conditions Optional conditions to limit the fetch
+     * @param int|bool $offset Where to start fetch from, set to false to skip it.
+     * @param int|bool $limit Maximum number of objects to fetch, set false to skip it.
+     * @return eZContentObject[]|array|null
+     */
     static function fetchList( $asObject = true, $conditions = null, $offset = false, $limit = false )
     {
         $limitation = null;
@@ -1046,6 +1116,15 @@ class eZContentObject extends eZPersistentObject
                                                     $asObject );
     }
 
+    /**
+     * Returns a filtered array of content objects.
+     *
+     * @param array|null $conditions Optional conditions to limit the fetch
+     * @param int|bool $offset Where to start fetch from, set to false to skip it.
+     * @param int|bool $limit Maximum number of objects to fetch, set false to skip it.
+     * @param bool $asObject Whether to return objects or not
+     * @return array|eZPersistentObject[]|null
+     */
     static function fetchFilteredList( $conditions = null, $offset = false, $limit = false, $asObject = true )
     {
         $limits = null;
@@ -1058,10 +1137,11 @@ class eZContentObject extends eZPersistentObject
                                                     $asObject );
     }
 
-    /*!
-     \return The number of objects in the database. Optionally \a $conditions can be used to limit the list count.
-     \sa fetchList
-    */
+    /**
+     * Returns the number of objects in the database. Optionally \a $conditions can be used to limit the list count.
+     * @param array|null $conditions
+     * @return int
+     */
     static function fetchListCount( $conditions = null )
     {
         $rows =  eZPersistentObject::fetchObjectList( eZContentObject::definition(),
@@ -1075,12 +1155,28 @@ class eZContentObject extends eZPersistentObject
         return $rows[0]['count'];
     }
 
+    /**
+     * Returns an array of content objects with the content class id $contentClassID
+     *
+     * @param int $contentClassID
+     * @param bool $asObject Whether to return objects or not
+     * @param int|bool $offset Where to start fetch from, set to false to skip it.
+     * @param int|bool $limit Maximum number of objects to fetch, set false to skip it.
+
+     * @return eZContentObject[]|array|null
+     */
     static function fetchSameClassList( $contentClassID, $asObject = true, $offset = false, $limit = false )
     {
         $conditions = array( 'contentclass_id' => $contentClassID );
         return eZContentObject::fetchFilteredList( $conditions, $offset, $limit, $asObject );
     }
 
+    /**
+     * Returns the number of content objects with the content class id $contentClassID
+     *
+     * @param int $contentClassID
+     * @return int
+     */
     static function fetchSameClassListCount( $contentClassID )
     {
         $result = eZPersistentObject::fetchObjectList( eZContentObject::definition(),
@@ -1093,17 +1189,24 @@ class eZContentObject extends eZPersistentObject
         return $result[0]['count'];
     }
 
-    /*!
-      Returns the current version of this document.
-    */
+    /**
+     * Returns the current version of this document.
+     *
+     * @param bool $asObject If true, returns an eZContentObjectVersion; if false, returns an array
+     * @return eZContentObjectVersion|array|bool
+     */
     function currentVersion( $asObject = true )
     {
         return eZContentObjectVersion::fetchVersion( $this->attribute( "current_version" ), $this->ID, $asObject );
     }
 
-    /*!
-      Returns the given object version. False is returned if the versions does not exist.
-    */
+    /**
+     * Returns the given object version. False is returned if the versions does not exist.
+     *
+     * @param int $version
+     * @param bool $asObject If true, returns an eZContentObjectVersion; if false, returns an array
+     * @return eZContentObjectVersion|array|bool
+     */
     function version( $version, $asObject = true )
     {
         if ( $asObject )
@@ -1130,12 +1233,11 @@ class eZContentObject extends eZPersistentObject
     }
 
     /**
-     * Returns an array of eZContentObjectVersion for the current object
-     * according to the conditions in $parameters.
+     * Returns an array of eZContentObjectVersion for the current object according to the conditions in $parameters.
      *
-     * @param boolean $asObject
+     * @param bool $asObject If true, returns an eZContentObjectVersion; if false, returns an array
      * @param array $parameters
-     * @return array
+     * @return eZContentObjectVersion[]|array
      */
     function versions( $asObject = true, $parameters = array() )
     {
@@ -1164,9 +1266,11 @@ class eZContentObject extends eZPersistentObject
                                                     $asObject );
     }
 
-    /*!
-     \return \c true if the object has any versions remaining.
-    */
+    /**
+     * Returns true if the object has any versions remaining.
+     *
+     * @return bool
+     */
     function hasRemainingVersions()
     {
         $remainingVersions = $this->versions( false );
@@ -1178,25 +1282,48 @@ class eZContentObject extends eZPersistentObject
         return true;
     }
 
+    /**
+     * Creates an initial content object version
+     *
+     * @param int $userID
+     * @param string|bool $initialLanguageCode
+     * @return eZContentObjectVersion
+     */
     function createInitialVersion( $userID, $initialLanguageCode = false )
     {
         return eZContentObjectVersion::create( $this->attribute( "id" ), $userID, 1, $initialLanguageCode );
     }
 
+    /**
+     * Creates a new version for the language $languageCode
+     *
+     * @param string $languageCode
+     * @param bool $copyFromLanguageCode
+     * @param int|bool $copyFromVersion
+     * @param bool $versionCheck
+     * @param int $status
+     *
+     * @return eZContentObjectVersion
+     */
     function createNewVersionIn( $languageCode, $copyFromLanguageCode = false, $copyFromVersion = false, $versionCheck = true, $status = eZContentObjectVersion::STATUS_DRAFT )
     {
         return $this->createNewVersion( $copyFromVersion, $versionCheck, $languageCode, $copyFromLanguageCode, $status );
     }
 
-    /*!
-     Creates a new version and returns it as an eZContentObjectVersion object.
-     If version number is given as argument that version is used to create a copy.
-     \param $versionCheck If \c true it will check if there are too many version and
-                          remove some of them to make room for a new.
-
-     \note Transaction unsafe. If you call several transaction unsafe methods you must enclose
-     the calls within a db transaction; thus within db->begin and db->commit.
-    */
+    /**
+     * Creates a new version and returns it as an eZContentObjectVersion object.
+     *
+     * Transaction unsafe. If you call several transaction unsafe methods you must enclose
+     * the calls within a db transaction; thus within db->begin and db->commit.
+     *
+     * @param int|bool $copyFromVersion If given, that version is used to create a copy.
+     * @param bool $versionCheck If \c true it will check if there are too many version and remove some of them to make room for a new.
+     * @param string|bool $languageCode
+     * @param string|bool $copyFromLanguageCode
+     * @param int $status
+     *
+     * @return eZContentObjectVersion
+     */
     function createNewVersion( $copyFromVersion = false, $versionCheck = true, $languageCode = false, $copyFromLanguageCode = false, $status = eZContentObjectVersion::STATUS_DRAFT )
     {
         $db = eZDB::instance();
@@ -1289,15 +1416,24 @@ class eZContentObject extends eZPersistentObject
         return $copiedVersion;
     }
 
-    /*!
-     Creates a new version and returns it as an eZContentObjectVersion object.
-     If version number is given as argument that version is used to create a copy.
-     \param $languageCode If \c false all languages will be copied, otherwise
-                          only specified by the locale code string or an array
-                          of the locale code strings.
-     \note Transaction unsafe. If you call several transaction unsafe methods you must enclose
-     the calls within a db transaction; thus within db->begin and db->commit.
-    */
+    /**
+     * Creates a new version and returns it as an eZContentObjectVersion object.
+     *
+     * If version number is given as argument that version is used to create a copy.
+     *
+     * Transaction unsafe. If you call several transaction unsafe methods you must enclose
+     * the calls within a db transaction; thus within db->begin and db->commit.
+     *
+     * @param eZContentObject $newObject
+     * @param eZContentObjectVersion $version
+     * @param int $newVersionNumber
+     * @param int|bool $contentObjectID
+     * @param int $status
+     * @param string|bool $languageCode If false all languages will be copied, otherwise only specified by the locale code string or an array of the locale code strings.
+     * @param string|bool $copyFromLanguageCode
+     *
+     * @return eZContentObjectVersion
+     */
     function copyVersion( &$newObject, &$version, $newVersionNumber, $contentObjectID = false, $status = eZContentObjectVersion::STATUS_DRAFT, $languageCode = false, $copyFromLanguageCode = false )
     {
         $user = eZUser::currentUser();
@@ -1419,9 +1555,17 @@ class eZContentObject extends eZPersistentObject
         return $clonedVersion;
     }
 
-    /*!
-     Creates a new content object instance and stores it.
-    */
+    /**
+     * Creates a new content object instance and stores it.
+     *
+     * @param string $name
+     * @param int $contentclassID
+     * @param int $userID
+     * @param int $sectionID
+     * @param int $version
+     * @param string|bool $languageCode
+     * @return eZContentObject
+     */
     static function create( $name, $contentclassID, $userID, $sectionID = 1, $version = 1, $languageCode = false )
     {
         if ( $languageCode == false )
@@ -1447,6 +1591,9 @@ class eZContentObject extends eZPersistentObject
         return new eZContentObject( $row );
     }
 
+    /**
+     * Resets certain attributes of the content object on clone and resets the data map
+     */
     function __clone()
     {
         $this->setAttribute( 'id', null );
@@ -1455,11 +1602,15 @@ class eZContentObject extends eZPersistentObject
         $this->resetDataMap();
     }
 
-    /*!
-     Makes a copy of the object which is stored and then returns it.
-     \note Transaction unsafe. If you call several transaction unsafe methods you must enclose
-     the calls within a db transaction; thus within db->begin and db->commit.
-    */
+    /**
+     * Makes a copy of the object which is stored and then returns it.
+     *
+     * Transaction unsafe. If you call several transaction unsafe methods you must enclose
+     * the calls within a db transaction; thus within db->begin and db->commit.
+     *
+     * @param bool $allVersions If true, all versions are copied. If false, only the latest version is copied
+     * @return eZContentObject
+     */
     function copy( $allVersions = true )
     {
         eZDebugSetting::writeDebug( 'kernel-content-object-copy', 'Copy start, all versions=' . ( $allVersions ? 'true' : 'false' ), 'copy' );
@@ -1557,11 +1708,17 @@ class eZContentObject extends eZPersistentObject
         return $contentObject;
     }
 
-    /*!
-     Copies the given version of the object and creates a new current version.
-     \note Transaction unsafe. If you call several transaction unsafe methods you must enclose
-     the calls within a db transaction; thus within db->begin and db->commit.
-    */
+    /**
+     * Copies the given version of the object and creates a new current version.
+     *
+     * Transaction unsafe. If you call several transaction unsafe methods you must enclose
+     * the calls within a db transaction; thus within db->begin and db->commit.
+     *
+     * @param int $version
+     * @param string|bool $language
+     *
+     * @return int The new version number
+     */
     function copyRevertTo( $version, $language = false )
     {
         $versionObject = $this->createNewVersionIn( $language, false, $version );
@@ -1569,6 +1726,14 @@ class eZContentObject extends eZPersistentObject
         return $versionObject->attribute( 'version' );
     }
 
+    /**
+     * Fixes reverse relations
+     *
+     * @see eZObjectRelationListType::fixRelatedObjectItem()
+     *
+     * @param int $objectID
+     * @param string|bool $mode See eZObjectRelationListType::fixRelatedObjectItem() for valid modes
+     */
     static function fixReverseRelations( $objectID, $mode = false )
     {
         $db = eZDB::instance();
@@ -1597,12 +1762,12 @@ class eZContentObject extends eZPersistentObject
         }
     }
 
-    /*!
-      If nodeID is not given, this function will remove object from database. All versions and translations of this object will be lost.
-      Otherwise, it will check node assignment and only delete the object from this node if it was assigned to other nodes as well.
-      \note Transaction unsafe. If you call several transaction unsafe methods you must enclose
-     the calls within a db transaction; thus within db->begin and db->commit.
-    */
+    /**
+     * Deletes the current object, all versions and translations, and corresponding tree nodes from the database
+     *
+     * Transaction unsafe. If you call several transaction unsafe methods you must enclose
+     * the calls within a db transaction; thus within db->begin and db->commit.
+     */
     function purge()
     {
         $delID = $this->ID;
@@ -1733,9 +1898,13 @@ class eZContentObject extends eZPersistentObject
         $db->commit();
     }
 
-    /*!
-     \note Transaction unsafe. If you call several transaction unsafe methods you must enclose
-     the calls within a db transaction; thus within db->begin and db->commit.
+    /**
+     * Archives the current object and removes assigned nodes
+     *
+     * Transaction unsafe. If you call several transaction unsafe methods you must enclose
+     * the calls within a db transaction; thus within db->begin and db->commit.
+     *
+     * @param int $nodeID
      */
     function removeThis( $nodeID = null )
     {
@@ -1814,12 +1983,13 @@ class eZContentObject extends eZPersistentObject
         }
     }
 
-    /*!
-     Removes old internal drafts by the specified user associated with this content object.
-     Only internal drafts older than 1 day will be considered.
-     \param $userID The ID of the user to cleanup for, if \c false it will use the current user.
+    /**
+     * Removes old internal drafts by the specified user associated for the past time span given by $timeDuration
+     *
+     * @param int|bool $userID The ID of the user to cleanup for, if false it will use the current user.
+     * @param int $timeDuration default time duration for internal drafts 60*60*24 seconds (1 day)
      */
-    function cleanupInternalDrafts( $userID = false, $timeDuration = 86400 ) // default time duration for internal drafts 60*60*24 seconds (1 day)
+    function cleanupInternalDrafts( $userID = false, $timeDuration = 86400 )
     {
         if ( !is_numeric( $timeDuration ) ||
              $timeDuration < 0 )
@@ -1846,13 +2016,13 @@ class eZContentObject extends eZPersistentObject
         }
     }
 
-    /*!
-     \static
-     Removes all old internal drafts by the specified user.
-     Only internal drafts older than 1 day will be considered.
-     \param $userID The ID of the user to cleanup for, if \c false it will use the current user.
+    /**
+     * Removes all old internal drafts by the specified user for the past time span given by $timeDuration
+     *
+     * @param int|bool $userID The ID of the user to cleanup for, if false it will use the current user.
+     * @param int $timeDuration default time duration for internal drafts 60*60*24 seconds (1 day)
      */
-    static function cleanupAllInternalDrafts( $userID = false, $timeDuration = 86400 ) // default time duration for internal drafts 60*60*24 seconds (1 day)
+    static function cleanupAllInternalDrafts( $userID = false, $timeDuration = 86400 ) //
     {
         if ( !is_numeric( $timeDuration ) ||
              $timeDuration < 0 )
@@ -1884,8 +2054,7 @@ class eZContentObject extends eZPersistentObject
      *
      * @param int $contentObjectID
      * @param bool $asObject
-     * @param array|null $limit the limit array passed to
-     *        eZPersistentObject::fetchObjectList
+     * @param array|null $limit the limit array passed to {@see eZPersistentObject::fetchObjectList}
      * @return eZContentObjectAttribute[]|array|null
      */
     function allContentObjectAttributes( $contentObjectID, $asObject = true, $limit = null )
@@ -1898,12 +2067,20 @@ class eZContentObject extends eZPersistentObject
                                                     $asObject );
     }
 
-    /*!
-      Fetches the attributes for the current published version of the object.
-      TODO: fix using of $asObject parameter,
-            fix condition for getting attribute from cache,
-            probably need to move method to eZContentObjectVersion class
-    */
+    /**
+     * Fetches the attributes for the current published version of the object.
+     *
+     * @todo fix using of $asObject parameter
+     * @todo fix condition for getting attribute from cache
+     * @todo probably need to move method to eZContentObjectVersion class
+     *
+     * @param bool $asObject
+     * @param int|bool $version
+     * @param string|bool $language
+     * @param int|bool $contentObjectAttributeID
+     * @param bool $distinctItemsOnly
+     * @return eZContentObjectAttribute[]|array
+     */
     function contentObjectAttributes( $asObject = true, $version = false, $language = false, $contentObjectAttributeID = false, $distinctItemsOnly = false )
     {
         $db = eZDB::instance();
@@ -1986,20 +2163,24 @@ class eZContentObject extends eZPersistentObject
         return $returnAttributeArray;
     }
 
-    /*!
-     Initializes the cached copy of the content object attributes for the given version and language
-    */
+    /**
+     * Initializes the cached copy of the content object attributes for the given version and language
+     *
+     * @param eZContentObjectAttribute[] $attributes
+     * @param int $version
+     * @param string $language
+     */
     function setContentObjectAttributes( &$attributes, $version, $language )
     {
         $this->ContentObjectAttributes[$version][$language] = $attributes;
     }
 
-    /*!
-      \static
-      Fetches the attributes for an array of objects. The objList parameter
-      contains an array of objects ( instanceOf eZContentObject or a object that is or
-      extends eZContentObjectTreeNode ) to fetch attributes from.
-    */
+    /**
+     * Fetches the attributes for an array of objects or nodes
+     *
+     * @param eZContentObject[]|eZContentObjectTreeNode[] $objList
+     * @param bool $asObject
+     */
     static function fillNodeListAttributes( $objList, $asObject = true )
     {
         $db = eZDB::instance();
@@ -2074,12 +2255,19 @@ class eZContentObject extends eZPersistentObject
         }
     }
 
+    /**
+     * Resets the object's input relation list
+     */
     function resetInputRelationList()
     {
         $this->InputRelationList = array( eZContentObject::RELATION_EMBED => array(),
                                           eZContentObject::RELATION_LINK =>  array() );
     }
 
+    /**
+     * @param int[] $addingIDList
+     * @param int $relationType
+     */
     function appendInputRelationList( $addingIDList, $relationType )
     {
         if ( !is_array( $addingIDList ) )
@@ -2105,6 +2293,10 @@ class eZContentObject extends eZPersistentObject
         }
     }
 
+    /**
+     * @param int|bool $editVersion
+     * @return bool
+     */
     function commitInputRelations( $editVersion )
     {
         foreach ( $this->InputRelationList as $relationType => $relatedObjectIDArray )
@@ -2129,6 +2321,13 @@ class eZContentObject extends eZPersistentObject
         return true;
     }
 
+    /**
+     * @param eZContentObjectAttribute[] $contentObjectAttributes
+     * @param string $attributeDataBaseName
+     * @param array|bool $inputParameters
+     * @param array $parameters
+     * @return array
+     */
     function validateInput( $contentObjectAttributes, $attributeDataBaseName,
                             $inputParameters = false, $parameters = array() )
     {
@@ -2252,6 +2451,10 @@ class eZContentObject extends eZPersistentObject
         return $result;
     }
 
+    /**
+     * @param eZContentObjectAttribute[] $contentObjectAttributes
+     * @param string $attributeDataBaseName
+     */
     function fixupInput( $contentObjectAttributes, $attributeDataBaseName )
     {
         $http = eZHTTPTool::instance();
@@ -2261,6 +2464,13 @@ class eZContentObject extends eZPersistentObject
         }
     }
 
+    /**
+     * @param eZContentObjectAttribute[] $contentObjectAttributes
+     * @param string $attributeDataBaseName
+     * @param array $customActionAttributeArray
+     * @param array $customActionParameters
+     * @return array
+     */
     function fetchInput( $contentObjectAttributes, $attributeDataBaseName,
                          $customActionAttributeArray, $customActionParameters )
     {
@@ -2320,6 +2530,12 @@ class eZContentObject extends eZPersistentObject
         return $result;
     }
 
+    /**
+     * @param eZContentObjectAttribute $contentObjectAttribute
+     * @param string $attributeDataBaseName
+     * @param array $customActionAttributeArray
+     * @param array $customActionParameters
+     */
     function handleCustomHTTPActions( $contentObjectAttribute, $attributeDataBaseName,
                                       $customActionAttributeArray, $customActionParameters )
     {
@@ -2336,6 +2552,12 @@ class eZContentObject extends eZPersistentObject
                                                           $customActionAttributeArray, $customActionParameters );
     }
 
+    /**
+     * @param string $attributeDataBaseName
+     * @param array $customActionAttributeArray
+     * @param array $customActionParameters
+     * @param int|bool $objectVersion
+     */
     function handleAllCustomHTTPActions( $attributeDataBaseName,
                                          $customActionAttributeArray, $customActionParameters,
                                          $objectVersion = false )
@@ -2359,11 +2581,18 @@ class eZContentObject extends eZPersistentObject
         $customActionParameters['base_name'] = $oldAttributeDataBaseName;
     }
 
+    /**
+     *
+     */
     static function recursionProtectionStart()
     {
         $GLOBALS["ez_content_object_recursion_protect"] = array();
     }
 
+    /**
+     * @param int $id
+     * @return bool
+     */
     static function recursionProtect( $id )
     {
         if ( isset( $GLOBALS["ez_content_object_recursion_protect"][$id] ) )
@@ -2377,14 +2606,20 @@ class eZContentObject extends eZPersistentObject
         }
     }
 
+    /**
+     *
+     */
     static function recursionProtectionEnd()
     {
         unset( $GLOBALS["ez_content_object_recursion_protect"] );
     }
 
-    /*!
-     \note Transaction unsafe. If you call several transaction unsafe methods you must enclose
-     the calls within a db transaction; thus within db->begin and db->commit.
+    /**
+     * Transaction unsafe. If you call several transaction unsafe methods you must enclose
+     * the calls within a db transaction; thus within db->begin and db->commit.
+     *
+     * @param eZContentObjectAttribute[] $contentObjectAttributes
+     * @param array $attributeInputMap
      */
     function storeInput( $contentObjectAttributes,
                          $attributeInputMap )
@@ -2402,9 +2637,11 @@ class eZContentObject extends eZPersistentObject
         unset( $this->ContentObjectAttributes );
     }
 
-    /*!
-     Returns the next available version number for this object.
-    */
+    /**
+     * Returns the next available version number for this object.
+     *
+     * @return int
+     */
     function nextVersion()
     {
         $db = eZDB::instance();
@@ -2414,9 +2651,11 @@ class eZContentObject extends eZPersistentObject
 
     }
 
-    /*!
-     Returns the previous available version number for this object, if existing, false otherwise ( if the object has only one version )
-    */
+    /**
+     * Returns the previous available version number for this object, if existing, false otherwise ( if the object has only one version )
+     *
+     * @return int|bool
+     */
     function previousVersion()
     {
         $db = eZDB::instance();
@@ -2433,9 +2672,11 @@ class eZContentObject extends eZPersistentObject
         }
     }
 
-    /*!
-     Returns number of exist versions.
-    */
+    /**
+     * Returns the number of existing versions.
+     *
+     * @return mixed
+     */
     function getVersionCount()
     {
         $db = eZDB::instance();
@@ -2445,11 +2686,21 @@ class eZContentObject extends eZPersistentObject
 
     }
 
+    /**
+     * Returns the current object's language
+     *
+     * @return bool|string
+     */
     function currentLanguage()
     {
         return $this->CurrentLanguage;
     }
 
+    /**
+     * Returns the language object of the current object's language
+     *
+     * @return eZContentLanguage|bool|
+     */
     function currentLanguageObject()
     {
         if ( $this->CurrentLanguage )
@@ -2464,17 +2715,32 @@ class eZContentObject extends eZPersistentObject
         return $language;
     }
 
+    /**
+     * Sets the current object's language and resets the name
+     *
+     * @param string $lang
+     */
     function setCurrentLanguage( $lang )
     {
         $this->CurrentLanguage = $lang;
         $this->Name = null;
     }
 
+    /**
+     * Returns the current object's initial language object, or false if not set
+     *
+     * @return eZContentLanguage|bool
+     */
     function initialLanguage()
     {
         return isset( $this->InitialLanguageID ) ? eZContentLanguage::fetch( $this->InitialLanguageID ) : false;
     }
 
+    /**
+     * Returns the current object's initial language code, or false if not set
+     *
+     * @return string|bool
+     */
     function initialLanguageCode()
     {
         $initialLanguage = $this->initialLanguage();
@@ -2482,13 +2748,17 @@ class eZContentObject extends eZPersistentObject
         return ( $initialLanguage !== false ) ?  $initialLanguage->attribute( 'locale' ) : false;
     }
 
-    /*!
-     Adds a new location (node) to the current object.
-     \param $parenNodeID The id of the node to use as parent.
-     \param $asObject    If true it will return the new child-node as an object, if not it returns the ID.
-     \note Transaction unsafe. If you call several transaction unsafe methods you must enclose
-      the calls within a db transaction; thus within db->begin and db->commit.
-      */
+    /**
+     * Adds a new location (node) to the current object.
+     *
+     * Transaction unsafe. If you call several transaction unsafe methods you must enclose
+     * the calls within a db transaction; thus within db->begin and db->commit.
+     *
+     * @param int $parentNodeID The id of the node to use as parent.
+     * @param bool $asObject If true it will return the new child-node as an object, if not it returns the ID.
+     *
+     * @return eZContentObjectTreeNode|int
+     */
     function addLocation( $parentNodeID, $asObject = false )
     {
         $node = eZContentObjectTreeNode::addChildTo( $this->ID, $parentNodeID, true, $this->CurrentVersion );
@@ -2511,11 +2781,18 @@ class eZContentObject extends eZPersistentObject
         }
     }
 
-    /*!
-     Adds a link to the given content object id.
-     \note Transaction unsafe. If you call several transaction unsafe methods you must enclose
-     the calls within a db transaction; thus within db->begin and db->commit.
-    */
+    /**
+     * Adds a link to the given content object id.
+     *
+     * Transaction unsafe. If you call several transaction unsafe methods you must enclose
+     * the calls within a db transaction; thus within db->begin and db->commit.
+     *
+     * @param int $toObjectID
+     * @param int|bool $fromObjectVersion
+     * @param int $attributeID
+     * @param int $relationType
+     * @return bool|void
+     */
     function addContentObjectRelation( $toObjectID,
                                        $fromObjectVersion = false,
                                        $attributeID = 0,
@@ -2586,17 +2863,21 @@ class eZContentObject extends eZPersistentObject
         }
     }
 
-    /*!
-     Removes a link to the given content object id.
-     \param $toObjectID If \c false it will delete relations to all the objects.
-     \param $attributeID ID of class attribute.
-                         IF it is > 0 we remove relations created by a specific objectrelation[list] attribute.
-                         If it is set to 0 we remove relations created without using of objectrelation[list] attribute.
-                         If it is set to false, we remove all relations, no matter how were they created:
-                         using objectrelation[list] attribute or using "Add related objects" functionality in obect editing mode.
-     \note Transaction unsafe. If you call several transaction unsafe methods you must enclose
-     the calls within a db transaction; thus within db->begin and db->commit.
-    */
+    /**
+     * Removes a link to the given content object id.
+     *
+     * Transaction unsafe. If you call several transaction unsafe methods you must enclose
+     * the calls within a db transaction; thus within db->begin and db->commit.
+     *
+     * @param int|bool $toObjectID If false it will delete relations to all the objects.
+     * @param bool $fromObjectVersion
+     * @param int $attributeID  ID of class attribute.
+     *                          If it is > 0 we remove relations created by a specific objectrelation[list] attribute.
+     *                          If it is set to 0 we remove relations created without using of objectrelation[list] attribute.
+     *                          If it is set to false, we remove all relations, no matter how were they created:
+     *                          using objectrelation[list] attribute or using "Add related objects" functionality in obect editing mode.
+     * @param int $relationType
+     */
     function removeContentObjectRelation( $toObjectID = false, $fromObjectVersion = false, $attributeID = 0, $relationType = eZContentObject::RELATION_COMMON )
     {
         $db = eZDB::instance();
@@ -2670,6 +2951,11 @@ class eZContentObject extends eZPersistentObject
         $db->commit();
     }
 
+    /**
+     * @param int $currentVersion
+     * @param int $newVersion
+     * @param int|bool $newObjectID
+     */
     function copyContentObjectRelations( $currentVersion, $newVersion, $newObjectID = false )
     {
         $objectID = $this->ID;
@@ -2700,6 +2986,9 @@ class eZContentObject extends eZPersistentObject
         $db->commit();
     }
 
+    /**
+     * @return bool
+     */
     static function isObjectRelationTyped()
     {
         $siteIni = eZINI::instance( 'site.ini' );
@@ -2713,6 +3002,10 @@ class eZContentObject extends eZPersistentObject
         return false;
     }
 
+    /**
+     * @param bool $allRelations
+     * @return int
+     */
     static function relationTypeMask( $allRelations = false )
     {
         $relationTypeMask = eZContentObject::RELATION_COMMON |
@@ -2731,29 +3024,44 @@ class eZContentObject extends eZPersistentObject
         return $relationTypeMask;
     }
 
-    /*!
-     Returns the related or reverse related objects:
-     \param $attributeID :  ( makes sense only when $params['AllRelations'] not set or eZContentObject::RELATION_ATTRIBUTE )
-                            >0              - return relations made with attribute ID ( "related object(s)" datatype )
-                            0 or false  ( $params['AllRelations'] is eZContentObject::RELATION_ATTRIBUTE )
-                                            - return relations made with any attributes
-                            false       ( $params['AllRelations'] not set )
-                                            - return ALL relations (deprecated, use "$params['AllRelations'] = true" instead)
-     \param $groupByAttribute : false - return all relations as an array of content objects
-                                true  - return all relations groupped by attribute ID
-                                This parameter makes sense only when $attributeID == false or $params['AllRelations'] = true
-     \param $params : other parameters from template fetch function :
-                $params['AllRelations']     - relation type filter :
-                            true    - return ALL relations, including attribute-level
-                            false   - return object-level relations
-                            >0      - bit mask of EZ_CONTENT_OBJECT_RELATION_* values
-                $params['SortBy']           - related objects sorting mode.
-                            Supported modes: class_identifier, class_name, modified, name, published, section
-                $params['IgnoreVisibility'] - ignores 'hidden' state of related objects if true
-                $params['RelatedClassIdentifiers'] - limit returned relations to objects of the specified class identifiers
-     \param $reverseRelatedObjects : if "true" returns reverse related contentObjects
-                                     if "false" returns related contentObjects
-    */
+    /**
+     * Returns related or reverse related objects
+     *
+     * @param int|bool $fromObjectVersion   If omitted, the current version will be used
+     * @param int|bool $objectID        If omitted, the current object will be used
+     * @param int|bool $attributeID     makes sense only when $params['AllRelations'] not set or eZContentObject::RELATION_ATTRIBUTE
+     *                                  $attributeID = 0|false ( $params['AllRelations'] is eZContentObject::RELATION_ATTRIBUTE )
+     *                                      - return relations made with any attributes
+     *                                  $attributeID > 0
+     *                                      - return relations made with attribute ID ( "related object(s)" datatype )
+     *                                  $attributeID = false ( $params['AllRelations'] not set )
+     *                                      - return ALL relations (deprecated, use "$params['AllRelations'] = true" instead)
+     * @param bool $groupByAttribute    This parameter makes sense only when $attributeID == false or $params['AllRelations'] = true
+     *                                  $groupByAttribute = false
+     *                                      - return all relations as an array of content objects
+     *                                  $groupByAttribute = true
+     *                                      - return all relations groupped by attribute ID
+     * @param array|bool $params        Other parameters from template fetch function
+     *                                  $params['AllRelations'] = true
+     *                                      - return ALL relations, including attribute-level
+     *                                  $params['AllRelations'] = false
+     *                                      - return objec level relations only
+     *                                  $params['AllRelations'] = int > 0
+     *                                      - bit mask of EZ_CONTENT_OBJECT_RELATION_* values
+     *                                  $params['SortBy']
+     *                                      - Possible values:
+     *                                          "class_identifier", "class_name", "modified",
+     *                                          "name", "published", "section"
+     *                                  $params['IgnoreVisibility'] = true
+     *                                      - Include related objects with a 'hidden' state
+     *                                  $params['IgnoreVisibility'] = false
+     *                                      - Exclude related objects with a 'hidden' state
+     *                                  $params['RelatedClassIdentifiers'] = array
+     *                                      - limit returned relations to objects of the specified class identifiers
+     * @param bool $reverseRelatedObjects   true -> returns reverse related objects
+     *                                      false -> returns related objects
+     * @return eZContentObject[]|array eZContentObject[], if $params['AsObject'] is set to true (default), array otherwise
+     */
     function relatedObjects( $fromObjectVersion = false,
                              $objectID = false,
                              $attributeID = 0,
@@ -2947,27 +3255,18 @@ class eZContentObject extends eZPersistentObject
         return $ret;
     }
 
-    /*!
-     Returns the related objects.
-    \param $attributeID :  ( makes sense only when $params['AllRelations'] not set or eZContentObject::RELATION_ATTRIBUTE )
-                           >0           - return relations made with attribute ID ( "related object(s)" datatype )
-                           0 or false  ( $params['AllRelations'] is eZContentObject::RELATION_ATTRIBUTE )
-                                           - return relations made with any attributes
-                           false        ( $params['AllRelations'] not set )
-                                           - return ALL relations (deprecated, use "$params['AllRelations'] = true" instead)
-    \param $groupByAttribute : false - return all relations as an array of content objects
-                               true  - return all relations groupped by attribute ID
-                               This parameter makes sense only when $attributeID == false or $params['AllRelations'] = true
-    \param $params : other parameters from template fetch function :
-               $params['AllRelations'] - relation type filter :
-                           true - return ALL relations, including attribute-level
-                           false    - return object-level relations
-                           >0       - bit mask of EZ_CONTENT_OBJECT_RELATION_* values
-                $params['SortBy']           - related objects sorting mode.
-                            Supported modes: class_identifier, class_name, modified, name, published, section
-                $params['IgnoreVisibility'] - ignores 'hidden' state of related objects if true
-                $params['RelatedClassIdentifiers'] - limit returned relations to objects of the specified class identifiers
-    */
+    /**
+     * Returns related objects.
+     *
+     * @see relatedObjects()
+     *
+     * @param int|bool $fromObjectVersion
+     * @param int|bool $fromObjectID
+     * @param int|bool $attributeID
+     * @param bool $groupByAttribute
+     * @param array|bool $params
+     * @return array|eZContentObject[]
+     */
     function relatedContentObjectList( $fromObjectVersion = false,
                                        $fromObjectID = false,
                                        $attributeID = 0,
@@ -2978,9 +3277,15 @@ class eZContentObject extends eZPersistentObject
         return $this->relatedObjects( $fromObjectVersion, $fromObjectID, $attributeID, $groupByAttribute, $params );
     }
 
-    /*!
-     Returns the xml-linked objects.
-    */
+    /**
+     * Returns the xml-linked objects.
+     *
+     * @see relatedObjects()
+     *
+     * @param int|bool $fromObjectVersion
+     * @param int|bool $fromObjectID
+     * @return array|eZContentObject[]
+     */
     function linkedContentObjectList( $fromObjectVersion = false, $fromObjectID = false )
     {
         return $this->relatedObjects( $fromObjectVersion,
@@ -2990,9 +3295,15 @@ class eZContentObject extends eZPersistentObject
                                       array( 'AllRelations' => eZContentObject::RELATION_LINK ) );
     }
 
-    /*!
-     Returns the xml-embedded objects.
-    */
+    /**
+     * Returns the xml-embedded objects.
+     *
+     * @see relatedObjects()
+     *
+     * @param int|bool $fromObjectVersion
+     * @param int|bool $fromObjectID
+     * @return array|eZContentObject[]
+     */
     function embeddedContentObjectList( $fromObjectVersion = false, $fromObjectID = false )
     {
         return $this->relatedObjects( $fromObjectVersion,
@@ -3002,9 +3313,15 @@ class eZContentObject extends eZPersistentObject
                                       array( 'AllRelations' => eZContentObject::RELATION_EMBED ) );
     }
 
-    /*!
-     Returns the reverse xml-linked objects.
-    */
+    /**
+     * Returns the reverse xml-linked objects.
+     *
+     * @see relatedObjects()
+     *
+     * @param int|bool $fromObjectVersion
+     * @param int|bool $fromObjectID
+     * @return array|eZContentObject[]
+     */
     function reverseLinkedObjectList( $fromObjectVersion = false, $fromObjectID = false )
     {
         return $this->relatedObjects( $fromObjectVersion,
@@ -3015,9 +3332,15 @@ class eZContentObject extends eZPersistentObject
                                       true );
     }
 
-    /*!
-     Returns the reverse xml-embedded objects.
-    */
+    /**
+     * Returns the reverse xml-embedded objects.
+     *
+     * @see relatedObjects()
+     *
+     * @param int|bool $fromObjectVersion
+     * @param int|bool $fromObjectID
+     * @return array|eZContentObject[]
+     */
     function reverseEmbeddedObjectList( $fromObjectVersion = false, $fromObjectID = false )
     {
         return $this->relatedObjects( $fromObjectVersion,
@@ -3028,7 +3351,18 @@ class eZContentObject extends eZPersistentObject
                                       true );
     }
 
-    // left for compatibility
+    /**
+     * Left for compatibility
+     *
+     * @see relatedObjects()
+     *
+     * @deprecated
+     * @param bool $fromObjectVersion
+     * @param bool $fromObjectID
+     * @param int $attributeID
+     * @param bool $params
+     * @return array
+     */
     function relatedContentObjectArray( $fromObjectVersion = false,
                                         $fromObjectID = false,
                                         $attributeID = 0,
@@ -3041,23 +3375,16 @@ class eZContentObject extends eZPersistentObject
                                                           $params );
     }
 
-    /*!
-     \return the number of related objects
-    \param $attributeID :  ( makes sense only when $params['AllRelations'] not set or eZContentObject::RELATION_ATTRIBUTE )
-                           >0           - return relations made with attribute ID ( "related object(s)" datatype )
-                           0 or false  ( $params['AllRelations'] is eZContentObject::RELATION_ATTRIBUTE )
-                                           - return relations made with any attributes
-                           false        ( $params['AllRelations'] not set )
-                                           - return ALL relations (deprecated, use "$params['AllRelations'] = true" instead)
-    \param $params : other parameters from template fetch function :
-               $params['AllRelations'] - relation type filter :
-                           true - return ALL relations, including attribute-level
-                           false    - return object-level relations
-                           >0       - bit mask of EZ_CONTENT_OBJECT_RELATION_* values
-                $params['SortBy']           - related objects sorting mode.
-                            Supported modes: class_identifier, class_name, modified, name, published, section
-                $params['IgnoreVisibility'] - ignores 'hidden' state of related objects if true
-    */
+    /**
+     * Returns the number of related objects
+     *
+     * @see relatedObjectCount()
+     *
+     * @param int|bool $fromObjectVersion
+     * @param int|bool $attributeID
+     * @param array|bool $params
+     * @return int
+     */
     function relatedContentObjectCount( $fromObjectVersion = false,
                                         $attributeID = 0,
                                         $params = false )
@@ -3069,26 +3396,17 @@ class eZContentObject extends eZPersistentObject
                                           $params );
     }
 
-    /*!
-     Returns the objects to which this object are related .
-    \param $attributeID :  ( makes sense only when $params['AllRelations'] not set or eZContentObject::RELATION_ATTRIBUTE )
-                           >0           - return relations made with attribute ID ( "related object(s)" datatype )
-                           0 or false  ( $params['AllRelations'] is eZContentObject::RELATION_ATTRIBUTE )
-                                           - return relations made with any attributes
-                           false        ( $params['AllRelations'] not set )
-                                           - return ALL relations (deprecated, use "$params['AllRelations'] = true" instead)
-    \param $groupByAttribute : false - return all relations as an array of content objects
-                               true  - return all relations groupped by attribute ID
-                               This parameter makes sense only when $attributeID == false or $params['AllRelations'] = true
-    \param $params : other parameters from template fetch function :
-                $params['AllRelations'] - relation type filter :
-                           true - return ALL relations, including attribute-level
-                           false    - return object-level relations
-                           >0       - bit mask of EZ_CONTENT_OBJECT_RELATION_* values
-                $params['SortBy']           - related objects sorting mode.
-                            Supported modes: class_identifier, class_name, modified, name, published, section
-                $params['IgnoreVisibility'] - ignores 'hidden' state of related objects if true
-    */
+    /**
+     * Returns the objects to which this object are related .
+     *
+     * @see relatedObjects()
+     *
+     * @param int|bool $version
+     * @param int|bool $attributeID
+     * @param bool $groupByAttribute
+     * @param array|bool $params
+     * @return array|eZContentObject[]
+     */
     function reverseRelatedObjectList( $version = false,
                                        $attributeID = 0,
                                        $groupByAttribute = false,
@@ -3097,9 +3415,14 @@ class eZContentObject extends eZPersistentObject
         return $this->relatedObjects( $version, $this->ID, $attributeID, $groupByAttribute, $params, true );
     }
 
-    /*!
-     Returns the xml-linked objects count.
-    */
+    /**
+     * Returns the xml-linked objects count.
+     *
+     * @see relatedObjectCount()
+     *
+     * @param int|bool $fromObjectVersion
+     * @return int
+     */
     function linkedContentObjectCount( $fromObjectVersion = false )
     {
         return $this->relatedObjectCount( $fromObjectVersion,
@@ -3108,9 +3431,14 @@ class eZContentObject extends eZPersistentObject
                                           array( 'AllRelations' => eZContentObject::RELATION_LINK ) );
     }
 
-    /*!
-     Returns the xml-embedded objects count.
-    */
+    /**
+     * Returns the xml-embedded objects count.
+     *
+     * @see relatedObjectCount()
+     *
+     * @param int|bool $fromObjectVersion
+     * @return int
+     */
     function embeddedContentObjectCount( $fromObjectVersion = false )
     {
         return $this->relatedObjectCount( $fromObjectVersion,
@@ -3119,9 +3447,14 @@ class eZContentObject extends eZPersistentObject
                                           array( 'AllRelations' => eZContentObject::RELATION_EMBED ) );
     }
 
-    /*!
-     Returns the reverse xml-linked objects count.
-    */
+    /**
+     * Returns the reverse xml-linked objects count.
+     *
+     * @see relatedObjectCount()
+     *
+     * @param int|bool $fromObjectVersion
+     * @return int
+     */
     function reverseLinkedObjectCount( $fromObjectVersion = false )
     {
         return $this->relatedObjectCount( $fromObjectVersion,
@@ -3130,9 +3463,14 @@ class eZContentObject extends eZPersistentObject
                                           array( 'AllRelations' => eZContentObject::RELATION_LINK ) );
     }
 
-    /*!
-     Returns the reverse xml-embedded objects count.
-    */
+    /**
+     * Returns the reverse xml-embedded objects count.
+     *
+     * @see relatedObjectCount()
+     *
+     * @param int|bool $fromObjectVersion
+     * @return int
+     */
     function reverseEmbeddedObjectCount( $fromObjectVersion = false )
     {
         return $this->relatedObjectCount( $fromObjectVersion,
@@ -3144,7 +3482,7 @@ class eZContentObject extends eZPersistentObject
     /**
      * Fetch the number of (reverse) related objects
      *
-     * @param int $version
+     * @param bool|int $version
      * @param int $attributeID
      *        This parameter only makes sense if $params[AllRelations] is unset,
      *        set to false, or matches eZContentObject::RELATION_ATTRIBUTE
@@ -3153,10 +3491,10 @@ class eZContentObject extends eZPersistentObject
      *          Count relations made with any attribute
      *        - >0
      *          Count relations made with attribute $attributeID
-     * @param int|false $reverseRelatedObjects
+     * @param int|bool $reverseRelatedObjects
      *        Wether to count related objects (false) or reverse related
      *        objects (false)
-     * @param array|false $params
+     * @param array|bool $params
      *        Various params, as an associative array.
      *        Possible values:
      *        - AllRelations (bool|int)
@@ -3257,47 +3595,52 @@ class eZContentObject extends eZPersistentObject
         return $rows[0]['count'];
     }
 
-    /*!
-     Returns the number of objects to which this object is related.
-    \param $attributeID :  ( makes sense only when $params['AllRelations'] not set or eZContentObject::RELATION_ATTRIBUTE )
-                           >0           - return relations made with attribute ID ( "related object(s)" datatype )
-                           0 or false  ( $params['AllRelations'] is eZContentObject::RELATION_ATTRIBUTE )
-                                           - return relations made with any attributes
-                           false        ( $params['AllRelations'] not set )
-                                           - return ALL relations (deprecated, use "$params['AllRelations'] = true" instead)
-    \param $params : other parameters from template fetch function :
-               $params['AllRelations'] - relation type filter :
-                           true - return ALL relations, including attribute-level
-                           false    - return object-level relations
-                           >0       - bit mask of EZ_CONTENT_OBJECT_RELATION_* values
-    */
+    /**
+     * Returns the number of objects to which this object is related.
+     *
+     * @see relatedObjectCount()
+     *
+     * @param int|bool $version
+     * @param int|bool $attributeID
+     * @param array|bool $params
+     * @return int
+     */
     function reverseRelatedObjectCount( $version = false, $attributeID = 0, $params = false )
     {
         return $this->relatedObjectCount( $version, $attributeID, true, $params );
     }
 
-    /*!
-     Returns the related objects.
-     \note This function is a duplicate of reverseRelatedObjectList(), use that function instead.
-    */
+    /**
+     * Returns the related objects.
+     *
+     * @see reverseRelatedObjectList()
+     *
+     * @deprecated This function is a duplicate of reverseRelatedObjectList(), use that function instead.
+     * @param int|bool $version
+     * @return array|eZContentObject[]
+     */
     function contentObjectListRelatingThis( $version = false )
     {
         return $this->reverseRelatedObjectList( $version );
     }
 
-    /*!
-     Get parent node IDs
-    */
+    /**
+     * Returns an array of parent node IDs
+     *
+     * @return int[]
+     */
     function parentNodeIDArray()
     {
         return $this->parentNodes( true, false );
     }
 
-    /*!
-     \param $version No longer in use, published nodes are used instead.
-     \param $asObject If true it fetches PHP objects, otherwise it fetches IDs.
-     \return the parnet nodes for the current object.
-    */
+    /**
+     * Returns the parent nodes for the current object.
+     *
+     * @param int|bool $version No longer in use, published nodes are used instead.
+     * @param bool $asObject If true it fetches PHP objects, otherwise it fetches IDs.
+     * @return eZContentObjectTreeNode[]|int[]
+     */
     function parentNodes( $version = false, $asObject = true )
     {
         // We no longer use node-assignment table to find the parents but uses
@@ -3325,18 +3668,21 @@ class eZContentObject extends eZPersistentObject
         return $retNodes;
     }
 
-    /*!
-     Creates a new node assignment that will place the object as child of node \a $nodeID.
-     \return The eZNodeAssignment object it created
-     \param $parentNodeID The node ID of the parent node
-     \param $isMain \c true if the created node is the main node of the object
-     \param $remoteID A string denoting the unique remote ID of the assignment or \c false for no remote id.
-     \param $sortField
-     \param $sortOrder
-     \note The returned assignment will already be stored in the database
-     \note Transaction unsafe. If you call several transaction unsafe methods you must enclose
-     the calls within a db transaction; thus within db->begin and db->commit.
-    */
+    /**
+     * Creates and returns a new node assignment that will place the object as child of node $nodeID.
+     *
+     * The returned assignment will already be stored in the database
+     *
+     * Transaction unsafe. If you call several transaction unsafe methods you must enclose
+     * the calls within a db transaction; thus within db->begin and db->commit.
+     *
+     * @param int $parentNodeID The node ID of the parent node
+     * @param bool $isMain True if the created node is the main node of the object
+     * @param string|bool $remoteID A string denoting the unique remote ID of the assignment or \c false for no remote id.
+     * @param int $sortField
+     * @param int $sortOrder
+     * @return eZNodeAssignment|null
+     */
     function createNodeAssignment( $parentNodeID, $isMain, $remoteID = false, $sortField = eZContentObjectTreeNode::SORT_FIELD_PUBLISHED, $sortOrder = eZContentObjectTreeNode::SORT_ORDER_DESC )
     {
         $nodeAssignment = eZNodeAssignment::create( array( 'contentobject_id' => $this->attribute( 'id' ),
@@ -3353,8 +3699,15 @@ class eZContentObject extends eZPersistentObject
         return $nodeAssignment;
     }
 
-    /*
+    /**
      * Creates object with nodeAssignment from given parent Node, class ID and language code.
+     *
+     * @param eZContentObjectTreeNode $parentNode
+     * @param int $contentClassID
+     * @param string $languageCode
+     * @param string|bool $remoteID
+     *
+     * @return eZContentObject|null
      */
     static function createWithNodeAssignment( $parentNode, $contentClassID, $languageCode, $remoteID = false )
     {
@@ -3381,10 +3734,12 @@ class eZContentObject extends eZPersistentObject
         return null;
     }
 
-
-    /*!
-     Returns the node assignments for the current object.
-    */
+    /**
+     * Returns the node assignments for the current object.
+     *
+     * @param bool $asObject
+     * @return eZContentObjectTreeNode[]|array
+     */
     function assignedNodes( $asObject = true )
     {
         $contentobjectID = $this->attribute( 'id' );
@@ -3416,9 +3771,11 @@ class eZContentObject extends eZPersistentObject
             return $nodesListArray;
     }
 
-    /*!
-     Returns the main node id for the current object.
-    */
+    /**
+     * Returns the main node id for the current object and sets the attribute MainNodeID in the current object
+     *
+     * @return int|null
+     */
     function mainNodeID()
     {
         if ( !is_numeric( $this->MainNodeID ) )
@@ -3429,27 +3786,41 @@ class eZContentObject extends eZPersistentObject
         return $this->MainNodeID;
     }
 
+    /**
+     * Returns the main node id for the current object.
+     *
+     * @return int|null
+     */
     function mainNode()
     {
         return eZContentObjectTreeNode::findMainNode( $this->attribute( 'id' ), true );
     }
 
-    /*!
-     Sets the permissions for this object.
-    */
+    /**
+     * Sets the permissions for this object.
+     *
+     * @param array $permissionArray
+     */
     function setPermissions( $permissionArray )
     {
         $this->Permissions =& $permissionArray;
     }
 
-    /*!
-     Returns the permission for the current object.
-    */
+    /**
+     * Returns the permission for the current object.
+     *
+     * @return array
+     */
     function permissions( )
     {
         return $this->Permissions;
     }
 
+    /**
+     * Returns a list of languages of the current object that the current user can edit
+     *
+     * @return eZContentLanguage[]
+     */
     function canEditLanguages()
     {
         $availableLanguages = $this->availableLanguages();
@@ -3468,6 +3839,11 @@ class eZContentObject extends eZPersistentObject
         return $languages;
     }
 
+    /**
+     * Returns a list of languages of the current object that the current user can create
+     *
+     * @return eZContentLanguage[]
+     */
     function canCreateLanguages()
     {
         $availableLanguages = $this->availableLanguages();
@@ -3485,6 +3861,12 @@ class eZContentObject extends eZPersistentObject
         return $languages;
     }
 
+    /**
+     * @param array $limitationValueList
+     * @param int $userID
+     * @param int|bool $contentObjectID
+     * @return string Returns "denied" or "allowed"
+     */
     function checkGroupLimitationAccess( $limitationValueList, $userID, $contentObjectID = false )
     {
         $access = 'denied';
@@ -3532,17 +3914,16 @@ class eZContentObject extends eZPersistentObject
         return $access;
     }
 
-    /*!
-     Check access for the current object
-
-     \param function name ( edit, read, remove, etc. )
-     \param original class ID ( used to check access for object creation ), default false
-     \param parent class id ( used to check access for object creation ), default false
-     \param return access list instead of access result (optional, default false )
-
-     \return 1 if has access, 0 if not.
-             If returnAccessList is set to true, access list is returned
-    */
+    /**
+     * Check access for the current object
+     *
+     * @param string $functionName Function name ( edit, read, remove, etc. )
+     * @param int|bool $originalClassID Used to check access for object creation
+     * @param int|bool $parentClassID Used to check access for object creation
+     * @param bool $returnAccessList If true, returns access list instead of access result
+     * @param string|bool $language
+     * @return array|int 1 if has access, 0 if not, array if $returnAccessList is true
+     */
     function checkAccess( $functionName, $originalClassID = false, $parentClassID = false, $returnAccessList = false, $language = false )
     {
         $classID = $originalClassID;
@@ -4099,6 +4480,13 @@ class eZContentObject extends eZPersistentObject
     // This code is automatically generated from templates/classlistfrompolicy.ctpl
     // DO NOT EDIT THIS CODE DIRECTLY, CHANGE THE TEMPLATE FILE INSTEAD
 
+    /**
+     * Returns an array of classes the current user has access to
+     *
+     * @param array $policy
+     * @param array|bool $allowedLanguageCodes
+     * @return array
+     */
     function classListFromPolicy( $policy, $allowedLanguageCodes = false )
     {
         $canCreateClassIDListPart = array();
@@ -4264,19 +4652,16 @@ class eZContentObject extends eZPersistentObject
     // This code is automatically generated from templates/classcreatelist.ctpl
     // DO NOT EDIT THIS CODE DIRECTLY, CHANGE THE TEMPLATE FILE INSTEAD
 
-    /*!
-     Finds all classes that the current user can create objects from and returns.
-     It is also possible to filter the list event more with \a $includeFilter and \a $groupList.
-
-     \param $asObject If \c true then it return eZContentClass objects, if not it will
-                      be an associative array with \c name and \c id keys.
-     \param $includeFilter If \c true then it will include only from class groups defined in
-                           \a $groupList, if not it will exclude those groups.
-     \param $groupList An array with class group IDs that should be used in filtering, use
-                       \c false if you do not wish to filter at all.
-     \param $fetchID A unique name for the current fetch, this must be supplied when filtering is
-                     used if you want caching to work.
-    */
+    /**
+     * Finds all classes that the current user can create objects from and returns.
+     * It is also possible to filter the list event more with $includeFilter and $groupList.
+     *
+     * @param bool $asObject If true then it return eZContentClass objects, if not it will be an associative array
+     * @param bool $includeFilter If true then it will include only from class groups defined in $groupList, if not it will exclude those groups.
+     * @param bool $groupList An array with class group IDs that should be used in filtering, use false if you do not wish to filter at all.
+     * @param bool $fetchID A unique name for the current fetch, this must be supplied when filtering is used if you want caching to work.
+     * @return array|eZPersistentObject[]
+     */
     function canCreateClassList( $asObject = false, $includeFilter = true, $groupList = false, $fetchID = false )
     {
         $ini = eZINI::instance();
@@ -4412,13 +4797,12 @@ class eZContentObject extends eZPersistentObject
     // This code is automatically generated from templates/classcreatelist.ctpl
     // code-template::auto-generated:END can-instantiate-class-list
 
-    /*!
-     Get accesslist for specified function
-
-     \param function
-
-     \return AccessList
-    */
+    /**
+     * Get accesslist for specified function
+     *
+     * @param string $function
+     * @return array|int
+     */
     function accessList( $function )
     {
         switch( $function )
@@ -4436,9 +4820,11 @@ class eZContentObject extends eZPersistentObject
         return 0;
     }
 
-    /*!
-     \return \c true if the current user can read this content object.
-    */
+    /**
+     * Returns true if the current user can read this content object.
+     *
+     * @return bool
+     */
     function canRead( )
     {
         if ( !isset( $this->Permissions["can_read"] ) )
@@ -4448,9 +4834,11 @@ class eZContentObject extends eZPersistentObject
         return ( $this->Permissions["can_read"] == 1 );
     }
 
-    /*!
-     \return \c true if the current user can create a pdf of this content object.
-    */
+    /**
+     * Returns true if the current user can create a pdf of this content object.
+     *
+     * @return bool
+     */
     function canPdf( )
     {
         if ( !isset( $this->Permissions["can_pdf"] ) )
@@ -4460,10 +4848,11 @@ class eZContentObject extends eZPersistentObject
         return ( $this->Permissions["can_pdf"] == 1 );
     }
 
-    /*!
-     \return \c true if the node can be viewed as embeded object by the current user.
-     \sa checkAccess().
-    */
+    /**
+     * Returns true if the node can be viewed as embeded object by the current user.
+     *
+     * @return bool
+     */
     function canViewEmbed( )
     {
         if ( !isset( $this->Permissions["can_view_embed"] ) )
@@ -4473,9 +4862,11 @@ class eZContentObject extends eZPersistentObject
         return ( $this->Permissions["can_view_embed"] == 1 );
     }
 
-    /*!
-     \return \c true if the current user can diff this content object.
-    */
+    /**
+     * Returns true if the current user can diff this content object.
+     *
+     * @return bool
+     */
     function canDiff( )
     {
         if ( !isset( $this->Permissions["can_diff"] ) )
@@ -4485,6 +4876,11 @@ class eZContentObject extends eZPersistentObject
         return ( $this->Permissions["can_diff"] == 1 );
     }
 
+    /**
+     * Returns true if the current user can create a content object like this one.
+     *
+     * @return bool
+     */
     function canCreate( )
     {
         if ( !isset( $this->Permissions["can_create"] ) )
@@ -4494,6 +4890,15 @@ class eZContentObject extends eZPersistentObject
         return ( $this->Permissions["can_create"] == 1 );
     }
 
+    /**
+     * Returns true if the current user can edit this content object.
+     *
+     * @param int|bool $originalClassID
+     * @param int|bool $parentClassID
+     * @param bool $returnAccessList
+     * @param string|bool $language
+     * @return bool
+     */
     function canEdit( $originalClassID = false, $parentClassID = false, $returnAccessList = false, $language = false )
     {
         $isCalledClean = ( func_num_args() == 0 );
@@ -4525,6 +4930,11 @@ class eZContentObject extends eZPersistentObject
         return ( $canEdit == 1 );
     }
 
+    /**
+     * Returns true if the current user can translate this content object.
+     *
+     * @return bool
+     */
     function canTranslate( )
     {
         if ( !isset( $this->Permissions["can_translate"] ) )
@@ -4546,6 +4956,11 @@ class eZContentObject extends eZPersistentObject
         return ( $this->Permissions["can_translate"] == 1 );
     }
 
+    /**
+     * Returns true if the current user can remove this content object.
+     *
+     * @return bool
+     */
     function canRemove( )
     {
 
@@ -4556,11 +4971,11 @@ class eZContentObject extends eZPersistentObject
         return ( $this->Permissions["can_remove"] == 1 );
     }
 
-    /*!
-     Check if the object can be moved. (actually checks 'edit' and 'remove' permissions)
-     \return \c true if the object can be moved by the current user.
-     \sa checkAccess().
-    */
+    /**
+     * Returns true if the current user can move this content object.
+     *
+     * @return bool
+     */
     function canMoveFrom( )
     {
 
@@ -4571,11 +4986,13 @@ class eZContentObject extends eZPersistentObject
         return ( $this->Permissions['can_move_from'] == 1 );
     }
 
-    /*!
-     \return The name of the class which this object was created from.
-
-     \note The object will cache the class name information so multiple calls will be fast.
-    */
+    /**
+     * Returns the name of the class which this object was created from.
+     *
+     * The object will cache the class name information so multiple calls will be fast.
+     *
+     * @return string|bool|null
+     */
     function className()
     {
         if ( !is_numeric( $this->ClassID ) )
@@ -4597,10 +5014,11 @@ class eZContentObject extends eZPersistentObject
         return $this->ClassName;
     }
 
-    /*!
-     Returns an array of the content actions which can be performed on
-     the current object.
-    */
+    /**
+     * Returns an array of the content actions which can be performed on the current object.
+     *
+     * @return array|bool
+     */
     function contentActionList()
     {
         $version = $this->attribute( 'current_version' );
@@ -4634,9 +5052,12 @@ class eZContentObject extends eZPersistentObject
         return $this->ContentActionList;
     }
 
-    /*!
-     \return true if the content action is in the content action list
-    */
+    /**
+     * Returns true if the given content action is in the content action list
+     *
+     * @param string $name Name of the content action
+     * @return bool
+     */
     function hasContentAction( $name )
     {
         $return = false;
@@ -4653,12 +5074,10 @@ class eZContentObject extends eZPersistentObject
         return $return;
     }
 
-    /*!
-     \return the languages the object has been translated into/exists in.
-
-     Returns an array with the language codes.
-
-     It uses the attribute \c avail_lang as the source for the language list.
+    /**
+     * Returns the languages the object has been translated into/exists in.
+     *
+     * @return array An array with the language codes.
      */
     function availableLanguages()
     {
@@ -4673,11 +5092,19 @@ class eZContentObject extends eZPersistentObject
         return $languages;
     }
 
+    /**
+     * Returns the languages the object has been translated into/exists in as a JSON string
+     *
+     * @return bool|string
+     */
     function availableLanguagesJsArray()
     {
         return eZContentLanguage::jsArrayByMask( $this->LanguageMask );
     }
 
+    /**
+     * @return eZContentLanguage[]|array
+     */
     function languages()
     {
         return isset( $this->LanguageMask ) ?
@@ -4685,12 +5112,18 @@ class eZContentObject extends eZPersistentObject
             array();
     }
 
+    /**
+     * @return eZContentLanguage[]|array
+     */
     function allLanguages()
     {
         $languages = isset( $this->LanguageMask ) ? eZContentLanguage::languagesByMask( $this->LanguageMask ) : array();
         return $languages;
     }
 
+    /**
+     * @return string|bool
+     */
     static function defaultLanguage()
     {
         if ( ! isset( $GLOBALS['eZContentObjectDefaultLanguage'] ) )
@@ -4716,31 +5149,34 @@ class eZContentObject extends eZPersistentObject
         return $GLOBALS['eZContentObjectDefaultLanguage'];
     }
 
-    /*!
-     \static
-     Set default language. Checks if default language is valid.
-
-     \param default language.
-     \note Deprecated.
-    */
+    /**
+     * Set default language. Checks if default language is valid.
+     *
+     * @deprecated
+     * @param string $lang Default language.
+     * @return bool
+     */
     static function setDefaultLanguage( $lang )
     {
         return false;
     }
 
-    /*!
-
-    */
+    /**
+     * @param string $name
+     */
     function setClassName( $name )
     {
         $this->ClassName = $name;
     }
 
-    /*!
-     \returns an array with locale strings, these strings represents the languages which content objects are allowed to be translated into.
-     \note the setting ContentSettings/TranslationList in site.ini determines the array.
-     \sa translationList
-    */
+    /**
+     * Returns an array with locale strings, these strings represents the languages which content objects
+     * are allowed to be translated into.
+     *
+     * The setting ContentSettings/TranslationList in site.ini determines the array.
+     *
+     * @return string[]
+     */
     static function translationStringList()
     {
         $translationList = array();
@@ -4754,11 +5190,14 @@ class eZContentObject extends eZPersistentObject
         return $translationList;
     }
 
-    /*!
-     \returns an array with locale objects, these objects represents the languages the content objects are allowed to be translated into.
-     \note the setting ContentSettings/TranslationList in site.ini determines the array.
-     \sa translationStringList
-    */
+    /**
+     * Returns an array with locale objects, these objects represents the languages the content objects are
+     * allowed to be translated into.
+     *
+     * The setting ContentSettings/TranslationList in site.ini determines the array.
+     *
+     * @return eZLocale[]
+     */
     static function translationList()
     {
         $translationList = array();
@@ -4772,21 +5211,26 @@ class eZContentObject extends eZPersistentObject
         return $translationList;
     }
 
-    /*!
-     Returns the attributes for the content object version \a $version and content object \a $contentObjectID.
-     \a $language defines the language to fetch.
-     \sa attributes
-    */
+    /**
+     * Returns the attributes for the content object version \a $version and content object \a $contentObjectID.
+     *
+     * @param int $version
+     * @param bool $asObject
+     * @return eZContentClassAttribute[]|array|null
+     */
     function fetchClassAttributes( $version = 0, $asObject = true )
     {
         return eZContentClassAttribute::fetchListByClassID( $this->attribute( 'contentclass_id' ), $version, $asObject );
     }
 
-    /*!
-     \private
-     Maps input lange to another one if defined in $options['language_map'].
-     If it cannot map it returns the original language.
-     \returns string
+    /**
+     * Maps input lange to another one if defined in $options['language_map'].
+     *
+     * If it cannot map it returns the original language.
+     *
+     * @param string $language
+     * @param array $options
+     * @return string
      */
     static function mapLanguage( $language, $options )
     {
@@ -4797,20 +5241,19 @@ class eZContentObject extends eZPersistentObject
         return $language;
     }
 
-    /*!
-     \static
-     Unserialize xml structure. Create object from xml input.
-
-     \param package
-     \param XML DOM Node
-     \param parent node object.
-     \param Options
-     \param owner ID, override owner ID, null to use XML owner id (optional)
-
-     \returns created object, false if could not create object/xml invalid
-     \note Transaction unsafe. If you call several transaction unsafe methods you must enclose
-     the calls within a db transaction; thus within db->begin and db->commit.
-    */
+    /**
+     * Unserialize xml structure. Creates an object from xml input.
+     *
+     * Transaction unsafe. If you call several transaction unsafe methods you must enclose
+     * the calls within a db transaction; thus within db->begin and db->commit.
+     *
+     * @param mixed $package
+     * @param DOMElement $domNode
+     * @param array $options
+     * @param int|bool $ownerID Override owner ID, null to use XML owner id (optional)
+     * @param string $handlerType
+     * @return array|bool|eZContentObject|null created object, false if could not create object/xml invalid
+     */
     static function unserialize( $package, $domNode, &$options, $ownerID = false, $handlerType = 'ezcontentobject' )
     {
         if ( $domNode->localName != 'object' )
@@ -4852,13 +5295,16 @@ class eZContentObject extends eZPersistentObject
             return $retValue;
         }
 
+        /** @var DOMElement $versionListNode */
         $versionListNode = $domNode->getElementsByTagName( 'version-list' )->item( 0 );
 
         $importedLanguages = array();
         foreach( $versionListNode->getElementsByTagName( 'version' ) as $versionDOMNode )
         {
+            /** @var DOMElement $versionDOMNode */
             foreach ( $versionDOMNode->getElementsByTagName( 'object-translation' ) as $versionDOMNodeChild )
             {
+                /** @var DOMElement $versionDOMNodeChild */
                 $importedLanguage = eZContentObject::mapLanguage( $versionDOMNodeChild->getAttribute( 'language' ), $options );
                 $language = eZContentLanguage::fetchByLocale( $importedLanguage );
                 // Check if the language is allowed in this setup.
@@ -5127,11 +5573,12 @@ class eZContentObject extends eZPersistentObject
         return $contentObject;
     }
 
-    /*!
-      Performs additional unserialization actions that need to be performed when all
-      objects contained in the package are already installed. (maintain objects' cross-relations)
-    */
-
+    /**
+     * Performs additional unserialization actions that need to be performed when all
+     * objects contained in the package are already installed. (maintain objects' cross-relations)
+     *
+     * @param mixed $package
+     */
     function postUnserialize( $package )
     {
         foreach( $this->versions() as $version )
@@ -5140,18 +5587,19 @@ class eZContentObject extends eZPersistentObject
         }
     }
 
-    /*!
-     \return a DOM structure of the content object and it's attributes.
-
-     \param package
-     \param Content object version, true for current version, false for all, else array containing specific versions.
-     \param package options ( optianal )
-     \param array of allowed nodes ( optional )
-     \param array of top nodes in current package export (optional )
-
-     \note Transaction unsafe. If you call several transaction unsafe methods you must enclose
-     the calls within a db transaction; thus within db->begin and db->commit.
-    */
+    /**
+     * Returns a DOM structure of the content object and it's attributes.
+     *
+     * Transaction unsafe. If you call several transaction unsafe methods you must enclose
+     * the calls within a db transaction; thus within db->begin and db->commit.
+     *
+     * @param mixed $package
+     * @param int|bool $specificVersion Content object version, true for current version, false for all, else array containing specific versions.
+     * @param array|bool $options Package options or false
+     * @param int[]|bool $contentNodeIDArray Array of allowed nodes or false
+     * @param int[]|bool $topNodeIDArray Array of top nodes in current package export or false
+     * @return bool|DOMElement
+     */
     function serialize( $package, $specificVersion = false, $options = false, $contentNodeIDArray = false, $topNodeIDArray = false )
     {
         if ( $options &&
@@ -5247,9 +5695,12 @@ class eZContentObject extends eZPersistentObject
         return $objectNode;
     }
 
-    /*!
-     \return a structure with information required for caching.
-    */
+    /**
+     * Returns a structure with information required for caching.
+     *
+     * @param $Params array
+     * @return array
+     */
     function cacheInfo( $Params )
     {
         $contentCacheInfo =& $GLOBALS['eZContentCacheInfo'];
@@ -5270,9 +5721,9 @@ class eZContentObject extends eZPersistentObject
         return $contentCacheInfo;
     }
 
-    /*!
-     Sets all view cache files to be expired
-    */
+    /**
+     * Sets all view cache files to be expired
+     */
     static function expireAllViewCache()
     {
         eZExpiryHandler::registerShutdownFunction();
@@ -5281,11 +5732,12 @@ class eZContentObject extends eZPersistentObject
         $handler->store();
     }
 
-    /*!
-     Sets all content cache files to be expired. Both view cache and cache blocks are expired.
-     \note Transaction unsafe. If you call several transaction unsafe methods you must enclose
-     the calls within a db transaction; thus within db->begin and db->commit.
-    */
+    /**
+     * Sets all content cache files to be expired. Both view cache and cache blocks are expired.
+     *
+     * Transaction unsafe. If you call several transaction unsafe methods you must enclose
+     * the calls within a db transaction; thus within db->begin and db->commit.
+     */
     static function expireAllCache()
     {
         eZExpiryHandler::registerShutdownFunction();
@@ -5296,12 +5748,12 @@ class eZContentObject extends eZPersistentObject
         $handler->store();
     }
 
-    /*!
-     Expires all template block cache. This should be expired anytime any content
-     is published/modified or removed.
-     \note Transaction unsafe. If you call several transaction unsafe methods you must enclose
-     the calls within a db transaction; thus within db->begin and db->commit.
-    */
+    /**
+     * Expires all template block cache. This should be expired anytime any content is published/modified or removed.
+     *
+     * Transaction unsafe. If you call several transaction unsafe methods you must enclose
+     * the calls within a db transaction; thus within db->begin and db->commit.
+     */
     static function expireTemplateBlockCache()
     {
         eZExpiryHandler::registerShutdownFunction();
@@ -5310,11 +5762,12 @@ class eZContentObject extends eZPersistentObject
         $handler->store();
     }
 
-    /*!
-     Sets all complex viewmode content cache files to be expired.
-     \note Transaction unsafe. If you call several transaction unsafe methods you must enclose
-     the calls within a db transaction; thus within db->begin and db->commit.
-    */
+    /**
+     * Sets all complex viewmode content cache files to be expired.
+     *
+     * Transaction unsafe. If you call several transaction unsafe methods you must enclose
+     * the calls within a db transaction; thus within db->begin and db->commit.
+     */
     static function expireComplexViewModeCache()
     {
         eZExpiryHandler::registerShutdownFunction();
@@ -5323,9 +5776,12 @@ class eZContentObject extends eZPersistentObject
         $handler->store();
     }
 
-    /*!
-     \return if the content cache timestamp \a $timestamp is expired.
-    */
+    /**
+     * Returns true if the content cache timestamp $timestamp is expired.
+     *
+     * @param int $timestamp UNIX Timestamp
+     * @return bool
+     */
     static function isCacheExpired( $timestamp )
     {
         eZExpiryHandler::registerShutdownFunction();
@@ -5338,9 +5794,12 @@ class eZContentObject extends eZPersistentObject
         return false;
     }
 
-    /*!
-     \return true if the viewmode is a complex viewmode.
-    */
+    /**
+     * Returns true if the viewmode is a complex viewmode.
+     *
+     * @param string $viewMode
+     * @return bool
+     */
     static function isComplexViewMode( $viewMode )
     {
         $ini = eZINI::instance();
@@ -5348,9 +5807,13 @@ class eZContentObject extends eZPersistentObject
         return in_array( $viewMode, $viewModes );
     }
 
-    /*!
-     \return true if the viewmode is a complex viewmode and the viewmode timestamp is expired.
-    */
+    /**
+     * Returns true if the viewmode is a complex viewmode and the viewmode timestamp is expired.
+     *
+     * @param string $viewMode
+     * @param int $timestamp UNIX Timestamp
+     * @return bool
+     */
     static function isComplexViewModeCacheExpired( $viewMode, $timestamp )
     {
         if ( !eZContentObject::isComplexViewMode( $viewMode ) )
@@ -5365,10 +5828,11 @@ class eZContentObject extends eZPersistentObject
         return false;
     }
 
-    /*!
-     Returns a list of all the authors for this object. The returned value is an
-     array of eZ user objects.
-    */
+    /**
+     * Returns a list of all the authors for this object
+     *
+     * @return eZUser[]
+     */
     function authorArray()
     {
         $db = eZDB::instance();
@@ -5386,9 +5850,14 @@ class eZContentObject extends eZPersistentObject
         return $return;
     }
 
-    /*!
-     \return the number of objects of the given class is created by the given user.
-    */
+    /**
+     * Returns the number of objects of the given class is created by the given user.
+     *
+     * @param int $classID
+     * @param int $userID
+     * @param int|bool $status
+     * @return int
+     */
     static function fetchObjectCountByUserID( $classID, $userID, $status = false )
     {
         $count = 0;
@@ -5404,21 +5873,21 @@ class eZContentObject extends eZPersistentObject
         return $count;
     }
 
-     /*!
-     \static
-      \deprecated This method is left here only for backward compatibility.
-                  Use eZContentObjectVersion::removeVersions() method instead.
+    /**
+     * @param int|bool $versionStatus
+     * @deprecated This method is left here only for backward compatibility. Use eZContentObjectVersion::removeVersions() method instead.
      */
-     static function removeVersions( $versionStatus = false )
-     {
-         eZContentObjectVersion::removeVersions( $versionStatus );
-     }
+    static function removeVersions( $versionStatus = false )
+    {
+        eZContentObjectVersion::removeVersions( $versionStatus );
+    }
 
-    /*!
-     Sets the object's name to $newName: tries to find attributes that are in 'object pattern name'
-     and updates them.
-     \return \c true if object's name was changed, otherwise \c false.
-    */
+    /**
+     * Sets the object's name to $newName: tries to find attributes that are in 'object pattern name' and updates them
+     *
+     * @param string $newName
+     * @return bool true if object's name was changed, otherwise false.
+     */
     function rename( $newName )
     {
         // get 'object name pattern'
@@ -5501,6 +5970,12 @@ class eZContentObject extends eZPersistentObject
         return ($operationResult != null ? true : false);
     }
 
+    /**
+     * Removes a translation from the current object
+     *
+     * @param int $languageID
+     * @return bool
+     */
     function removeTranslation( $languageID )
     {
         $language = eZContentLanguage::fetch( $languageID );
@@ -5619,11 +6094,18 @@ class eZContentObject extends eZPersistentObject
         return true;
     }
 
+    /**
+     * @return int
+     */
     function isAlwaysAvailable()
     {
         return ( $this->attribute( 'language_mask' ) & 1 );
     }
 
+    /**
+     * @param int $languageID
+     * @param int|bool $version
+     */
     function setAlwaysAvailableLanguageID( $languageID, $version = false )
     {
         $db = eZDB::instance();
@@ -5683,6 +6165,9 @@ class eZContentObject extends eZPersistentObject
         $db->commit();
     }
 
+    /**
+     * @return eZSection[]|null
+     */
     function allowedAssignSectionList()
     {
         $currentUser = eZUser::currentUser();
@@ -5820,6 +6305,10 @@ class eZContentObject extends eZPersistentObject
         return $allowedStateIDList;
     }
 
+    /**
+     * @param eZUser|null $user
+     * @return array
+     */
     function allowedAssignStateList( eZUser $user = null )
     {
         $allowedStateIDList = $this->allowedAssignStateIDList( $user );
@@ -5865,8 +6354,8 @@ class eZContentObject extends eZPersistentObject
      *
      * Uses a member variable that caches the result.
      *
+     * @param bool $refreshCache if the cache in the member variable needs to be refreshed
      * @return array an associative array with state group id => state id pairs
-     * @param boolean $refreshCache if the cache in the member variable needs to be refreshed
      */
     function stateIDArray( $refreshCache = false )
     {
@@ -5893,6 +6382,9 @@ class eZContentObject extends eZPersistentObject
         return $this->StateIDArray;
     }
 
+    /**
+     * @return array
+     */
     function stateIdentifierArray()
     {
         if ( !$this->ID )
@@ -5995,7 +6487,8 @@ class eZContentObject extends eZPersistentObject
 
     /**
      * Returns object's section identifier
-     * @return string
+     *
+     * @return string|bool
      */
     public function sectionIdentifier()
     {
@@ -6007,38 +6500,61 @@ class eZContentObject extends eZPersistentObject
         return false;
     }
 
+    /**
+     * @var int Object ID
+     */
     public $ID;
+
+    /**
+     * @var string Object name
+     */
     public $Name;
 
-    /// Stores the current language
+    /**
+     * @var bool|string Stores the current language
+     */
     public $CurrentLanguage;
 
-    /// Stores the current class name
+    /**
+     * @var bool|string Stores the current class name
+     */
     public $ClassName;
 
-    /// Cached class identifier
+    /**
+     * @var string The object's class identifier
+     */
     public $ClassIdentifier;
 
-    /// Contains the datamap for content object attributes
+    /**
+     * @var eZContentObjectAttribute[] The datamap for content object attributes
+     */
     public $DataMap = array();
 
-    /// Contains an array of the content object actions for the current object
+    /**
+     * @var array|bool Contains an array of the content object actions for the current object
+     */
     public $ContentActionList = false;
 
-    /// Contains a cached version of the content object attributes for the given version and language
+    /**
+     * @var eZContentObjectAttribute[] Contains a cached version of the content object attributes for the given version and language
+     */
     public $ContentObjectAttributes = array();
 
-    /// Contains the main node id for this object
+    /**
+     * @var int|bool Contains the main node id for this object
+     */
     public $MainNodeID = false;
 
-    /// Contains the arrays of relatedobject id by fetching input for this object
+    /**
+     * @var array Contains the arrays of relatedobject id by fetching input for this object
+     */
     public $InputRelationList = array();
 
     /**
      * Cache for the state ID array
      *
-     * @var array
-     * @see eZContentObject::stateIDArray()
+     * @var array|bool
+     * @see stateIDArray()
      */
     private $StateIDArray = false;
 }


### PR DESCRIPTION
Working with IDEs like PHPStorm gets a lot more convenient with correct PHPDocs - following #643, I converted the Doxygen to PHPDoc in `eZContentObject`:
- The descriptions have mostly been copied 1:1
- Where no descriptions have been present, I tried to add a small one
- **No other code changes have been made**

Cheers
 Jérôme
