### PR TITLE
Converted Doxygen to PHPDoc in eZDataType and all derived datatypes

### DIFF
--- a/kernel/classes/datatypes/ezauthor/ezauthortype.php
+++ b/kernel/classes/datatypes/ezauthor/ezauthortype.php
@@ -8,27 +8,24 @@
  * @package kernel
  */
 
-/*!
-  \class eZAuthorType ezauthortype.php
-  \ingroup eZDatatype
-  \brief eZAuthorType handles multiple authors
-
-*/
-
+/**
+ * eZAuthorType handles multiple authors
+ *
+ * @package kernel
+ */
 class eZAuthorType extends eZDataType
 {
     const DATA_TYPE_STRING = "ezauthor";
 
+    /**
+     * Initializes the datatype
+     */
     function eZAuthorType()
     {
         $this->eZDataType( self::DATA_TYPE_STRING, ezpI18n::tr( 'kernel/classes/datatypes', "Authors", 'Datatype name' ),
                            array( 'serialize_supported' => true ) );
     }
 
-    /*!
-     Validates the input and returns true if the input was
-     valid for this datatype.
-    */
     function validateObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         $actionRemoveSelected = false;
@@ -101,18 +98,12 @@ class eZAuthorType extends eZDataType
         return eZInputValidator::STATE_ACCEPTED;
     }
 
-    /*!
-     Store content
-    */
     function storeObjectAttribute( $contentObjectAttribute )
     {
         $author = $contentObjectAttribute->content();
         $contentObjectAttribute->setAttribute( "data_text", $author->xmlString() );
     }
 
-    /*!
-     Sets the default value.
-    */
     function initializeObjectAttribute( $contentObjectAttribute, $currentVersion, $originalContentObjectAttribute )
     {
         if ( $currentVersion != false )
@@ -122,9 +113,6 @@ class eZAuthorType extends eZDataType
         }
     }
 
-    /*!
-     Returns the content.
-    */
     function objectAttributeContent( $contentObjectAttribute )
     {
         $author = new eZAuthor( );
@@ -152,12 +140,9 @@ class eZAuthorType extends eZDataType
         return $author;
     }
 
-
-    /*!
-     Returns the meta data used for storing search indeces.
-    */
     function metaData( $contentObjectAttribute )
     {
+        /** @var eZAuthor $author */
         $author = $contentObjectAttribute->content();
         if ( !$author )
             return false;
@@ -176,12 +161,15 @@ class eZAuthorType extends eZDataType
         return eZStringUtils::implodeStr( $authorList, "&" );
     }
 
+    /**
+     * @inheritdoc
+     * @return eZAuthor
+     */
     function fromString( $contentObjectAttribute, $string )
     {
         $authorList = eZStringUtils::explodeStr( $string, '&' );
 
         $author = new eZAuthor( );
-
 
         foreach ( $authorList as $authorStr )
         {
@@ -193,9 +181,6 @@ class eZAuthorType extends eZDataType
         return $author;
     }
 
-    /*!
-     Fetches the http post var integer input and stores it in the data instance.
-    */
     function fetchObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         if ( $http->hasPostVariable( $base . "_data_author_id_" . $contentObjectAttribute->attribute( "id" ) ) )
@@ -253,9 +238,6 @@ class eZAuthorType extends eZDataType
         return count( $authorList ) > 0;
     }
 
-    /*!
-     Returns the string value.
-    */
     function title( $contentObjectAttribute, $name = null )
     {
         $author = $contentObjectAttribute->content( );

--- a/kernel/classes/datatypes/ezbinaryfile/ezbinaryfiletype.php
+++ b/kernel/classes/datatypes/ezbinaryfile/ezbinaryfiletype.php
@@ -8,13 +8,11 @@
  * @package kernel
  */
 
-/*!
-  \class eZBinaryFileType ezbinaryfiletype.php
-  \ingroup eZDatatype
-  \brief The class eZBinaryFileType handles files and association with content objects
-
-*/
-
+/**
+ * The class eZBinaryFileType handles files and association with content objects
+ *
+ * @package kernel
+ */
 class eZBinaryFileType extends eZDataType
 {
     const MAX_FILESIZE_FIELD = 'data_int1';
@@ -23,23 +21,23 @@ class eZBinaryFileType extends eZDataType
 
     const DATA_TYPE_STRING = "ezbinaryfile";
 
+    /**
+     * Initializes the datatype
+     */
     function eZBinaryFileType()
     {
         $this->eZDataType( self::DATA_TYPE_STRING, ezpI18n::tr( 'kernel/classes/datatypes', "File", 'Datatype name' ),
                            array( 'serialize_supported' => true ) );
     }
 
-    /*!
-     \return the binary file handler.
-    */
+    /**
+     * @return eZBinaryFileHandler
+     */
     function fileHandler()
     {
         return eZBinaryFileHandler::instance();
     }
 
-    /*!
-     \return the template name which the handler decides upon.
-    */
     function viewTemplate( $contentobjectAttribute )
     {
         $handler = $this->fileHandler();
@@ -50,14 +48,6 @@ class eZBinaryFileType extends eZDataType
         return $template;
     }
 
-    /*!
-     \return the template name to use for editing the attribute.
-     \note Default is to return the datatype string which is OK
-           for most datatypes, if you want dynamic templates
-           reimplement this function and return a template name.
-     \note The returned template name does not include the .tpl extension.
-     \sa viewTemplate, informationTemplate
-    */
     function editTemplate( $contentobjectAttribute )
     {
         $handler = $this->fileHandler();
@@ -68,14 +58,6 @@ class eZBinaryFileType extends eZDataType
         return $template;
     }
 
-    /*!
-     \return the template name to use for information collection for the attribute.
-     \note Default is to return the datatype string which is OK
-           for most datatypes, if you want dynamic templates
-           reimplement this function and return a template name.
-     \note The returned template name does not include the .tpl extension.
-     \sa viewTemplate, editTemplate
-    */
     function informationTemplate( $contentobjectAttribute )
     {
         $handler = $this->fileHandler();
@@ -86,9 +68,6 @@ class eZBinaryFileType extends eZDataType
         return $template;
     }
 
-    /*!
-     Sets value according to current version
-    */
     function initializeObjectAttribute( $contentObjectAttribute, $currentVersion, $originalContentObjectAttribute )
     {
         if ( $currentVersion != false )
@@ -105,10 +84,6 @@ class eZBinaryFileType extends eZDataType
         }
     }
 
-    /*!
-     The object is being moved to trash, do any necessary changes to the attribute.
-     Rename file and update db row with new name, so that access to the file using old links no longer works.
-    */
     function trashStoredObjectAttribute( $contentObjectAttribute, $version = null )
     {
         $contentObjectAttributeID = $contentObjectAttribute->attribute( "id" );
@@ -157,9 +132,6 @@ class eZBinaryFileType extends eZDataType
         }
     }
 
-    /*!
-     Delete stored attribute
-    */
     function deleteStoredObjectAttribute( $contentObjectAttribute, $version = null )
     {
         $contentObjectAttributeID = $contentObjectAttribute->attribute( "id" );
@@ -213,9 +185,9 @@ class eZBinaryFileType extends eZDataType
         }
     }
 
-    /*!
-     Checks if file uploads are enabled, if not it gives a warning.
-    */
+    /**
+     * Checks if file uploads are enabled, if not it gives a warning.
+     */
     function checkFileUploads()
     {
         $isFileUploadsEnabled = ini_get( 'file_uploads' ) != 0;
@@ -234,10 +206,6 @@ class eZBinaryFileType extends eZDataType
         }
     }
 
-    /*!
-     Validates the input and returns true if the input was
-     valid for this datatype.
-    */
     function validateObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         eZBinaryFileType::checkFileUploads();
@@ -279,9 +247,6 @@ class eZBinaryFileType extends eZDataType
         return eZInputValidator::STATE_ACCEPTED;
     }
 
-    /*!
-     Fetches the http post var integer input and stores it in the data instance.
-    */
     function fetchObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         eZBinaryFileType::checkFileUploads();
@@ -347,9 +312,6 @@ class eZBinaryFileType extends eZDataType
         return true;
     }
 
-    /*!
-     Does nothing, since the file has been stored. See fetchObjectAttributeHTTPInput for the actual storing.
-    */
     function storeObjectAttribute( $contentObjectAttribute )
     {
     }
@@ -365,25 +327,16 @@ class eZBinaryFileType extends eZDataType
         }
     }
 
-    /*!
-     HTTP file insertion is supported.
-    */
     function isHTTPFileInsertionSupported()
     {
         return true;
     }
 
-    /*!
-     HTTP file insertion is supported.
-    */
     function isRegularFileInsertionSupported()
     {
         return true;
     }
 
-    /*!
-     Inserts the file using the eZBinaryFile class.
-    */
     function insertHTTPFile( $object, $objectVersion, $objectLanguage,
                              $objectAttribute, $httpFile, $mimeData,
                              &$result )
@@ -409,7 +362,6 @@ class eZBinaryFileType extends eZDataType
             return false;
         }
 
-
         $filePath = $binary->attribute( 'filename' );
 
         $binary->setAttribute( "contentobject_attribute_id", $attributeID );
@@ -432,9 +384,6 @@ class eZBinaryFileType extends eZDataType
         return true;
     }
 
-    /*!
-     Inserts the file using the eZBinaryFile class.
-    */
     function insertRegularFile( $object, $objectVersion, $objectLanguage,
                                 $objectAttribute, $filePath,
                                 &$result )
@@ -478,7 +427,6 @@ class eZBinaryFileType extends eZDataType
         $fileHandler = eZClusterFileHandler::instance();
         $fileHandler->fileStore( $destination, 'binaryfile', true, $mimeData['name'] );
 
-
         $binary->setAttribute( "contentobject_attribute_id", $attributeID );
         $binary->setAttribute( "version", $objectVersion );
         $binary->setAttribute( "filename", $destFileName );
@@ -491,18 +439,12 @@ class eZBinaryFileType extends eZDataType
         return true;
     }
 
-    /*!
-      We support file information
-    */
     function hasStoredFileInformation( $object, $objectVersion, $objectLanguage,
                                        $objectAttribute )
     {
         return true;
     }
 
-    /*!
-      Extracts file information for the binaryfile entry.
-    */
     function storedFileInformation( $object, $objectVersion, $objectLanguage,
                                     $objectAttribute )
     {
@@ -514,9 +456,6 @@ class eZBinaryFileType extends eZDataType
         }
         return false;
     }
-    /*!
-      Updates download count for binary file.
-    */
     function handleDownload( $object, $objectVersion, $objectLanguage,
                              $objectAttribute )
     {
@@ -546,9 +485,6 @@ class eZBinaryFileType extends eZDataType
             $classAttribute->setAttribute( self::MAX_FILESIZE_FIELD, $filesizeValue );
         }
     }
-    /*!
-     Returns the object title.
-    */
     function title( $contentObjectAttribute,  $name = "original_filename" )
     {
         $value = false;
@@ -569,6 +505,10 @@ class eZBinaryFileType extends eZDataType
         return true;
     }
 
+    /**
+     * @inheritdoc
+     * @return eZBinaryFile
+     */
     function objectAttributeContent( $contentObjectAttribute )
     {
         $binaryFile = eZBinaryFile::fetch( $contentObjectAttribute->attribute( "id" ),
@@ -610,16 +550,13 @@ class eZBinaryFileType extends eZDataType
 
     function unserializeContentClassAttribute( $classAttribute, $attributeNode, $attributeParametersNode )
     {
+        /** @var DOMElement $sizeNode */
         $sizeNode = $attributeParametersNode->getElementsByTagName( 'max-size' )->item( 0 );
         $maxSize = $sizeNode->textContent;
         $unitSize = $sizeNode->getAttribute( 'unit-size' );
         $classAttribute->setAttribute( self::MAX_FILESIZE_FIELD, $maxSize );
     }
 
-    /*!
-     \return string representation of an contentobjectattribute data for simplified export
-
-    */
     function toString( $objectAttribute )
     {
         $binaryFile = $objectAttribute->content();
@@ -631,8 +568,6 @@ class eZBinaryFileType extends eZDataType
         else
             return '';
     }
-
-
 
     function fromString( $objectAttribute, $string )
     {
@@ -731,6 +666,7 @@ class eZBinaryFileType extends eZDataType
 
     /**
      * Checks if current HTTP request is asking for current binary file deletion
+     *
      * @param eZHTTPTool $http
      * @param eZContentObjectAttribute $contentObjectAttribute
      * @return bool

--- a/kernel/classes/datatypes/ezboolean/ezbooleantype.php
+++ b/kernel/classes/datatypes/ezboolean/ezbooleantype.php
@@ -8,17 +8,18 @@
  * @package kernel
  */
 
-/*!
-  \class eZBooleanType ezbooleantype.php
-  \ingroup eZDatatype
-  \brief Stores a boolean value
-
-*/
-
+/**
+ * Stores a boolean value
+ *
+ * @package kernel
+ */
 class eZBooleanType extends eZDataType
 {
     const DATA_TYPE_STRING = "ezboolean";
 
+    /**
+     * Initializes the datatype
+     */
     function eZBooleanType()
     {
         $this->eZDataType( self::DATA_TYPE_STRING, ezpI18n::tr( 'kernel/classes/datatypes', "Checkbox", 'Datatype name' ),
@@ -33,10 +34,6 @@ class eZBooleanType extends eZDataType
     {
     }
 
-
-   /*!
-     Sets the default value.
-    */
     function initializeObjectAttribute( $contentObjectAttribute, $currentVersion, $originalContentObjectAttribute )
     {
         if ( $currentVersion != false )
@@ -52,9 +49,6 @@ class eZBooleanType extends eZDataType
         }
     }
 
-    /*!
-      Validates the http post var boolean input.
-    */
     function validateObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         $classAttribute = $contentObjectAttribute->contentClassAttribute();
@@ -96,9 +90,6 @@ class eZBooleanType extends eZDataType
         }
     }
 
-    /*!
-     Fetches the http post var boolean input and stores it in the data instance.
-    */
     function fetchObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         if ( $http->hasPostVariable( $base . "_data_boolean_" . $contentObjectAttribute->attribute( "id" ) ))
@@ -117,9 +108,6 @@ class eZBooleanType extends eZDataType
         return true;
     }
 
-   /*!
-    Fetches the http post variables for collected information
-   */
     function fetchCollectionAttributeHTTPInput( $collection, $collectionAttribute, $http, $base, $contentObjectAttribute )
     {
         if ( $http->hasPostVariable( $base . "_data_boolean_" . $contentObjectAttribute->attribute( "id" ) ))
@@ -161,10 +149,7 @@ class eZBooleanType extends eZDataType
     {
         return $contentObjectAttribute->attribute( "data_int" );
     }
-    /*!
-     \return string representation of an contentobjectattribute data for simplified export
 
-    */
     function toString( $contentObjectAttribute )
     {
         return $contentObjectAttribute->attribute( 'data_int' );
@@ -195,17 +180,11 @@ class eZBooleanType extends eZDataType
         return 'int';
     }
 
-    /*!
-     Returns the content.
-    */
     function objectAttributeContent( $contentObjectAttribute )
     {
         return $contentObjectAttribute->attribute( "data_int" );
     }
 
-    /*!
-     Returns the integer value.
-    */
     function title( $contentObjectAttribute, $name = null )
     {
         return $contentObjectAttribute->attribute( "data_int" );

--- a/kernel/classes/datatypes/ezcountry/ezcountrytype.php
+++ b/kernel/classes/datatypes/ezcountry/ezcountrytype.php
@@ -8,17 +8,11 @@
  * @package kernel
  */
 
-/*!
-  \class eZCountryType ezcountrytype.php
-  \ingroup eZDatatype
-  \brief A content datatype that contains country.
-
-  The list of countries is fetched from contenet.ini.
-  Country is stored as text string.
-*/
-
-
-
+/**
+ * A content datatype that contains countries.
+ *
+ * @package kernel
+ */
 class eZCountryType extends eZDataType
 {
     const DATA_TYPE_STRING = 'ezcountry';
@@ -27,6 +21,9 @@ class eZCountryType extends eZDataType
 
     const MULTIPLE_CHOICE_FIELD = 'data_int1';
 
+    /**
+     * Initializes the datatype
+     */
     function eZCountryType()
     {
         $this->eZDataType( self::DATA_TYPE_STRING, ezpI18n::tr( 'kernel/classes/datatypes', 'Country', 'Datatype name' ),
@@ -34,9 +31,11 @@ class eZCountryType extends eZDataType
                                   'object_serialize_map' => array( 'data_text' => 'country' ) ) );
     }
 
-    /*!
-     Fetches country list from ini.
-    */
+    /**
+     * Fetches a list of countryies list from country.ini
+     *
+     * @return array
+     */
     static function fetchCountryList()
     {
         if ( isset( $GLOBALS['CountryList'] ) )
@@ -49,10 +48,11 @@ class eZCountryType extends eZDataType
         return $countries;
     }
 
-    /*!
-      Fetches translated country names from locale
-      \a $countries will be updated.
-    */
+    /**
+     * Fetches translated country names from locale. $countries will be updated.
+     *
+     * @param $countries
+     */
     static function fetchTranslatedNames( &$countries )
     {
         $locale = eZLocale::instance();
@@ -78,10 +78,13 @@ class eZCountryType extends eZDataType
         return strcoll( $a["Name"], $b["Name"] );
     }
 
-    /*!
-      Fetches country by \a $fetchBy.
-      if \a $fetchBy is false country name will be used.
-    */
+    /**
+     * Fetches country by $fetchBy. If $fetchBy is false country name will be used.
+     *
+     * @param string $value
+     * @param string|bool $fetchBy
+     * @return bool
+     */
     static function fetchCountry( $value, $fetchBy = false )
     {
         $fetchBy = !$fetchBy ? 'Name' : $fetchBy;
@@ -163,9 +166,6 @@ class eZCountryType extends eZDataType
         return false;
     }
 
-    /*!
-     Sets the default value.
-    */
     function initializeObjectAttribute( $contentObjectAttribute, $currentVersion, $originalContentObjectAttribute )
     {
         if ( $currentVersion != false )
@@ -216,9 +216,6 @@ class eZCountryType extends eZDataType
         return eZInputValidator::STATE_INVALID;
     }
 
-    /*!
-     Fetches the http post var and stores it in the data instance.
-    */
     function fetchObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         if ( $http->hasPostVariable( $base . '_country_' . $contentObjectAttribute->attribute( 'id' ) ) )
@@ -260,9 +257,6 @@ class eZCountryType extends eZDataType
         return true;
     }
 
-    /*!
-     Fetches the http post variables for collected information
-    */
     function fetchCollectionAttributeHTTPInput( $collection, $collectionAttribute, $http, $base, $contentObjectAttribute )
     {
         if ( $http->hasPostVariable( $base . "_country_" . $contentObjectAttribute->attribute( "id" ) ) )
@@ -286,9 +280,6 @@ class eZCountryType extends eZDataType
         $contentObjectAttribute->setAttribute( "data_text", $value );
     }
 
-    /*!
-     Simple string insertion is supported.
-    */
     function isSimpleStringInsertionSupported()
     {
         return true;
@@ -305,9 +296,10 @@ class eZCountryType extends eZDataType
         return true;
     }
 
-    /*!
-     Returns the content.
-    */
+    /**
+     * @inheritdoc
+     * @return array
+     */
     function objectAttributeContent( $contentObjectAttribute )
     {
         $value = $contentObjectAttribute->attribute( 'data_text' );
@@ -328,6 +320,10 @@ class eZCountryType extends eZDataType
         return $content;
     }
 
+    /**
+     * @inheritdoc
+     * @return array
+     */
     function classAttributeContent( $classAttribute )
     {
         $defaultCountry = $classAttribute->attribute( self::DEFAULT_LIST_FIELD );
@@ -346,9 +342,6 @@ class eZCountryType extends eZDataType
         return $content;
     }
 
-    /*!
-     Returns the meta data used for storing search indeces.
-    */
     function metaData( $contentObjectAttribute )
     {
         $content = $contentObjectAttribute->content();
@@ -368,9 +361,6 @@ class eZCountryType extends eZDataType
         return $content['value'];
     }
 
-    /*!
-     \return string representation of an contentobjectattribute data for simplified export
-    */
     function toString( $contentObjectAttribute )
     {
         return $contentObjectAttribute->attribute( 'data_text' );
@@ -381,9 +371,6 @@ class eZCountryType extends eZDataType
         return $contentObjectAttribute->setAttribute( 'data_text', $string );
     }
 
-    /*!
-     Returns the country for use as a title
-    */
     function title( $contentObjectAttribute, $name = null )
     {
         $content = $contentObjectAttribute->content();

--- a/kernel/classes/datatypes/ezdate/ezdatetype.php
+++ b/kernel/classes/datatypes/ezdate/ezdatetype.php
@@ -8,13 +8,11 @@
  * @package kernel
  */
 
-/*!
-  \class eZDateType ezdatetype.php
-  \ingroup eZDatatype
-  \brief Stores a date value
-
-*/
-
+/**
+ * Stores a date value
+ *
+ * @package kernel
+ */
 class eZDateType extends eZDataType
 {
     const DATA_TYPE_STRING = "ezdate";
@@ -25,13 +23,24 @@ class eZDateType extends eZDataType
 
     const DEFAULT_CURRENT_DATE = 1;
 
+    /**
+     * Initializes the datatype
+     */
     function eZDateType()
     {
         $this->eZDataType( self::DATA_TYPE_STRING, ezpI18n::tr( 'kernel/classes/datatypes', "Date", 'Datatype name' ),
                            array( 'serialize_supported' => true ) );
     }
 
-
+    /**
+     * Validates the given values if they form a valid date
+     *
+     * @param int|string $day
+     * @param int|string $month
+     * @param int|string $year
+     * @param eZContentObjectAttribute $contentObjectAttribute
+     * @return int
+     */
     function validateDateTimeHTTPInput( $day, $month, $year, $contentObjectAttribute )
     {
         $state = eZDateTimeValidator::validateDate( $day, $month, $year );
@@ -43,10 +52,7 @@ class eZDateType extends eZDataType
         }
         return $state;
     }
-    /*!
-     Validates the input and returns true if the input was
-     valid for this datatype.
-    */
+
     function validateObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         $classAttribute = $contentObjectAttribute->contentClassAttribute();
@@ -86,9 +92,6 @@ class eZDateType extends eZDataType
         return eZInputValidator::STATE_ACCEPTED;
     }
 
-    /*!
-     Fetches the http post var integer input and stores it in the data instance.
-    */
     function fetchObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         if ( $http->hasPostVariable( $base . '_date_year_' . $contentObjectAttribute->attribute( 'id' ) ) and
@@ -151,9 +154,6 @@ class eZDateType extends eZDataType
             return eZInputValidator::STATE_INVALID;
     }
 
-    /*!
-     Fetches the http post variables for collected information
-    */
     function fetchCollectionAttributeHTTPInput( $collection, $collectionAttribute, $http, $base, $contentObjectAttribute )
     {
         if ( $http->hasPostVariable( $base . '_date_year_' . $contentObjectAttribute->attribute( 'id' ) ) and
@@ -184,9 +184,10 @@ class eZDateType extends eZDataType
         return false;
     }
 
-    /*!
-     Returns the content.
-    */
+    /**
+     * @inheritdoc
+     * @return eZDate
+     */
     function objectAttributeContent( $contentObjectAttribute )
     {
         $date = new eZDate( );
@@ -195,9 +196,6 @@ class eZDateType extends eZDataType
         return $date;
     }
 
-    /*!
-     Set class attribute value for template version
-    */
     function initializeClassAttribute( $classAttribute )
     {
         if ( $classAttribute->attribute( self::DEFAULT_FIELD ) == null )
@@ -205,9 +203,6 @@ class eZDateType extends eZDataType
         $classAttribute->store();
     }
 
-    /*!
-     Sets the default value.
-    */
     function initializeObjectAttribute( $contentObjectAttribute, $currentVersion, $originalContentObjectAttribute )
     {
         if ( $currentVersion != false )
@@ -245,18 +240,15 @@ class eZDateType extends eZDataType
         return true;
     }
 
-    /*!
-     Returns the meta data used for storing search indeces.
-    */
+    /**
+     * @inheritdoc
+     * @return int
+     */
     function metaData( $contentObjectAttribute )
     {
         return (int)$contentObjectAttribute->attribute( 'data_int' );
     }
 
-    /*!
-     \return string representation of an contentobjectattribute data for simplified export
-
-    */
     function toString( $contentObjectAttribute )
     {
         return $contentObjectAttribute->attribute( 'data_int' );
@@ -267,9 +259,13 @@ class eZDateType extends eZDataType
         return $contentObjectAttribute->setAttribute( 'data_int', $string );
     }
 
-    /*!
-     Returns the date.
-    */
+    /**
+     * Returns the date in the current locale
+     *
+     * @param eZContentObjectAttribute $contentObjectAttribute
+     * @param null $name Unused
+     * @return string
+     */
     function title( $contentObjectAttribute, $name = null )
     {
         $locale = eZLocale::instance();
@@ -313,6 +309,7 @@ class eZDateType extends eZDataType
 
     function unserializeContentClassAttribute( $classAttribute, $attributeNode, $attributeParametersNode )
     {
+        /** @var DOMElement $defaultNode */
         $defaultNode = $attributeParametersNode->getElementsByTagName( 'default-value' )->item( 0 );
         $defaultValue = strtolower( $defaultNode->getAttribute( 'type' ) );
         switch ( $defaultValue )

--- a/kernel/classes/datatypes/ezdatetime/ezdatetimetype.php
+++ b/kernel/classes/datatypes/ezdatetime/ezdatetimetype.php
@@ -8,13 +8,11 @@
  * @package kernel
  */
 
-/*!
-  \class eZDateTimeType ezdatetimetype.php
-  \ingroup eZDatatype
-  \brief Stores a date and time value
-
-*/
-
+/**
+ * Stores a date and time value
+ *
+ * @package kernel
+ */
 class eZDateTimeType extends eZDataType
 {
     const DATA_TYPE_STRING = 'ezdatetime';
@@ -31,15 +29,27 @@ class eZDateTimeType extends eZDataType
 
     const DEFAULT_ADJUSTMENT = 2;
 
+    /**
+     * Initializes the datatype
+     */
     function eZDateTimeType()
     {
         $this->eZDataType( self::DATA_TYPE_STRING, ezpI18n::tr( 'kernel/classes/datatypes', "Date and time", 'Datatype name' ),
                            array( 'serialize_supported' => true ) );
     }
 
-    /*!
-     Private method only for use inside this class
-    */
+    /**
+     * Validates the given values if they form a valid datetime
+     *
+     * @param int|string $day
+     * @param int|string $month
+     * @param int|string $year
+     * @param int|string $hour
+     * @param int|string $minute
+     * @param int|string $second
+     * @param eZContentObjectAttribute $contentObjectAttribute
+     * @return int
+     */
     function validateDateTimeHTTPInput( $day, $month, $year, $hour, $minute, $second, $contentObjectAttribute )
     {
         $state = eZDateTimeValidator::validateDate( $day, $month, $year );
@@ -61,10 +71,6 @@ class eZDateTimeType extends eZDataType
         return $state;
     }
 
-    /*!
-     Validates the input and returns true if the input was
-     valid for this datatype.
-    */
     function validateObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         $classAttribute = $contentObjectAttribute->contentClassAttribute();
@@ -121,9 +127,6 @@ class eZDateTimeType extends eZDataType
             return eZInputValidator::STATE_ACCEPTED;
     }
 
-    /*!
-     Fetches the http post var integer input and stores it in the data instance.
-    */
     function fetchObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         $contentClassAttribute = $contentObjectAttribute->contentClassAttribute();
@@ -213,9 +216,6 @@ class eZDateTimeType extends eZDataType
             return eZInputValidator::STATE_INVALID;
     }
 
-   /*!
-    Fetches the http post variables for collected information
-   */
     function fetchCollectionAttributeHTTPInput( $collection, $collectionAttribute, $http, $base, $contentObjectAttribute )
     {
         $contentClassAttribute = $contentObjectAttribute->contentClassAttribute();
@@ -254,9 +254,10 @@ class eZDateTimeType extends eZDataType
         return false;
     }
 
-    /*!
-     Returns the content.
-    */
+    /**
+     * @inheritdoc
+     * @return eZDateTime
+     */
     function objectAttributeContent( $contentObjectAttribute )
     {
         $dateTime = new eZDateTime();
@@ -275,17 +276,11 @@ class eZDateTimeType extends eZDataType
         return true;
     }
 
-    /*!
-     Returns the meta data used for storing search indeces.
-    */
     function metaData( $contentObjectAttribute )
     {
         return (int)$contentObjectAttribute->attribute( 'data_int' );
     }
-    /*!
-     \return string representation of an contentobjectattribute data for simplified export
 
-    */
     function toString( $contentObjectAttribute )
     {
         return $contentObjectAttribute->attribute( 'data_int' );
@@ -296,9 +291,6 @@ class eZDateTimeType extends eZDataType
         return $contentObjectAttribute->setAttribute( 'data_int', $string );
     }
 
-    /*!
-     Set class attribute value for template version
-    */
     function initializeClassAttribute( $classAttribute )
     {
         if ( $classAttribute->attribute( self::DEFAULT_FIELD ) == null )
@@ -306,6 +298,12 @@ class eZDateTimeType extends eZDataType
         $classAttribute->store();
     }
 
+    /**
+     * Parses an XML Text into a DOMDocument
+     *
+     * @param string $xmlText
+     * @return DOMDocument
+     */
     function parseXML( $xmlText )
     {
         $dom = new DOMDocument;
@@ -313,6 +311,10 @@ class eZDateTimeType extends eZDataType
         return $dom;
     }
 
+    /**
+     * @inheritdoc
+     * @return array
+     */
     function classAttributeContent( $classAttribute )
     {
         $xmlText = $classAttribute->attribute( 'data_text5' );
@@ -356,6 +358,9 @@ class eZDateTimeType extends eZDataType
         return $content;
     }
 
+    /**
+     * @return array
+     */
     function defaultClassAttributeContent()
     {
         return array( 'year' => '',
@@ -366,9 +371,6 @@ class eZDateTimeType extends eZDataType
                       'second' => '' );
     }
 
-    /*!
-     Sets the default value.
-    */
     function initializeObjectAttribute( $contentObjectAttribute, $currentVersion, $originalContentObjectAttribute )
     {
         if ( $currentVersion != false )
@@ -429,6 +431,9 @@ class eZDateTimeType extends eZDataType
         return true;
     }
 
+    /**
+     * @return array
+     */
     function contentObjectArrayXMLMap()
     {
         return array( 'year' => 'year',
@@ -439,10 +444,6 @@ class eZDateTimeType extends eZDataType
                       'second' => 'second' );
     }
 
-
-    /*!
-     Returns the date.
-    */
     function title( $contentObjectAttribute, $name = null )
     {
         $locale = eZLocale::instance();

--- a/kernel/classes/datatypes/ezemail/ezemailtype.php
+++ b/kernel/classes/datatypes/ezemail/ezemailtype.php
@@ -8,17 +8,18 @@
  * @package kernel
  */
 
-/*!
-  \class eZEmailType ezemailtype.php
-  \ingroup eZDatatype
-  \brief Stores an email address
-
-*/
-
+/**
+ * Stores an email address
+ *
+ * @package kernel
+ */
 class eZEmailType extends eZDataType
 {
     const DATA_TYPE_STRING = "ezemail";
 
+    /**
+     * Initializes the datatype
+     */
     function eZEmailType()
     {
         $this->eZDataType( self::DATA_TYPE_STRING, ezpI18n::tr( 'kernel/classes/datatypes', "Email", 'Datatype name' ),
@@ -26,9 +27,6 @@ class eZEmailType extends eZDataType
                                   'object_serialize_map' => array( 'data_text' => 'email' ) ) );
     }
 
-    /*!
-     Sets the default value.
-    */
     function initializeObjectAttribute( $contentObjectAttribute, $currentVersion, $originalContentObjectAttribute )
     {
         if ( $currentVersion != false )
@@ -38,9 +36,13 @@ class eZEmailType extends eZDataType
         }
     }
 
-    /*
-     Private method, only for using inside this class.
-    */
+    /**
+     * Checks if $email is a valid email address
+     *
+     * @param string $email
+     * @param eZContentObjectAttribute $contentObjectAttribute
+     * @return int
+     */
     function validateEMailHTTPInput( $email, $contentObjectAttribute )
     {
         if ( !eZMail::validate( $email ) )
@@ -52,10 +54,6 @@ class eZEmailType extends eZDataType
         return eZInputValidator::STATE_ACCEPTED;
     }
 
-    /*!
-     Validates the input and returns true if the input was
-     valid for this datatype.
-    */
     function validateObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         $classAttribute = $contentObjectAttribute->contentClassAttribute();
@@ -91,9 +89,6 @@ class eZEmailType extends eZDataType
         return eZInputValidator::STATE_ACCEPTED;
     }
 
-    /*!
-     Fetches the http post var string input and stores it in the data instance.
-    */
     function fetchObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         if ( $http->hasPostVariable( $base . "_data_text_" . $contentObjectAttribute->attribute( "id" ) ) )
@@ -136,9 +131,6 @@ class eZEmailType extends eZDataType
             return eZInputValidator::STATE_INVALID;
     }
 
-    /*!
-     Fetches the http post variables for collected information
-    */
     function fetchCollectionAttributeHTTPInput( $collection, $collectionAttribute, $http, $base, $contentObjectAttribute )
     {
         if ( $http->hasPostVariable( $base . "_data_text_" . $contentObjectAttribute->attribute( "id" ) ) )
@@ -150,16 +142,14 @@ class eZEmailType extends eZDataType
         return false;
     }
 
-    /*!
-     Store the content.
-    */
     function storeObjectAttribute( $attribute )
     {
     }
 
-    /*!
-     Returns the content.
-    */
+    /**
+     * @inheritdoc
+     * @return string
+     */
     function objectAttributeContent( $contentObjectAttribute )
     {
         return $contentObjectAttribute->attribute( "data_text" );
@@ -170,18 +160,15 @@ class eZEmailType extends eZDataType
         return true;
     }
 
-    /*!
-     Returns the meta data used for storing search indeces.
-    */
+    /**
+     * @inheritdoc
+     * @returns string
+     */
     function metaData( $contentObjectAttribute )
     {
         return $contentObjectAttribute->attribute( "data_text" );
     }
 
-    /*!
-     \return string representation of an contentobjectattribute data for simplified export
-
-    */
     function toString( $contentObjectAttribute )
     {
         return $contentObjectAttribute->attribute( 'data_text' );
@@ -192,9 +179,6 @@ class eZEmailType extends eZDataType
         return $contentObjectAttribute->setAttribute( 'data_text', $string );
     }
 
-    /*!
-     Returns the text.
-    */
     function title( $contentObjectAttribute, $name = null )
     {
         return $contentObjectAttribute->attribute( "data_text" );

--- a/kernel/classes/datatypes/ezenum/ezenumtype.php
+++ b/kernel/classes/datatypes/ezenum/ezenumtype.php
@@ -8,12 +8,11 @@
  * @package kernel
  */
 
-/*!
-  \class eZEnumType ezenumtype.php
-  \ingroup eZDatatype
-
-*/
-
+/**
+ * Stores an eZEnum object
+ *
+ * @package kernel
+ */
 class eZEnumType extends eZDataType
 {
     const DATA_TYPE_STRING = 'ezenum';
@@ -22,18 +21,15 @@ class eZEnumType extends eZDataType
     const IS_OPTION_FIELD = 'data_int2';
     const IS_OPTION_VARIABLE = '_ezenum_isoption_value_';
 
-    /*!
-     Constructor
-    */
+    /**
+     * Initializes the datatype
+     */
     function eZEnumType()
     {
          $this->eZDataType( self::DATA_TYPE_STRING, ezpI18n::tr( 'kernel/classes/datatypes', 'Enum', 'Datatype name' ),
                             array( 'serialize_supported' => true ) );
     }
 
-    /*!
-     Sets value according to current version
-    */
     function initializeObjectAttribute( $contentObjectAttribute, $currentVersion, $originalContentObjectAttribute )
     {
         if ( $currentVersion != false )
@@ -82,9 +78,6 @@ class eZEnumType extends eZDataType
         $db->commit();
     }
 
-    /*!
-     Set class attribute value for template version
-    */
     function initializeClassAttribute( $classAttribute )
     {
         $contentClassAttributeID = $classAttribute->attribute( 'id' );
@@ -104,9 +97,6 @@ class eZEnumType extends eZDataType
         }
     }
 
-    /*!
-     Delete stored object attribute
-    */
     function deleteStoredObjectAttribute( $contentObjectAttribute, $version = null )
     {
         $contentObjectAttributeID = $contentObjectAttribute->attribute( 'id' );
@@ -114,9 +104,6 @@ class eZEnumType extends eZDataType
 
     }
 
-    /*!
-     Delete stored class attribute
-    */
     function deleteStoredClassAttribute( $contentClassAttribute, $version = null )
     {
         $contentClassAttributeID = $contentClassAttribute->attribute( 'id' );
@@ -124,9 +111,6 @@ class eZEnumType extends eZDataType
 
     }
 
-    /*!
-     Fetches the http post var integer input and stores it in the data instance.
-    */
     function fetchObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         $contentObjectAttributeID = $contentObjectAttribute->attribute( 'id' );
@@ -176,10 +160,6 @@ class eZEnumType extends eZDataType
         return false;
     }
 
-    /*!
-     Validates the input and returns true if the input was
-     valid for this datatype.
-    */
     function validateObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         if ( $http->hasPostVariable( $base . '_data_enumid_' . $contentObjectAttribute->attribute( 'id' ) ) )
@@ -200,17 +180,14 @@ class eZEnumType extends eZDataType
         return eZInputValidator::STATE_ACCEPTED;
     }
 
-    /*!
-     Does nothing since it has been stored.
-     See fetchObjectAttributeHTTPInput for the actual storing.
-    */
     function storeObjectAttribute( $contentObjectAttribute )
     {
     }
 
-    /*!
-     Returns actual the class attribute content.
-    */
+    /**
+     * @inheritdoc
+     * @return eZEnum
+     */
     function objectAttributeContent( $contentObjectAttribute )
     {
         $contentObjectAttributeID = $contentObjectAttribute->attribute( 'id' );
@@ -227,18 +204,11 @@ class eZEnumType extends eZDataType
         return $enum;
     }
 
-    /*!
-     Validates the input and returns true if the input was
-     valid for this datatype.
-    */
     function validateClassAttributeHTTPInput( $http, $base, $contentClassAttribute )
     {
         return eZInputValidator::STATE_ACCEPTED;
     }
 
-    /*!
-     Fetches the http post var integer input and stores it in the data instance.
-    */
     function fetchClassAttributeHTTPInput( $http, $base, $contentClassAttribute )
     {
         $ismultiple = $base . self::IS_MULTIPLE_VARIABLE . $contentClassAttribute->attribute( 'id' );
@@ -266,6 +236,7 @@ class eZEnumType extends eZDataType
             $array_enumID = $http->postVariable(  $enumID );
             $array_enumElement = $http->postVariable( $enumElement );
             $array_enumValue = $http->postVariable( $enumValue );
+            /** @var eZEnum $enum */
             $enum = $contentClassAttribute->content();
             $enum->setValue( $array_enumID, $array_enumElement, $array_enumValue, $version );
             $contentClassAttribute->setContent( $enum );
@@ -287,9 +258,10 @@ class eZEnumType extends eZDataType
         $contentClassAttribute->content()->setVersion( eZContentClass::VERSION_STATUS_MODIFIED );
     }
 
-    /*!
-     Returns the content.
-    */
+    /**
+     * @inheritdoc
+     * @return eZEnum
+     */
     function classAttributeContent( $contentClassAttribute )
     {
         $id = $contentClassAttribute->attribute( 'id' );
@@ -305,12 +277,14 @@ class eZEnumType extends eZDataType
         {
             case 'new_enumelement' :
             {
+                /** @var eZEnum $enum */
                 $enum = $contentClassAttribute->content( );
                 $enum->addEnumeration('');
                 $contentClassAttribute->setContent( $enum );
             }break;
             case 'remove_selected' :
             {
+                /** @var eZEnum $enum */
                 $enum = $contentClassAttribute->content( );
                 $version = $contentClassAttribute->attribute( 'version' );
                 $postvarname = 'ContentClass' . '_data_enumremove_' . $contentClassAttribute->attribute( 'id' );
@@ -327,13 +301,10 @@ class eZEnumType extends eZDataType
         }
     }
 
-    /*!
-     Returns the object attribute title.
-    */
     function title( $contentObjectAttribute, $name = null )
     {
         $enum = $this->objectAttributeContent( $contentObjectAttribute );
-
+        /** @var eZEnumObjectValue[] $enumObjectList */
         $enumObjectList = $enum->attribute( 'enumobject_list' );
 
         $value = '';
@@ -348,9 +319,10 @@ class eZEnumType extends eZDataType
         return $value;
     }
 
-    /*!
-     Returns the meta data used for storing search indeces.
-    */
+    /**
+     * @inheritdoc
+     * @return string
+     */
     function metaData( $contentObjectAttribute )
     {
         $contentObjectAttributeID = $contentObjectAttribute->attribute( 'id' );
@@ -369,15 +341,13 @@ class eZEnumType extends eZDataType
         $return = '';
         foreach ( $enum->attribute( 'enumobject_list' ) as $enumElement )
         {
+            /** @var eZEnumObjectValue $enumElement */
             $return .= $enumElement->attribute( 'enumvalue' ) . ' ';
             $return .= $enumElement->attribute( 'enumelement' ) . ' ';
         }
         return $return;
     }
 
-    /*!
-     Sets \c grouped_input to \c true when checkboxes or radiobuttons are used.
-    */
     function objectDisplayInformation( $objectAttribute, $mergeInfo = false )
     {
         $classAttribute = $objectAttribute->contentClassAttribute();
@@ -393,10 +363,6 @@ class eZEnumType extends eZDataType
     {
         return true;
     }
-
-    /*!
-     \return a DOM representation of the content object attribute
-    */
 
     function serializeContentObjectAttribute( $package, $contentObjectAttribute )
     {
@@ -420,14 +386,6 @@ class eZEnumType extends eZDataType
         return $node;
     }
 
-
-    /*!
-     Unserialize contentobject attribute
-
-     \param package
-     \param contentobject attribute object
-     \param ezdomnode object
-    */
     function unserializeContentObjectAttribute( $package, $objectAttribute, $attributeNode )
     {
         if ( $attributeNode->hasChildNodes() )
@@ -435,6 +393,7 @@ class eZEnumType extends eZDataType
             $contentObjectAttributeID = $objectAttribute->attribute( 'id' );
             $contentObjectAttributeVersion = $objectAttribute->attribute( 'version' );
 
+            /** @var DOMElement[] $enumNodes */
             $enumNodes = $attributeNode->childNodes;
             foreach ( $enumNodes as $enumNode )
             {
@@ -455,7 +414,6 @@ class eZEnumType extends eZDataType
         }
     }
 
-
     function hasObjectAttributeContent( $contentObjectAttribute )
     {
         return true;
@@ -466,11 +424,13 @@ class eZEnumType extends eZDataType
         $isOption = $classAttribute->attribute( self::IS_OPTION_FIELD );
         $isMultiple = $classAttribute->attribute( self::IS_MULTIPLE_FIELD );
         $content = $classAttribute->attribute( 'content' );
+        /** @var eZEnumObjectValue[] $enumList */
         $enumList = $content->attribute( 'enum_list' );
         $attributeParametersNode->setAttribute( 'is-option', $isOption ? 'true' : 'false' );
         $attributeParametersNode->setAttribute( 'is-multiple', $isMultiple ? 'true' : 'false' );
 
         $elementListNode = $attributeParametersNode->ownerDocument->createElement( 'elements' );
+        /** @var DOMNode $attributeParametersNode */
         $attributeParametersNode->appendChild( $elementListNode );
         foreach( $enumList as $enumElement )
         {
@@ -490,9 +450,11 @@ class eZEnumType extends eZDataType
         $classAttribute->setAttribute( self::IS_MULTIPLE_FIELD, $isMultiple );
 
         $enum = new eZEnum( $classAttribute->attribute( 'id' ), $classAttribute->attribute( 'version' ) );
+        /** @var DOMElement $elementListNode */
         $elementListNode = $attributeParametersNode->getElementsByTagName( 'elements' )->item( 0 );
         if ( $elementListNode )
         {
+            /** @var DOMElement[] $elementList */
             $elementList = $elementListNode->getElementsByTagName( 'element' );
             foreach ( $elementList as $element )
             {

--- a/kernel/classes/datatypes/ezfloat/ezfloattype.php
+++ b/kernel/classes/datatypes/ezfloat/ezfloattype.php
@@ -8,13 +8,11 @@
  * @package kernel
  */
 
-/*!
-  \class eZFloatType ezfloattype.php
-  \ingroup eZDatatype
-  \brief Stores a float value
-
-*/
-
+/**
+ * Stores a float value
+ *
+ * @package kernel
+ */
 class eZFloatType extends eZDataType
 {
     const DATA_TYPE_STRING = "ezfloat";
@@ -30,6 +28,9 @@ class eZFloatType extends eZDataType
     const HAS_MAX_VALUE = 2;
     const HAS_MIN_MAX_VALUE = 3;
 
+    /**
+     * Initializes the datatype
+     */
     function eZFloatType()
     {
         $this->eZDataType( self::DATA_TYPE_STRING, ezpI18n::tr( 'kernel/classes/datatypes', "Float", 'Datatype name' ),
@@ -38,9 +39,6 @@ class eZFloatType extends eZDataType
         $this->FloatValidator = new eZFloatValidator();
     }
 
-    /*!
-     Sets the default value.
-    */
     function initializeObjectAttribute( $contentObjectAttribute, $currentVersion, $originalContentObjectAttribute )
     {
         if ( $currentVersion != false )
@@ -62,9 +60,6 @@ class eZFloatType extends eZDataType
         }
     }
 
-    /*!
-     Fetches the http post var float input and stores it in the data instance.
-    */
     function fetchObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         if ( $http->hasPostVariable( $base . "_data_float_" . $contentObjectAttribute->attribute( "id" ) ) )
@@ -83,10 +78,6 @@ class eZFloatType extends eZDataType
         return false;
     }
 
-    /*!
-     Validates the input and returns true if the input was
-     valid for this datatype.
-    */
     function validateObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         if ( $http->hasPostVariable( $base . "_data_float_" . $contentObjectAttribute->attribute( "id" ) ) )
@@ -308,17 +299,14 @@ class eZFloatType extends eZDataType
         return (float)$contentObjectAttribute->attribute( "data_float" );
     }
 
-    /*!
-     Returns the content.
-    */
+    /**
+     * @inheritdoc
+     * @return float
+     */
     function objectAttributeContent( $contentObjectAttribute )
     {
         return $contentObjectAttribute->attribute( 'data_float' );
     }
-
-    /*!
-     Returns the float value.
-    */
 
     function title( $contentObjectAttribute, $name = null )
     {
@@ -329,10 +317,7 @@ class eZFloatType extends eZDataType
     {
         return $contentObjectAttribute->attribute( 'data_float' ) !== null;
     }
-    /*!
-     \return string representation of an contentobjectattribute data for simplified export
 
-    */
     function toString( $contentObjectAttribute )
     {
         return $contentObjectAttribute->attribute( 'data_float' );
@@ -405,8 +390,9 @@ class eZFloatType extends eZDataType
         return array();
     }
 
-    /// \privatesection
-    /// The float value validator
+    /**
+     * @var eZFloatValidator
+     */
     public $FloatValidator;
 }
 

--- a/kernel/classes/datatypes/ezidentifier/ezidentifiertype.php
+++ b/kernel/classes/datatypes/ezidentifier/ezidentifiertype.php
@@ -8,13 +8,11 @@
  * @package kernel
  */
 
-/*!
-  \class eZIdentifierType ezidentifiertype.php
-  \ingroup eZDatatype
-  \brief The class eZIdentifierType does
-
-*/
-
+/**
+ * Stores an eZIdentifier
+ *
+ * @package kernel
+ */
 class eZIdentifierType extends eZDataType
 {
     const PRETEXT_FIELD = "data_text1";
@@ -34,9 +32,9 @@ class eZIdentifierType extends eZDataType
 
     const DATA_TYPE_STRING = "ezidentifier";
 
-    /*!
-     Constructor
-    */
+    /**
+     * Initializes the datatype
+     */
     function eZIdentifierType()
     {
         $this->eZDataType( self::DATA_TYPE_STRING,
@@ -47,10 +45,6 @@ class eZIdentifierType extends eZDataType
         $this->IntegerValidator = new eZIntegerValidator( 1 );
     }
 
-    /*!
-     Validates the input and returns true if the input was
-     valid for this datatype.
-    */
     function validateObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
     }
@@ -59,17 +53,14 @@ class eZIdentifierType extends eZDataType
     {
     }
 
-    /*!
-     Store the content. Since the content has been stored in function fetchObjectAttributeHTTPInput(),
-     this function is with empty code.
-    */
     function storeObjectAttribute( $contentObjectattribute )
     {
     }
 
-    /*!
-     Returns the content.
-    */
+    /**
+     * @inheritdoc
+     * @return string
+     */
     function objectAttributeContent( $contentObjectAttribute )
     {
         $content = $contentObjectAttribute->attribute( "data_text" );
@@ -86,7 +77,6 @@ class eZIdentifierType extends eZDataType
         return $contentObjectAttribute->attribute( 'data_text' );
     }
 
-
     function fromString( $contentObjectAttribute, $string )
     {
         if ( $string == '' )
@@ -94,6 +84,7 @@ class eZIdentifierType extends eZDataType
         $contentObjectAttribute->setAttribute( 'data_text', $string );
         return true;
     }
+
     function hasObjectAttributeContent( $contentObjectAttribute )
     {
         $content = $contentObjectAttribute->attribute( "data_text" );
@@ -112,10 +103,6 @@ class eZIdentifierType extends eZDataType
         }
     }
 
-    /*!
-      Validates the input and returns true if the input was
-      valid for this datatype.
-    */
     function validateClassAttributeHTTPInput( $http, $base, $classAttribute )
     {
         $startValueName = $base . self::START_VALUE_VARIABLE . $classAttribute->attribute( "id" );
@@ -192,17 +179,15 @@ class eZIdentifierType extends eZDataType
         return true;
     }
 
-    /*!
-     Returns the meta data used for storing search indices.
-    */
+    /**
+     * @inheritdoc
+     * @return string
+     */
     function metaData( $contentObjectAttribute )
     {
         return $contentObjectAttribute->attribute( "data_text" );
     }
 
-    /*!
-     Returns the text.
-    */
     function title( $contentObjectAttribute, $name = null )
     {
         return  $contentObjectAttribute->attribute( "data_text" );
@@ -212,7 +197,6 @@ class eZIdentifierType extends eZDataType
     {
         return true;
     }
-
 
     function initializeObjectAttribute( $contentObjectAttribute, $currentVersion, $originalContentObjectAttribute )
     {
@@ -227,10 +211,6 @@ class eZIdentifierType extends eZDataType
         }
     }
 
-    /*!
-      When published it will check if it needs to aquire a new unique identifier, if so
-      it updates all existing versions with this new identifier.
-    */
     function onPublish( $contentObjectAttribute, $contentObject, $publishedNodes )
     {
         $contentClassAttribute = $contentObjectAttribute->attribute( 'contentclass_attribute' );
@@ -239,10 +219,13 @@ class eZIdentifierType extends eZDataType
         return $ret;
     }
 
-    /*!
-      \private
-      Assigns the identifiervalue for the first version of the current attribute.
-    */
+    /**
+     * Assigns the identifiervalue for the first version of the current attribute.
+     *
+     * @param eZContentClassAttribute $contentClassAttribute
+     * @param eZContentObjectAttribute $contentObjectAttribute
+     * @return bool
+     */
     function assignValue( $contentClassAttribute, $contentObjectAttribute )
     {
 
@@ -329,10 +312,14 @@ class eZIdentifierType extends eZDataType
         return 'string';
     }
 
-    /*!
-      \private
-      Store the new value to the attribute.
-    */
+    /**
+     * Stores the new value to the attribute.
+     *
+     * @param eZContentClassAttribute $contentClassAttribute
+     * @param eZContentObjectAttribute $contentObjectAttribute
+     * @param string $identifierValue
+     * @return bool
+     */
     function storeIdentifierValue( $contentClassAttribute, $contentObjectAttribute, $identifierValue )
     {
         $value = eZIdentifierType::generateIdentifierString( $contentClassAttribute, $identifierValue );
@@ -341,6 +328,13 @@ class eZIdentifierType extends eZDataType
         return true;
     }
 
+    /**
+     * Generates an identifier string
+     *
+     * @param eZContentClassAttribute $contentClassAttribute
+     * @param string|bool $identifierValue
+     * @return string
+     */
     function generateIdentifierString( $contentClassAttribute, $identifierValue = false )
     {
         $preText = $contentClassAttribute->attribute( self::PRETEXT_FIELD );

--- a/kernel/classes/datatypes/ezimage/ezimagetype.php
+++ b/kernel/classes/datatypes/ezimage/ezimagetype.php
@@ -8,21 +8,18 @@
  * @package kernel
  */
 
-/*!
-  \class eZImageType ezimagetype.php
-  \ingroup eZDatatype
-  \brief The class eZImageType handles image accounts and association with content objects
-
-  \note The method initializeObjectAttribute was removed in 3.8, the new
-        storage technique removes the need to have it.
-*/
-
+/**
+ * The class eZImageType handles image accounts and association with content objects
+ */
 class eZImageType extends eZDataType
 {
     const FILESIZE_FIELD = 'data_int1';
     const FILESIZE_VARIABLE = '_ezimage_max_filesize_';
     const DATA_TYPE_STRING = "ezimage";
 
+    /**
+     * Initializes the datatype
+     */
     function eZImageType()
     {
         $this->eZDataType( self::DATA_TYPE_STRING, ezpI18n::tr( 'kernel/classes/datatypes', "Image", 'Datatype name' ),
@@ -38,10 +35,13 @@ class eZImageType extends eZDataType
         }
     }
 
-    /*!
-     The object is being moved to trash, do any necessary changes to the attribute.
-     Rename file and update db row with new name, so that access to the file using old links no longer works.
-    */
+    /**
+     * The object is being moved to trash, do any necessary changes to the attribute.
+     * Rename file and update db row with new name, so that access to the file using old links no longer works.
+     *
+     * @param eZContentObjectAttribute $contentObjectAttribute
+     * @param int|null $version
+     */
     function trashStoredObjectAttribute( $contentObjectAttribute, $version = null )
     {
         $imageHandler = $contentObjectAttribute->attribute( "content" );
@@ -187,15 +187,6 @@ class eZImageType extends eZDataType
         }
     }
 
-    /**
-     * Validate the object attribute input in http. If there is validation failure, there failure message will be put into $contentObjectAttribute->ValidationError
-     * @param $http: http object
-     * @param $base:
-     * @param $contentObjectAttribute: content object attribute being validated
-     * @return validation result- eZInputValidator::STATE_INVALID or eZInputValidator::STATE_ACCEPTED
-     *
-     * @see kernel/classes/eZDataType#validateObjectAttributeHTTPInput($http, $base, $objectAttribute)
-     */
     function validateObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         $classAttribute = $contentObjectAttribute->contentClassAttribute();
@@ -267,15 +258,6 @@ class eZImageType extends eZDataType
         return eZInputValidator::STATE_ACCEPTED;
     }
 
-    /**
-     * Fetch object attribute http input, override the ezDataType method
-     * This method is triggered when submiting a http form which includes Image class
-     * Image is stored into file system every time there is a file input and validation result is valid.
-     * @param $http http object
-     * @param $base
-     * @param $contentObjectAttribute : the content object attribute being handled
-     * @return true if content object is not null, false if content object is null
-     */
     function fetchObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         $result = false;
@@ -333,25 +315,16 @@ class eZImageType extends eZDataType
         }
     }
 
-    /*!
-     HTTP file insertion is supported.
-    */
     function isHTTPFileInsertionSupported()
     {
         return true;
     }
 
-    /*!
-     Regular file insertion is supported.
-    */
     function isRegularFileInsertionSupported()
     {
         return true;
     }
 
-    /*!
-     Inserts the file using the Image Handler eZImageAliasHandler.
-    */
     function insertHTTPFile( $object, $objectVersion, $objectLanguage,
                              $objectAttribute, $httpFile, $mimeData,
                              &$result )
@@ -372,9 +345,6 @@ class eZImageType extends eZDataType
         return $status;
     }
 
-    /*!
-     Inserts the file using the Image Handler eZImageAliasHandler.
-    */
     function insertRegularFile( $object, $objectVersion, $objectLanguage,
                                 $objectAttribute, $filePath,
                                 &$result )
@@ -395,18 +365,12 @@ class eZImageType extends eZDataType
         return $status;
     }
 
-    /*!
-      We support file information
-    */
     function hasStoredFileInformation( $object, $objectVersion, $objectLanguage,
                                        $objectAttribute )
     {
         return true;
     }
 
-    /*!
-      Extracts file information for the image entry.
-    */
     function storedFileInformation( $object, $objectVersion, $objectLanguage,
                                     $objectAttribute )
     {
@@ -485,12 +449,16 @@ class eZImageType extends eZDataType
         }
     }
 
-    /*!
-     Will return one of the following items from the original alias.
-     - alternative_text - If it's not empty
-     - Default paramater in \a $name if it exists
-     - original_filename, this is the default fallback.
-    */
+    /**
+     * Will return one of the following items from the original alias.
+     * - alternative_text - If it's not empty
+     * - Default paramater in \a $name if it exists
+     * - original_filename, this is the default fallback.
+     *
+     * @param eZContentObjectAttribute $contentObjectAttribute
+     * @param string $name
+     * @return string
+     */
     function title( $contentObjectAttribute, $name = 'original_filename' )
     {
         $content = $contentObjectAttribute->content();
@@ -515,6 +483,10 @@ class eZImageType extends eZDataType
         return $handler->attribute( 'is_valid' );
     }
 
+    /**
+     * @inheritdoc
+     * @return eZImageAliasHandler
+     */
     function objectAttributeContent( $contentObjectAttribute )
     {
         $imageHandler = new eZImageAliasHandler( $contentObjectAttribute );
@@ -543,16 +515,13 @@ class eZImageType extends eZDataType
 
     function unserializeContentClassAttribute( $classAttribute, $attributeNode, $attributeParametersNode )
     {
+        /** @var DOMElement $sizeNode */
         $sizeNode = $attributeParametersNode->getElementsByTagName( 'max-size' )->item( 0 );
         $maxSize = $sizeNode->textContent;
         $unitSize = $sizeNode->getAttribute( 'unit-size' );
         $classAttribute->setAttribute( self::FILESIZE_FIELD, $maxSize );
     }
 
-
-    /*!
-     \return a DOM representation of the content object attribute
-    */
     function serializeContentObjectAttribute( $package, $objectAttribute )
     {
         $node = $this->createContentObjectAttributeDOMNode( $objectAttribute );
@@ -596,10 +565,6 @@ class eZImageType extends eZDataType
         $content->store( $objectAttribute );
     }
 
-    /*!
-     \return string representation of an contentobjectattribute data for simplified export
-
-    */
     function toString( $objectAttribute )
     {
         $content = $objectAttribute->content();

--- a/kernel/classes/datatypes/ezinisetting/ezinisettingtype.php
+++ b/kernel/classes/datatypes/ezinisetting/ezinisettingtype.php
@@ -8,16 +8,13 @@
  * @package kernel
  */
 
-/*!
-  \class eZIniSettingType ezinisettingtype.php
-  \ingroup eZDatatype
-  \brief A content datatype for setting ini file settings
-
-  Enable editing and versioning of ini files from the admin interface
-*/
-
-
-
+/**
+ * A content datatype for setting ini file settings
+ *
+ * Enable editing and versioning of ini files from the admin interface
+ *
+ * @package kernel
+ */
 class eZIniSettingType extends eZDataType
 {
     const DATA_TYPE_STRING = 'ezinisetting';
@@ -37,9 +34,9 @@ class eZIniSettingType extends eZDataType
 
     const CLASS_TYPE_ARRAY = 6;
 
-    /*!
-     Initializes with a string id and a description.
-    */
+    /**
+     * Initializes the datatype
+     */
     function eZIniSettingType()
     {
         $this->eZDataType( self::DATA_TYPE_STRING, ezpI18n::tr( 'kernel/classes/datatypes', 'Ini Setting', 'Datatype name' ),
@@ -312,15 +309,14 @@ class eZIniSettingType extends eZDataType
         }
     }
 
-    /*!
-     \private
-     Parse array input text into array with korrect keys.
-
-     \param input text
-     \param array to store parsed file to
-
-     \return true if parsed successfully, false if illegal syntax
-    */
+    /**
+     * Parse array input text into array with korrect keys.
+     *
+     * @param string $inputText
+     * @param array $outputArray array to store parsed file to
+     * @param bool $makeEmptyArray
+     * @return bool true if parsed successfully, false if illegal syntax
+     */
     function parseArrayInput( $inputText, &$outputArray, $makeEmptyArray = false )
     {
         $lineArray = explode( "\n", $inputText );
@@ -358,6 +354,10 @@ class eZIniSettingType extends eZDataType
         return true;
     }
 
+    /**
+     * @inheritdoc
+     * @return array
+     */
     function objectAttributeContent( $contentObjectAttribute )
     {
         $contentClassAttribute = $contentObjectAttribute->attribute( 'contentclass_attribute' );
@@ -449,10 +449,6 @@ class eZIniSettingType extends eZDataType
         $attributeParametersNode->appendChild( $siteAccessListNode );
     }
 
-    /*!
-
-     Use Override to do ini alterations if the specified site access does not exist
-    */
     function unserializeContentClassAttribute( $classAttribute, $attributeNode, $attributeParametersNode )
     {
         $file = $attributeParametersNode->getElementsByTagName( 'file' )->item( 0 )->textContent;
@@ -464,7 +460,6 @@ class eZIniSettingType extends eZDataType
         $classAttribute->setAttribute( self::CLASS_SECTION_FIELD, $section );
         $classAttribute->setAttribute( self::CLASS_PARAMETER_FIELD, $parameter );
         $classAttribute->setAttribute( self::CLASS_TYPE_FIELD, $type );
-
 
         /* Get and check if site access settings exist in this setup */
         $remoteIniInstanceList = $attributeParametersNode->getElementsByTagName( 'ini_instance' )->item( 0 )->textContent;
@@ -509,47 +504,44 @@ class eZIniSettingType extends eZDataType
         $classAttribute->setAttribute( self::SITE_ACCESS_LIST_FIELD, $siteAccess );
     }
 
-
-    /*!
-     \private
-     Get Ini section parameter name
-
-     \param Content Class Attribute
-    */
+    /**
+     * Returns the ini section parameter name
+     *
+     * @param eZContentClassAttribute $contentClassAttribute
+     * @return string
+     */
     function iniParameterName( $contentClassAttribute )
     {
         return $contentClassAttribute->attribute( self::CLASS_PARAMETER_FIELD );
     }
 
-    /*!
-     \private
-     Get ini settings file
-
-     \param Content Class Attribute
-    */
+    /**
+     * Returns the ini settings file name
+     *
+     * @param eZContentClassAttribute $contentClassAttribute
+     * @return mixed
+     */
     function iniFile( $contentClassAttribute )
     {
         return $contentClassAttribute->attribute( self::CLASS_FILE_FIELD );
     }
 
-    /*!
-     \private
-     Get Ini file section name
-
-     \param Content Class Attribute
-    */
+    /**
+     * Returns the ini file section name
+     *
+     * @param eZContentClassAttribute $contentClassAttribute
+     * @return string
+     */
     function iniSection( $contentClassAttribute )
     {
         return $contentClassAttribute->attribute( self::CLASS_SECTION_FIELD );
     }
 
-    /*!
-     \private
-     \static
-     Set site access list, including override option
-
-     \param contentClassAttribute to set site access list and override options
-    */
+    /**
+     * Sets site access list, including override option
+     *
+     * @param eZContentClassAttribute $contentClassAttribute
+     */
     function setSiteAccessList( $contentClassAttribute )
     {
         $config = eZINI::instance( 'site.ini' );
@@ -569,7 +561,6 @@ class eZIniSettingType extends eZDataType
         $value = $contentObjectAttribute->attribute( 'data_text' );
         return implode( '|', array( $value, $makeEmptyArray ) );
     }
-
 
     function fromString( $contentObjectAttribute, $string )
     {

--- a/kernel/classes/datatypes/ezinteger/ezintegertype.php
+++ b/kernel/classes/datatypes/ezinteger/ezintegertype.php
@@ -8,18 +8,17 @@
  * @package kernel
  */
 
-/*!
-  \class eZIntegerType ezintegertype.php
-  \ingroup eZDatatype
-  \brief A content datatype which handles integers
-
-  It provides the functionality to work as an integer and handles
-  class definition input, object definition input and object viewing.
-
-  It uses the spare field data_int in a content object attribute for storing
-  the attribute data.
-*/
-
+/**
+ * A content datatype which handles integers
+ *
+ * It provides the functionality to work as an integer and handles
+ * class definition input, object definition input and object viewing.
+ *
+ * It uses the spare field data_int in a content object attribute for storing
+ * the attribute data.
+ *
+ * @package kernel
+ */
 class eZIntegerType extends eZDataType
 {
     const DATA_TYPE_STRING = "ezinteger";
@@ -35,6 +34,9 @@ class eZIntegerType extends eZDataType
     const HAS_MAX_VALUE = 2;
     const HAS_MIN_MAX_VALUE = 3;
 
+    /**
+     * Initializes the datatype
+     */
     function eZIntegerType()
     {
         $this->eZDataType( self::DATA_TYPE_STRING, ezpI18n::tr( 'kernel/classes/datatypes', "Integer", 'Datatype name' ),
@@ -43,9 +45,14 @@ class eZIntegerType extends eZDataType
         $this->IntegerValidator = new eZIntegerValidator();
     }
 
-    /*!
-     Private method, only for using inside this class.
-    */
+    /**
+     * Checks if $data is valid
+     *
+     * @param int|string $data
+     * @param eZContentObjectAttribute $contentObjectAttribute
+     * @param eZContentClassAttribute $classAttribute
+     * @return int
+     */
     function validateIntegerHTTPInput( $data, $contentObjectAttribute, $classAttribute )
     {
         $min = $classAttribute->attribute( self::MIN_VALUE_FIELD );
@@ -103,10 +110,6 @@ class eZIntegerType extends eZDataType
 
     }
 
-    /*!
-     Validates the input and returns true if the input was
-     valid for this datatype.
-    */
     function validateObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         $classAttribute = $contentObjectAttribute->contentClassAttribute();
@@ -146,9 +149,6 @@ class eZIntegerType extends eZDataType
     {
     }
 
-    /*!
-     Sets the default value.
-    */
     function initializeObjectAttribute( $contentObjectAttribute, $currentVersion, $originalContentObjectAttribute )
     {
         if ( $currentVersion != false )
@@ -170,9 +170,6 @@ class eZIntegerType extends eZDataType
         }
     }
 
-    /*!
-     Fetches the http post var integer input and stores it in the data instance.
-    */
     function fetchObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         if ( $http->hasPostVariable( $base . "_data_integer_" . $contentObjectAttribute->attribute( "id" ) ) )
@@ -214,9 +211,6 @@ class eZIntegerType extends eZDataType
             return eZInputValidator::STATE_INVALID;
     }
 
-    /*!
-     Fetches the http post variables for collected information
-    */
     function fetchCollectionAttributeHTTPInput( $collection, $collectionAttribute, $http, $base, $contentObjectAttribute )
     {
         if ( $http->hasPostVariable( $base . "_data_integer_" . $contentObjectAttribute->attribute( "id" ) ) )
@@ -230,9 +224,6 @@ class eZIntegerType extends eZDataType
         return false;
     }
 
-    /*!
-     Does nothing, the data is already present in the attribute.
-    */
     function storeObjectAttribute( $object_attribute )
     {
     }
@@ -367,26 +358,24 @@ class eZIntegerType extends eZDataType
         return false;
     }
 
-    /*!
-     Returns the content.
-    */
+    /**
+     * @inheritdoc
+     * @return int
+     */
     function objectAttributeContent( $contentObjectAttribute )
     {
         return $contentObjectAttribute->attribute( "data_int" );
     }
 
-
-    /*!
-     Returns the meta data used for storing search indeces.
-    */
+    /**
+     * @inheritdoc
+     * @return int
+     */
     function metaData( $contentObjectAttribute )
     {
         return (int)$contentObjectAttribute->attribute( "data_int" );
     }
-    /*!
-     \return string representation of an contentobjectattribute data for simplified export
 
-    */
     function toString( $contentObjectAttribute )
     {
         return $contentObjectAttribute->attribute( 'data_int' );
@@ -397,9 +386,6 @@ class eZIntegerType extends eZDataType
         return $contentObjectAttribute->setAttribute( 'data_int', $string );
     }
 
-    /*!
-     Returns the integer value.
-    */
     function title( $contentObjectAttribute, $name = null )
     {
         return $contentObjectAttribute->attribute( "data_int" );
@@ -415,9 +401,6 @@ class eZIntegerType extends eZDataType
         return true;
     }
 
-    /*!
-     \return true if the datatype can be indexed
-    */
     function isIndexable()
     {
         return true;
@@ -498,8 +481,9 @@ class eZIntegerType extends eZDataType
         return true;
     }
 
-    /// \privatesection
-    /// The integer value validator
+    /**
+     * @var eZIntegerValidator
+     */
     public $IntegerValidator;
 }
 

--- a/kernel/classes/datatypes/ezisbn/ezisbntype.php
+++ b/kernel/classes/datatypes/ezisbn/ezisbntype.php
@@ -8,19 +8,20 @@
  * @package kernel
  */
 
-/*!
-  \class eZISBNType ezisbntype.php
-  \brief Handles ISBN type strings
-  \ingroup eZDatatype
-
-*/
-
+/**
+ * Handles ISBN type strings
+ *
+ * @package kernel
+ */
 class eZISBNType extends eZDataType
 {
     const DATA_TYPE_STRING = "ezisbn";
     const CLASS_IS_ISBN13 = 'data_int1';
     const CONTENT_VALUE = 'data_text';
 
+    /**
+     * Initializes the datatype
+     */
     function eZISBNType()
     {
         $this->eZDataType( self::DATA_TYPE_STRING, ezpI18n::tr( 'kernel/classes/datatypes', "ISBN", 'Datatype name' ),
@@ -28,10 +29,6 @@ class eZISBNType extends eZDataType
                                   'object_serialize_map' => array( self::CONTENT_VALUE => 'isbn' ) ) );
     }
 
-    /*!
-     Validates the input and returns true if the input was
-     valid for this datatype.
-    */
     function validateObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         $classAttribute = $contentObjectAttribute->contentClassAttribute();
@@ -132,15 +129,15 @@ class eZISBNType extends eZDataType
         return eZInputValidator::STATE_INVALID;
     }
 
-
-    /*!
-     \private
-     Validates the ISBN number \a $isbnNr.
-     All characters should be numeric except the last digit that may be the character X,
-     which should be calculated as 10.
-     \param $isbnNr A string containing the number without any dashes.
-     \return \c true if it is valid.
-    */
+    /**
+     * Validates the ISBN number $isbnNr.
+     *
+     * All characters should be numeric except the last digit that may be the character X,
+     * which should be calculated as 10.
+     *
+     * @param string $isbnNr A string containing the number without any dashes.
+     * @return bool true if it is valid.
+     */
     function validateISBNChecksum ( $isbnNr )
     {
         $result = 0;
@@ -166,13 +163,14 @@ class eZISBNType extends eZDataType
         return ( $result % 11 == 0 );
     }
 
-    /*!
-     \private
-     \deprecated, should use the class eZISBN13 instead.
-     Validates the ISBN-13 number \a $isbnNr.
-     \param $isbnNr A string containing the number without any dashes.
-     \return \c true if it is valid.
-    */
+    /**
+     * Validates the ISBN-13 number $isbnNr.
+     *
+     * @deprecated Use {@see eZISBN13::validateISBN13Checksum()} instead
+     * @param string $isbnNr
+     * @param int $error
+     * @return bool
+     */
     function validateISBN13Checksum ( $isbnNr, &$error )
     {
         $isbn13 = new eZISBN13();
@@ -181,11 +179,12 @@ class eZISBNType extends eZDataType
         return $status;
     }
 
-    /*!
-      Calculate the ISBN-13 checkdigit and return a valid ISBN-13 number
-      based on an ISBN-10 number as input.
-      \return a valid ISBN-13 number.
-    */
+    /**
+     * Calculate the ISBN-13 checkdigit and return a valid ISBN-13 number based on an ISBN-10 number as input.
+     *
+     * @param string $isbnNr
+     * @return string
+     */
     static function convertISBN10toISBN13( $isbnNr )
     {
         $isbnNr = 978 . substr( $isbnNr, 0, 9 );
@@ -207,9 +206,6 @@ class eZISBNType extends eZDataType
         return $isbnNr;
     }
 
-    /*!
-     Fetches the http post var string input and stores it in the data instance.
-    */
     function fetchObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         $classAttribute = $contentObjectAttribute->contentClassAttribute();
@@ -291,9 +287,6 @@ class eZISBNType extends eZDataType
         return true;
     }
 
-    /*!
-     Store the content.
-    */
     function storeObjectAttribute( $attribute )
     {
     }
@@ -313,9 +306,10 @@ class eZISBNType extends eZDataType
         return false;
     }
 
-    /*!
-     Returns the content.
-    */
+    /**
+     * @inheritdoc
+     * @return array
+     */
     function objectAttributeContent( $contentObjectAttribute )
     {
         $data = $contentObjectAttribute->attribute( self::CONTENT_VALUE );
@@ -345,6 +339,10 @@ class eZISBNType extends eZDataType
         return $isbn;
     }
 
+    /**
+     * @inheritdoc
+     * @return array
+     */
     function classAttributeContent( $classAttribute )
     {
         $ISBN_13 = $classAttribute->attribute( self::CLASS_IS_ISBN13 );
@@ -354,27 +352,16 @@ class eZISBNType extends eZDataType
         return $content;
     }
 
-
-    /*!
-     ISBN numbers are indexable, returns \c true.
-    */
     function isIndexable()
     {
         return true;
     }
 
-    /*!
-     Returns the meta data used for storing search indeces.
-    */
     function metaData( $contentObjectAttribute )
     {
         return $contentObjectAttribute->attribute( self::CONTENT_VALUE );
     }
 
-    /*!
-     \return string representation of an contentobjectattribute data for simplified export
-
-    */
     function toString( $contentObjectAttribute )
     {
         return $contentObjectAttribute->attribute( self::CONTENT_VALUE );
@@ -385,18 +372,11 @@ class eZISBNType extends eZDataType
         return $contentObjectAttribute->setAttribute( self::CONTENT_VALUE, $string );
     }
 
-    /*!
-     Returns the text.
-    */
     function title( $data_instance, $name = null )
     {
         return $data_instance->attribute( self::CONTENT_VALUE );
     }
 
-    /*!
-     Initializes the class attribute.
-     data_int will be se default to 1, as this is ISBN-13.
-    */
     function initializeClassAttribute( $classAttribute )
     {
         if ( $classAttribute->attribute( self::CLASS_IS_ISBN13 ) === null )
@@ -405,17 +385,11 @@ class eZISBNType extends eZDataType
         }
     }
 
-    /*!
-      Check if an ISBN value exist in the datatype.
-    */
     function hasObjectAttributeContent( $contentObjectAttribute )
     {
         return trim( $contentObjectAttribute->attribute( self::CONTENT_VALUE ) ) != '';
     }
 
-    /*!
-      See also eZDataType:cleanDBDataBeforeImport().
-    */
     function cleanDBDataBeforeImport()
     {
         eZISBNGroup::cleanAll();

--- a/kernel/classes/datatypes/ezkeyword/ezkeywordtype.php
+++ b/kernel/classes/datatypes/ezkeyword/ezkeywordtype.php
@@ -8,31 +8,24 @@
  * @package kernel
  */
 
-/*!
-  \class eZKeywordType ezkeywordtype.php
-  \ingroup eZDatatype
-  \brief A content datatype which handles keyword indexes
-
-*/
-
-
-
+/**
+ * A content datatype which handles keyword indexes
+ *
+ * @package kernel
+ */
 class eZKeywordType extends eZDataType
 {
     const DATA_TYPE_STRING = 'ezkeyword';
 
-    /*!
-     Initializes with a keyword id and a description.
-    */
+    /**
+     * Initializes the datatype
+     */
     function eZKeywordType()
     {
         $this->eZDataType( self::DATA_TYPE_STRING, ezpI18n::tr( 'kernel/classes/datatypes', 'Keywords', 'Datatype name' ),
                            array( 'serialize_supported' => true ) );
     }
 
-    /*!
-     Sets the default value.
-    */
     function initializeObjectAttribute( $contentObjectAttribute, $currentVersion, $originalContentObjectAttribute )
     {
         if ( $currentVersion != false )
@@ -53,10 +46,6 @@ class eZKeywordType extends eZDataType
         }
     }
 
-    /*!
-     Validates the input and returns true if the input was
-     valid for this datatype.
-    */
     function validateObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         $classAttribute = $contentObjectAttribute->contentClassAttribute();
@@ -83,9 +72,6 @@ class eZKeywordType extends eZDataType
         return eZInputValidator::STATE_ACCEPTED;
     }
 
-    /*!
-     Fetches the http post var keyword input and stores it in the data instance.
-    */
     function fetchObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         if ( $http->hasPostVariable( $base . '_ezkeyword_data_text_' . $contentObjectAttribute->attribute( 'id' ) ) )
@@ -99,10 +85,6 @@ class eZKeywordType extends eZDataType
         return false;
     }
 
-    /*!
-     Does nothing since it uses the data_text field in the content object attribute.
-     See fetchObjectAttributeHTTPInput for the actual storing.
-    */
     function storeObjectAttribute( $attribute )
     {
         // create keyword index
@@ -135,9 +117,10 @@ class eZKeywordType extends eZDataType
         return true;
     }
 
-    /*!
-     Returns the content.
-    */
+    /**
+     * @inheritdoc
+     * @return eZKeyword
+     */
     function objectAttributeContent( $attribute )
     {
         $keyword = new eZKeyword();
@@ -146,9 +129,6 @@ class eZKeywordType extends eZDataType
         return $keyword;
     }
 
-    /*!
-     Returns the meta data used for storing search indeces.
-    */
     function metaData( $attribute )
     {
         $keyword = new eZKeyword();
@@ -158,9 +138,6 @@ class eZKeywordType extends eZDataType
         return $return;
     }
 
-    /*!
-     Delete stored object attribute
-    */
     function deleteStoredObjectAttribute( $contentObjectAttribute, $version = null )
     {
         if ( $version != null ) // Do not delete if discarding draft
@@ -209,9 +186,6 @@ class eZKeywordType extends eZDataType
                      WHERE objectattribute_id='$contentObjectAttributeID'" );
     }
 
-    /*!
-     Returns the content of the keyword for use as a title
-    */
     function title( $attribute, $name = null )
     {
         $keyword = new eZKeyword();
@@ -235,13 +209,6 @@ class eZKeywordType extends eZDataType
         return true;
     }
 
-    /**
-     *
-     * Returns string representation of an contentobjectattribute data for simplified export
-     *
-     * @param eZContentObjectAttribute $contentObjectAttribute
-     * @return string
-     */
     function toString( $contentObjectAttribute )
     {
         $keyword = new eZKeyword();

--- a/kernel/classes/datatypes/ezmatrix/ezmatrixtype.php
+++ b/kernel/classes/datatypes/ezmatrix/ezmatrixtype.php
@@ -8,13 +8,11 @@
  * @package kernel
  */
 
-/*!
-  \class eZMatrixType ezmatrixtype.php
-  \ingroup eZDatatype
-  \brief The class eZMatrixType does
-
-*/
-
+/**
+ * Datatype that stores an eZMatrix object
+ *
+ * @package kernel
+ */
 class eZMatrixType extends eZDataType
 {
     const DEFAULT_NAME_VARIABLE = '_ezmatrix_default_name_';
@@ -24,21 +22,18 @@ class eZMatrixType extends eZDataType
     const CELL_VARIABLE = '_ezmatrix_cell_';
     const DATA_TYPE_STRING = 'ezmatrix';
 
-    /*!
-     Constructor
-    */
+    /**
+     * Initializes the datatype
+     */
     function eZMatrixType()
     {
         $this->eZDataType( self::DATA_TYPE_STRING, ezpI18n::tr( 'kernel/classes/datatypes', 'Matrix', 'Datatype name' ),
                            array( 'serialize_supported' => true ) );
     }
 
-    /*!
-     Validates the input and returns true if the input was
-     valid for this datatype.
-    */
     function validateObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
+        /** @var array|bool $data */
         $data = false;
         if ( $http->hasPostVariable( $base . '_ezmatrix_cell_' . $contentObjectAttribute->attribute( 'id' ) ) )
             $data = $http->PostVariable( $base . '_ezmatrix_cell_' . $contentObjectAttribute->attribute( 'id' ) );
@@ -58,9 +53,6 @@ class eZMatrixType extends eZDataType
         return eZInputValidator::STATE_ACCEPTED;
     }
 
-    /*!
-     Store content
-    */
     function storeObjectAttribute( $contentObjectAttribute )
     {
         $matrix = $contentObjectAttribute->content();
@@ -71,15 +63,17 @@ class eZMatrixType extends eZDataType
 
     function storeClassAttribute( $contentClassAttribute, $version )
     {
+        /** @var eZMatrixDefinition $matrixDefinition */
         $matrixDefinition = $contentClassAttribute->content();
         $contentClassAttribute->setAttribute( 'data_text5', $matrixDefinition->xmlString() );
         $matrixDefinition->decodeClassAttribute( $contentClassAttribute->attribute( 'data_text5' ) );
         $contentClassAttribute->setContent(  $matrixDefinition );
     }
 
-    /*!
-     Returns the content.
-    */
+    /**
+     * @inheritdoc
+     * @return eZMatrix
+     */
     function objectAttributeContent( $contentObjectAttribute )
     {
         $matrix = new eZMatrix( '' );
@@ -102,9 +96,6 @@ class eZMatrixType extends eZDataType
         return $count > 0;
     }
 
-    /*!
-     Returns the meta data used for storing search indeces.
-    */
     function metaData( $contentObjectAttribute )
     {
         $matrix = $contentObjectAttribute->content();
@@ -123,9 +114,6 @@ class eZMatrixType extends eZDataType
         return $metaDataArray;
     }
 
-    /*!
-     Fetches the http post var matrix cells input and stores it in the data instance.
-    */
     function fetchObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         $cellsVarName = $base . self::CELL_VARIABLE . $contentObjectAttribute->attribute( 'id' );
@@ -202,9 +190,6 @@ class eZMatrixType extends eZDataType
         }
     }
 
-    /*!
-     Returns the integer value.
-    */
     function title( $contentObjectAttribute, $name = 'name' )
     {
         $matrix = $contentObjectAttribute->content( );
@@ -214,9 +199,6 @@ class eZMatrixType extends eZDataType
         return $value;
     }
 
-    /*!
-     Sets the default value.
-    */
     function initializeObjectAttribute( $contentObjectAttribute, $currentVersion, $originalContentObjectAttribute )
     {
 
@@ -281,7 +263,6 @@ class eZMatrixType extends eZDataType
         $columnNameVariable = $base . '_data_ezmatrix_column_name_' . $classAttribute->attribute( 'id' );
         $columnIDVariable = $base . '_data_ezmatrix_column_id_' . $classAttribute->attribute( 'id' );
 
-
         if ( $http->hasPostVariable( $columnNameVariable ) && $http->hasPostVariable( $columnIDVariable ) )
         {
             $columns = array();
@@ -339,9 +320,10 @@ class eZMatrixType extends eZDataType
         $classAttribute->setAttribute( 'data_text5', $matrixDefinition->xmlString() );
     }
 
-    /*!
-     Returns the content.
-    */
+    /**
+     * @inheritdoc
+     * @return eZMatrixDefinition
+     */
     function classAttributeContent( $contentClassAttribute )
     {
         $matrixDefinition = new eZMatrixDefinition();
@@ -356,6 +338,7 @@ class eZMatrixType extends eZDataType
         {
             case 'new_ezmatrix_column' :
             {
+                /** @var eZMatrixDefinition $matrixDefinition */
                 $matrixDefinition = $contentClassAttribute->content( );
                 $matrixDefinition->addColumn( '' );
                 $contentClassAttribute->setContent( $matrixDefinition );
@@ -363,6 +346,7 @@ class eZMatrixType extends eZDataType
             }break;
             case 'remove_selected' :
             {
+                /** @var eZMatrixDefinition $matrixDefinition */
                 $matrixDefinition = $contentClassAttribute->content( );
 
                 $postvarname = 'ContentClass' . '_data_ezmatrix_column_remove_' . $contentClassAttribute->attribute( 'id' );
@@ -385,10 +369,6 @@ class eZMatrixType extends eZDataType
         return true;
     }
 
-    /*!
-     \return string representation of an contentobjectattribute data for simplified export
-
-    */
     function toString( $contentObjectAttribute )
     {
         $matrix = $contentObjectAttribute->attribute( 'content' );
@@ -435,6 +415,7 @@ class eZMatrixType extends eZDataType
 
     function serializeContentClassAttribute( $classAttribute, $attributeNode, $attributeParametersNode )
     {
+        /** @var eZMatrixDefinition $content */
         $content = $classAttribute->content();
         if ( $content )
         {
@@ -471,7 +452,9 @@ class eZMatrixType extends eZDataType
         $classAttribute->setAttribute( 'data_int1', $defaultRowCount );
 
         $matrixDefinition = new eZMatrixDefinition();
+        /** @var DOMElement $columnsNode */
         $columnsNode = $attributeParametersNode->getElementsByTagName( 'columns' )->item( 0 );
+        /** @var DOMElement[] $columnsList */
         $columnsList = $columnsNode->getElementsByTagName( 'column' );
         foreach ( $columnsList  as $columnNode )
         {

--- a/kernel/classes/datatypes/ezmedia/ezmediatype.php
+++ b/kernel/classes/datatypes/ezmedia/ezmediatype.php
@@ -8,13 +8,11 @@
  * @package kernel
  */
 
-/*!
-  \class eZMediaType ezmediatype.php
-  \ingroup eZDatatype
-  \brief The class eZMediaType handles storage and playback of media files.
-
-*/
-
+/**
+ * The class eZMediaType handles storage and playback of media files.
+ *
+ * @package kernel
+ */
 class eZMediaType extends eZDataType
 {
     const DATA_TYPE_STRING = "ezmedia";
@@ -23,15 +21,15 @@ class eZMediaType extends eZDataType
     const TYPE_FIELD = "data_text1";
     const TYPE_VARIABLE = "_ezmedia_type_";
 
+    /**
+     * Initializes the datatype
+     */
     function eZMediaType()
     {
         $this->eZDataType( self::DATA_TYPE_STRING, ezpI18n::tr( 'kernel/classes/datatypes', "Media", 'Datatype name' ),
                            array( 'serialize_supported' => true ) );
     }
 
-    /*!
-     Sets value according to current version
-    */
     function postInitializeObjectAttribute( $contentObjectAttribute, $currentVersion, $originalContentObjectAttribute )
     {
         if ( $currentVersion != false )
@@ -62,10 +60,6 @@ class eZMediaType extends eZDataType
         }
     }
 
-    /*!
-     The object is being moved to trash, do any necessary changes to the attribute.
-     Rename file and update db row with new name, so that access to the file using old links no longer works.
-    */
     function trashStoredObjectAttribute( $contentObjectAttribute, $version = null )
     {
         $contentObjectAttributeID = $contentObjectAttribute->attribute( "id" );
@@ -114,9 +108,6 @@ class eZMediaType extends eZDataType
         }
     }
 
-    /*!
-     Delete stored attribute
-    */
     function deleteStoredObjectAttribute( $contentObjectAttribute, $version = null )
     {
         $contentObjectAttributeID = $contentObjectAttribute->attribute( "id" );
@@ -170,10 +161,6 @@ class eZMediaType extends eZDataType
         eZMedia::removeByID( $contentObjectAttributeID, $version );
     }
 
-    /*!
-     Validates the input and returns true if the input was
-     valid for this datatype.
-    */
     function validateObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         $classAttribute = $contentObjectAttribute->contentClassAttribute();
@@ -214,9 +201,6 @@ class eZMediaType extends eZDataType
         return eZInputValidator::STATE_ACCEPTED;
     }
 
-    /*!
-     Checks if file uploads are enabled, if not it gives a warning.
-    */
     function checkFileUploads()
     {
         $isFileUploadsEnabled = ini_get( 'file_uploads' ) != 0;
@@ -233,11 +217,12 @@ class eZMediaType extends eZDataType
         }
     }
 
-    /*!
-     \static
-     Returns plugin page by media type
-
-    */
+    /**
+     * Returns plugin page by media type
+     *
+     * @param string $mediaType
+     * @return string
+     */
     function pluginPage( $mediaType )
     {
         $pluginPage = '';
@@ -266,9 +251,6 @@ class eZMediaType extends eZDataType
         return $pluginPage;
     }
 
-    /*!
-     Fetches input and stores it in the data instance.
-    */
     function fetchObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
 
@@ -369,25 +351,16 @@ class eZMediaType extends eZDataType
         }
     }
 
-    /*!
-     HTTP file insertion is supported.
-    */
     function isHTTPFileInsertionSupported()
     {
         return true;
     }
 
-    /*!
-     Regular file insertion is supported.
-    */
     function isRegularFileInsertionSupported()
     {
         return true;
     }
 
-    /*!
-     Inserts the file using the eZMedia class.
-    */
     function insertHTTPFile( $object, $objectVersion, $objectLanguage,
                              $objectAttribute, $httpFile, $mimeData,
                              &$result )
@@ -446,16 +419,12 @@ class eZMediaType extends eZDataType
         $fileHandler = eZClusterFileHandler::instance();
         $fileHandler->fileStore( $filePath, 'mediafile', true, $mimeData['name'] );
 
-
         $media->store();
 
         $objectAttribute->setContent( $media );
         return true;
     }
 
-    /*!
-     Inserts the file using the eZMedia class.
-    */
     function insertRegularFile( $object, $objectVersion, $objectLanguage,
                                 $objectAttribute, $filePath,
                                 &$result )
@@ -538,18 +507,12 @@ class eZMediaType extends eZDataType
         return true;
     }
 
-    /*!
-      We support file information
-    */
     function hasStoredFileInformation( $object, $objectVersion, $objectLanguage,
                                        $objectAttribute )
     {
         return true;
     }
 
-    /*!
-      Extracts file information for the media entry.
-    */
     function storedFileInformation( $object, $objectVersion, $objectLanguage,
                                     $objectAttribute )
     {
@@ -595,9 +558,6 @@ class eZMediaType extends eZDataType
         }
     }
 
-    /*!
-     Returns the object title.
-    */
     function title( $contentObjectAttribute,  $name = "original_filename" )
     {
         $mediaFile = eZMedia::fetch( $contentObjectAttribute->attribute( "id" ),
@@ -621,6 +581,10 @@ class eZMediaType extends eZDataType
        return true;
     }
 
+    /**
+     * @inheritdoc
+     * @return eZMedia
+     */
     function objectAttributeContent( $contentObjectAttribute )
     {
         $mediaFile = eZMedia::fetch( $contentObjectAttribute->attribute( "id" ),
@@ -633,14 +597,15 @@ class eZMediaType extends eZDataType
         return $mediaFile;
     }
 
+    /**
+     * @inheritdoc
+     * @return string
+     */
     function metaData( $contentObjectAttribute )
     {
         return "";
     }
-    /*!
-     \return string representation of an contentobjectattribute data for simplified export
 
-    */
     function toString( $objectAttribute )
     {
         $mediaFile = $objectAttribute->content();
@@ -652,8 +617,6 @@ class eZMediaType extends eZDataType
         else
             return '';
     }
-
-
 
     function fromString( $objectAttribute, $string )
     {
@@ -689,6 +652,7 @@ class eZMediaType extends eZDataType
 
     function unserializeContentClassAttribute( $classAttribute, $attributeNode, $attributeParametersNode )
     {
+        /** @var DOMElement $sizeNode */
         $sizeNode = $attributeParametersNode->getElementsByTagName( 'max-size' )->item( 0 );
         $maxSize = $sizeNode->textContent;
         $unitSize = $sizeNode->getAttribute( 'unit-size' );
@@ -738,6 +702,7 @@ class eZMediaType extends eZDataType
 
     function unserializeContentObjectAttribute( $package, $objectAttribute, $attributeNode )
     {
+        /** @var DOMElement $mediaNode */
         $mediaNode = $attributeNode->getElementsByTagName( 'media-file' )->item( 0 );
         if ( !$mediaNode )
         {

--- a/kernel/classes/datatypes/ezmultioption/ezmultioptiontype.php
+++ b/kernel/classes/datatypes/ezmultioption/ezmultioptiontype.php
@@ -8,45 +8,38 @@
  * @package kernel
  */
 
-/*!
-  \class eZMultiOptionType ezmultioptiontype.php
-  \ingroup eZDatatype
-  \brief A datatype which works with multiple options.
-
-  This allows the user to add several option choices almost as if he
-  was adding attributes with option datatypes.
-
-  This class implements the interface for a datatype but passes
-  most of the work over to the eZMultiOption class which handles
-  parsing, storing and manipulation of multioptions and options.
-
-  This datatype supports:
-  - fetch and validation of HTTP data
-  - search indexing
-  - product option information
-  - class title
-  - class serialization
-
-*/
-
+/**
+ * A datatype which works with multiple options.
+ *
+ * This allows the user to add several option choices almost as if he was adding attributes with option datatypes.
+ *
+ * This class implements the interface for a datatype but passes
+ * most of the work over to the eZMultiOption class which handles
+ * parsing, storing and manipulation of multioptions and options.
+ *
+ * This datatype supports:
+ * - fetch and validation of HTTP data
+ * - search indexing
+ * - product option information
+ * - class title
+ * - class serialization
+ *
+ * @package kernel
+ */
 class eZMultiOptionType extends eZDataType
 {
     const DEFAULT_NAME_VARIABLE = "_ezmultioption_default_name_";
     const DATA_TYPE_STRING = "ezmultioption";
 
-    /*!
-     Constructor to initialize the datatype.
-    */
+    /**
+     * Initializes the datatype
+     */
     function eZMultiOptionType()
     {
         $this->eZDataType( self::DATA_TYPE_STRING, ezpI18n::tr( 'kernel/classes/datatypes', "Multi-option", 'Datatype name' ),
                            array( 'serialize_supported' => true ) );
     }
 
-    /*!
-     Validates the input for this datatype.
-     \return True if input is valid.
-    */
     function validateObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         $count = 0;
@@ -119,22 +112,19 @@ class eZMultiOptionType extends eZDataType
             }
         }
 
-
         return eZInputValidator::STATE_ACCEPTED;
     }
 
-    /*!
-     This function calles xmlString function to create xml string and then store the content.
-    */
     function storeObjectAttribute( $contentObjectAttribute )
     {
         $multioption = $contentObjectAttribute->content();
         $contentObjectAttribute->setAttribute( "data_text", $multioption->xmlString() );
     }
 
-    /*!
-     \return An eZMultiOption object which contains all the option data
-    */
+    /**
+     * @inheritdoc
+     * @return eZMultiOption
+     */
     function objectAttributeContent( $contentObjectAttribute )
     {
         $multioption = new eZMultiOption( "" );
@@ -147,17 +137,11 @@ class eZMultiOptionType extends eZDataType
         return true;
     }
 
-    /*!
-     \return The internal XML text.
-    */
     function metaData( $contentObjectAttribute )
     {
         return $contentObjectAttribute->attribute( "data_text" );
     }
 
-    /*!
-     Fetches the http post var integer input and stores it in the data instance.
-    */
     function fetchObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         $multioptionIDArray = $http->hasPostVariable( $base . "_data_multioption_id_" . $contentObjectAttribute->attribute( "id" ) )
@@ -200,9 +184,6 @@ class eZMultiOptionType extends eZDataType
         return true;
     }
 
-    /*!
-     Fetches the http post variables for collected information
-    */
     function fetchCollectionAttributeHTTPInput( $collection, $collectionAttribute, $http, $base, $contentObjectAttribute )
     {
         $multioptionValue = $http->postVariable( $base . "_data_multioption_value_" . $contentObjectAttribute->attribute( "id" ) );
@@ -210,20 +191,26 @@ class eZMultiOptionType extends eZDataType
         return true;
     }
 
-    /*!
-     This function performs specific actions.
-
-     It has some special actions with parameters which is done by exploding
-     $action into several parts with delimeter '_'.
-     The first element is the name of specific action to perform.
-     The second element will contain the key value or id.
-
-     The various operation's that is performed by this function are as follow.
-     - new-option - A new option is added to a multioption.
-     - remove-selected-option - Removes a selected option.
-     - new_multioption - Adds a new multioption.
-     - remove_selected_multioption - Removes all multioptions given by a selection list
-    */
+    /**
+     * This function performs specific actions.
+     *
+     * It has some special actions with parameters which is done by exploding
+     *
+     * $action into several parts with delimeter '_'.
+     * The first element is the name of specific action to perform.
+     * The second element will contain the key value or id.
+     *
+     * The various operation's that is performed by this function are as follow.
+     * - new-option - A new option is added to a multioption.
+     * - remove-selected-option - Removes a selected option.
+     * - new_multioption - Adds a new multioption.
+     * - remove_selected_multioption - Removes all multioptions given by a selection list
+     *
+     * @param eZHTTPTool $http
+     * @param string $action
+     * @param eZContentObjectAttribute $contentObjectAttribute
+     * @param array $parameters
+     */
     function customObjectAttributeHTTPAction( $http, $action, $contentObjectAttribute, $parameters )
     {
         $actionlist = explode( "_", $action );
@@ -276,11 +263,6 @@ class eZMultiOptionType extends eZDataType
         }
     }
 
-    /*!
-     Finds the option which has the correct ID , if found it returns an option structure.
-
-     \param $optionString must contain the multioption ID an underscore (_) and a the option ID.
-    */
     function productOptionInformation( $objectAttribute, $optionID, $productItem )
     {
         $multioption = $objectAttribute->attribute( 'content' );
@@ -306,9 +288,6 @@ class eZMultiOptionType extends eZDataType
         return $multioption->attribute( $name );
     }
 
-    /*!
-      \return \c true if there are more than one multioption in the list.
-    */
     function hasObjectAttributeContent( $contentObjectAttribute )
     {
         $multioption = $contentObjectAttribute->content();
@@ -316,9 +295,6 @@ class eZMultiOptionType extends eZDataType
         return count( $multioptions ) > 0;
     }
 
-    /*!
-     Sets default multioption values.
-    */
     function initializeObjectAttribute( $contentObjectAttribute, $currentVersion, $originalContentObjectAttribute )
     {
         if ( $currentVersion == false )
@@ -383,7 +359,6 @@ class eZMultiOptionType extends eZDataType
         return eZStringUtils::implodeStr( $multioptionArray, "&" );
     }
 
-
     function fromString( $contentObjectAttribute, $string )
     {
         if ( $string == '' )
@@ -400,7 +375,6 @@ class eZMultiOptionType extends eZDataType
         foreach ( $multioptionArray as $multioptionStr )
         {
             $optionArray = eZStringUtils::explodeStr( $multioptionStr, '|' );
-
 
             $newID = $multioption->addMultiOption( array_shift( $optionArray ),
                                             $priority,

--- a/kernel/classes/datatypes/ezmultioption2/ezmultioption2type.php
+++ b/kernel/classes/datatypes/ezmultioption2/ezmultioption2type.php
@@ -8,63 +8,55 @@
  * @package kernel
  */
 
-/*!
-  \class eZMultiOption2Type ezmultioption2type.php
-  \ingroup eZDatatype
-  \brief A datatype which works with multiple options.
-
-  This allows the user to add several option choices almost as if he
-  was adding attributes with option datatypes.
-
-  This class implements the interface for a datatype but passes
-  most of the work over to the eZMultiOption2 class which handles
-  parsing, storing and manipulation of multioption2s and options.
-
-  This datatype supports:
-  - fetch and validation of HTTP data
-  - search indexing
-  - product option information
-  - class title
-  - class serialization
-
-*/
-
+/**
+ * A datatype which works with multiple options.
+ *
+ * This allows the user to add several option choices almost as if he
+ * was adding attributes with option datatypes.
+ *
+ * This class implements the interface for a datatype but passes
+ * most of the work over to the eZMultiOption2 class which handles
+ * parsing, storing and manipulation of multioption2s and options.
+ *
+ * This datatype supports:
+ * - fetch and validation of HTTP data
+ * - search indexing
+ * - product option information
+ * - class title
+ * - class serialization
+ *
+ * @package kernel
+ */
 class eZMultiOption2Type extends eZDataType
 {
     const DEFAULT_NAME_VARIABLE = "_ezmultioption2_default_name_";
     const MAX_CHILD_LEVEL = 50;
     const DATA_TYPE_STRING = "ezmultioption2";
 
-    /*!
-     Constructor to initialize the datatype.
-    */
+    /**
+     * Initializes this datatype
+     */
     function eZMultiOption2Type()
     {
         $this->eZDataType( self::DATA_TYPE_STRING, ezpI18n::tr( 'kernel/classes/datatypes', "Multi-option2", 'Datatype name' ),
                            array( 'serialize_supported' => true ) );
     }
 
-    /*!
-     Validates the input for this datatype.
-     \return True if input is valid.
-    */
     function validateObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         return eZInputValidator::STATE_ACCEPTED;
     }
 
-    /*!
-     This function calles xmlString function to create xml string and then store the content.
-    */
     function storeObjectAttribute( $contentObjectAttribute )
     {
         $optiongroup = $contentObjectAttribute->content();
         $contentObjectAttribute->setAttribute( "data_text", $optiongroup->xmlString() );
     }
 
-    /*!
-     \return An eZMultiOption2 object which contains all the option data
-    */
+    /**
+     * @inheritdoc
+     * @return eZMultiOption2
+     */
     function objectAttributeContent( $contentObjectAttribute )
     {
         $optiongroup = new eZMultiOption2( "" );
@@ -77,17 +69,11 @@ class eZMultiOption2Type extends eZDataType
         return true;
     }
 
-    /*!
-     \return The internal XML text.
-    */
     function metaData( $contentObjectAttribute )
     {
         return $contentObjectAttribute->attribute( "data_text" );
     }
 
-    /*!
-     Fetches the http post var integer input and stores it in the data instance.
-    */
     function fetchObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         $editMode = $http->postVariable( $base . "_data_edit_mode_" . $contentObjectAttribute->attribute( "id" ) );
@@ -136,6 +122,13 @@ class eZMultiOption2Type extends eZDataType
         return true;
     }
 
+    /**
+     * @param eZMultiOption2 $parentOptionGroup
+     * @param eZHTTPTool $http
+     * @param string $base
+     * @param eZContentObjectAttribute $contentObjectAttribute
+     * @param int $depth
+     */
     function fetchHTTPInputForGroup( $parentOptionGroup, $http, $base, $contentObjectAttribute, $depth = 0 )
     {
 
@@ -198,7 +191,6 @@ class eZMultiOption2Type extends eZDataType
 
                 $newID = $optionGroup->addMultiOption( $multioptionName, $multiOptionPriority, $defaultValue, $multioptionID  );
 
-
                 $optionCountArray = $http->hasPostVariable( $base . "_data_option_option_id_" .
                                                             $contentObjectAttribute->attribute( "id" ) . '_' .
                                                             $optionGroupID . '_' .  $multioptionID )
@@ -252,26 +244,31 @@ class eZMultiOption2Type extends eZDataType
 
     }
 
-
-    /*!
-     This function performs specific actions.
-
-     It has some special actions with parameters which is done by exploding
-     $action into several parts with delimeter '_'.
-     The first element is the name of specific action to perform.
-     The second element will contain the key value or id.
-
-     The various operation's that is performed by this function are as follow.
-     - new-option - A new option is added to a multioption.
-     - remove-selected-option - Removes a selected option.
-     - new_multioption - Adds a new multioption.
-     - remove_selected_multioption - Removes all multioptions given by a selection list
-    */
+    /**
+     * This function performs specific actions.
+     *
+     * It has some special actions with parameters which is done by exploding
+     * $action into several parts with delimeter '_'.
+     * The first element is the name of specific action to perform.
+     * The second element will contain the key value or id.
+     *
+     * The various operation's that is performed by this function are as follow.
+     * - new-option - A new option is added to a multioption.
+     * - remove-selected-option - Removes a selected option.
+     * - new_multioption - Adds a new multioption.
+     * - remove_selected_multioption - Removes all multioptions given by a selection list
+     *
+     * @param eZHTTPTool $http
+     * @param string $action
+     * @param eZContentObjectAttribute $contentObjectAttribute
+     * @param array $parameters
+     */
     function customObjectAttributeHTTPAction( $http, $action, $contentObjectAttribute, $parameters )
     {
         $actionlist = explode( "_", $action );
         if ( $actionlist[0] == "new-option" )
         {
+            /** @var eZMultiOption2 $rootGroup */
             $rootGroup = $contentObjectAttribute->content();
             $groupID = $actionlist[1];
             $multioptionID = $actionlist[2];
@@ -288,6 +285,7 @@ class eZMultiOption2Type extends eZDataType
         }
         else if ( $actionlist[0] == "new-sublevel" )
         {
+            /** @var eZMultiOption2 $rootGroup */
             $rootGroup = $contentObjectAttribute->content();
             $groupID = $actionlist[1];
             $multioptionID = $actionlist[2];
@@ -310,6 +308,7 @@ class eZMultiOption2Type extends eZDataType
         }
         else if ( $actionlist[0] == "new-group" )
         {
+            /** @var eZMultiOption2 $rootGroup */
             $rootGroup = $contentObjectAttribute->content();
             $childGroup = new eZMultiOption2( '', 0, $rootGroup->getMultiOptionIDCounter(),$rootGroup->getOptionCounter() );
             $rootGroup->addChildGroup( $childGroup );
@@ -323,6 +322,7 @@ class eZMultiOption2Type extends eZDataType
         }
         else if ( $actionlist[0] == "remove-selected-option" )
         {
+            /** @var eZMultiOption2 $rootGroup */
             $rootGroup = $contentObjectAttribute->content();
             $groupID = $actionlist[1];
             $multioptionID = $actionlist[2];
@@ -342,6 +342,7 @@ class eZMultiOption2Type extends eZDataType
         }
         else if ( $actionlist[0] == "new-multioption" )
         {
+            /** @var eZMultiOption2 $rootGroup */
             $rootGroup = $contentObjectAttribute->content();
             $groupID = $actionlist[1];
             $group = $rootGroup->findGroup( $groupID );
@@ -359,6 +360,7 @@ class eZMultiOption2Type extends eZDataType
         }
         else if ( $actionlist[0] == "remove-selected-multioption" )
         {
+            /** @var eZMultiOption2 $rootGroup */
             $rootGroup = $contentObjectAttribute->content();
             $groupID = $actionlist[1];
             $postvarname = "ContentObjectAttribute" . "_data_multioption_remove_" . $contentObjectAttribute->attribute( "id" ) . "_" . $groupID;
@@ -384,11 +386,13 @@ class eZMultiOption2Type extends eZDataType
             $editMode = $actionlist[1];
             $sessionVarName = 'eZEnhancedMultioption_edit_mode_' . $contentObjectAttribute->attribute( 'id' );
             $http->setSessionVariable( $sessionVarName, $editMode );
+            /** @var eZMultiOption2 $rootGroup */
             $rootGroup = $contentObjectAttribute->content();
             $contentObjectAttribute->setContent( $rootGroup );
         }
         else if ( $actionlist[0] == "reset-rules" )
         {
+            /** @var eZMultiOption2 $rootGroup */
             $rootGroup = $contentObjectAttribute->content();
             $rootGroup->Rules = array();
             $contentObjectAttribute->setContent( $rootGroup );
@@ -451,7 +455,6 @@ class eZMultiOption2Type extends eZDataType
         else if ( $actionlist[0] == "remove-object" )
         {
 
-
             $rootGroup = $contentObjectAttribute->content();
             $groupID = $actionlist[1];
             $multioptionID = $actionlist[2];
@@ -462,7 +465,6 @@ class eZMultiOption2Type extends eZDataType
             $contentObjectAttribute->setContent( $rootGroup );
             $contentObjectAttribute->store();
 
-
         }
         else
         {
@@ -470,9 +472,6 @@ class eZMultiOption2Type extends eZDataType
         }
     }
 
-    /*!
-     Finds the option which has the correct ID , if found it returns an option structure.
-    */
     function productOptionInformation( $objectAttribute, $optionID, $productItem )
     {
         $optiongroup = $objectAttribute->attribute( 'content' );
@@ -488,10 +487,11 @@ class eZMultiOption2Type extends eZDataType
         return null;
     }
 
-
-    /*!
-      \return \c true if there are more than one multioption in the list.
-    */
+    /**
+     * Returns true if there are more than one multioption in the list.
+     * @param eZContentObjectAttribute $contentObjectAttribute
+     * @return bool
+     */
     function hasObjectAttributeContent( $contentObjectAttribute )
     {
         $groups = $contentObjectAttribute->content();
@@ -499,9 +499,6 @@ class eZMultiOption2Type extends eZDataType
         return count( $grouplist ) > 0;
     }
 
-    /*!
-     Sets default multioption values.
-    */
     function initializeObjectAttribute( $contentObjectAttribute, $currentVersion, $originalContentObjectAttribute )
     {
         if ( $currentVersion == false )
@@ -527,11 +524,6 @@ class eZMultiOption2Type extends eZDataType
         return false;
     }
 
-
-    /*!
-     Validates the input for an object attribute during add to basket process
-     and returns a validation state as defined in eZInputValidator.
-    */
     function validateAddToBasket( $objectAttribute, $data, &$errors )
     {
 
@@ -539,7 +531,6 @@ class eZMultiOption2Type extends eZDataType
         $rules = $optiongroup->Rules;
 
         $validationErrors = array();
-
 
         foreach( $data as $moptionID => $selectedItem )
         {
@@ -594,9 +585,6 @@ class eZMultiOption2Type extends eZDataType
         return eZInputValidator::STATE_ACCEPTED;
     }
 
-    /*!
-     \return true if the datatype requires validation during add to basket procedure
-    */
     function isAddToBasketValidationRequired()
     {
         return true;
@@ -637,14 +625,6 @@ class eZMultiOption2Type extends eZDataType
         $objectAttribute->setAttribute( 'data_text', $xmlString );
     }
 
-    /*!
-     \return the template name to use for editing the attribute.
-     \note Default is to return the datatype string which is OK
-           for most datatypes, if you want dynamic templates
-           reimplement this function and return a template name.
-     \note The returned template name does not include the .tpl extension.
-     \sa viewTemplate, informationTemplate
-    */
     function editTemplate( $contentObjectAttribute )
     {
         $http = eZHTTPTool::instance();

--- a/kernel/classes/datatypes/ezmultiprice/ezmultipricetype.php
+++ b/kernel/classes/datatypes/ezmultiprice/ezmultipricetype.php
@@ -8,13 +8,11 @@
  * @package kernel
  */
 
-/*!
-  \class eZMultiPriceType ezmultipricetype.php
-  \ingroup eZMultiDatatype
-  \brief Stores a price in multicurrency.
-
-*/
-
+/**
+ * Stores a price in multicurrency.
+ *
+ * @package kernel
+ */
 class eZMultiPriceType extends eZDataType
 {
     const DATA_TYPE_STRING = 'ezmultiprice';
@@ -27,22 +25,20 @@ class eZMultiPriceType extends eZDataType
     const INCLUDED_VAT = 1;
     const EXCLUDED_VAT = 2;
 
+    /**
+     * Initializes the datatype
+     */
     function eZMultiPriceType()
     {
         $this->eZDataType( self::DATA_TYPE_STRING, ezpI18n::tr( 'kernel/classes/datatypes', 'Multi-price', 'Datatype name' ),
                             array( 'serialize_supported' => true ) );
     }
 
-    /*!
-     Validates the input and returns true if the input was
-     valid for this datatype.
-    */
     function validateObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         // Check "price inc/ex VAT" and "VAT type" fields.
         $vatTypeID = $http->postVariable( $base . '_ezmultiprice_vat_id_' . $contentObjectAttribute->attribute( 'id' ) );
         $vatExInc = $http->postVariable( $base . '_ezmultiprice_inc_ex_vat_' . $contentObjectAttribute->attribute( 'id' ) );
-
 
         if ( $vatExInc == 1 && $vatTypeID == -1 )
         {
@@ -85,9 +81,6 @@ class eZMultiPriceType extends eZDataType
         $multiprice->store();
     }
 
-    /*!
-     Set default class attribute value
-    */
     function initializeClassAttribute( $classAttribute )
     {
         if ( $classAttribute->attribute( self::INCLUDE_VAT_FIELD ) == 0 )
@@ -95,9 +88,6 @@ class eZMultiPriceType extends eZDataType
         $classAttribute->store();
     }
 
-    /*!
-     Sets the default value.
-    */
     function initializeObjectAttribute( $contentObjectAttribute, $currentVersion, $originalContentObjectAttribute )
     {
         if ( $currentVersion != false )
@@ -107,9 +97,6 @@ class eZMultiPriceType extends eZDataType
         }
     }
 
-    /*!
-     Set default object attribute value.
-    */
     function postInitializeObjectAttribute( $objectAttribute, $currentVersion, $originalContentObjectAttribute )
     {
         $contentClassAttribute = $objectAttribute->contentClassAttribute();
@@ -124,6 +111,7 @@ class eZMultiPriceType extends eZDataType
         }
         else
         {
+            /** @var eZMultiPrice $originalMultiprice */
             $originalMultiprice = $originalContentObjectAttribute->content();
             $multiprice = new eZMultiPrice( $contentClassAttribute, $objectAttribute );
 
@@ -160,9 +148,6 @@ class eZMultiPriceType extends eZDataType
         return true;
     }
 
-    /*!
-     Fetches the http post var integer input and stores it in the data instance.
-    */
     function fetchObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         $multiprice = $contentObjectAttribute->attribute( 'content' );
@@ -189,9 +174,10 @@ class eZMultiPriceType extends eZDataType
         return true;
     }
 
-    /*!
-     Returns the content.
-    */
+    /**
+     * @inheritdoc
+     * @return eZMultiPrice
+     */
     function objectAttributeContent( $contentObjectAttribute )
     {
         $classAttribute = $contentObjectAttribute->contentClassAttribute();
@@ -208,9 +194,10 @@ class eZMultiPriceType extends eZDataType
         return $multiprice;
     }
 
-    /*!
-     Returns class content.
-    */
+    /**
+     * @inheritdoc
+     * @return eZMultiPrice
+     */
     function classAttributeContent( $classAttribute )
     {
         $contentObjectAttribute = false;
@@ -228,6 +215,7 @@ class eZMultiPriceType extends eZDataType
                 if ( $http->hasPostVariable( $selectedCurrencyName ) )
                 {
                     $selectedCurrency = $http->postVariable( $selectedCurrencyName );
+                    /** @var eZMultiPrice $multiprice */
                     $multiprice = $contentObjectAttribute->content();
 
                     // to keep right order of currency after adding we do 'remove' and 'add'
@@ -263,14 +251,6 @@ class eZMultiPriceType extends eZDataType
         }
     }
 
-    /**
-     * Return content action(s) which can be performed on object containing
-     * the current datatype. Return format is array of arrays with key 'name'
-     * and 'action'. 'action' can be mapped to url in datatype.ini
-     *
-     * @param eZContentClassAttribute $classAttribute
-     * @return array
-    */
     function contentActionList( $classAttribute )
     {
         $actionList = parent::contentActionList( $classAttribute );
@@ -283,9 +263,6 @@ class eZMultiPriceType extends eZDataType
         return $actionList;
     }
 
-    /*!
-     Clean up stored object attribute
-    */
     function deleteStoredObjectAttribute( $objectAttribute, $version = null )
     {
         eZMultiPrice::removeByID( $objectAttribute->attribute( 'id' ), $version );
@@ -306,6 +283,7 @@ class eZMultiPriceType extends eZDataType
 
         $multiprice = $contentObjectAttribute->attribute( 'content' );
 
+        /** @var eZMultiPriceData[] $priceList */
         $priceList = $multiprice->attribute( 'price_list' );
 
         $priceArray = explode( ',', $contentObjectAttribute->attribute( 'data_text' ) );
@@ -326,7 +304,6 @@ class eZMultiPriceType extends eZDataType
         }
         return eZStringUtils::implodeStr( $priceArray, '|' );
     }
-
 
     function fromString( $contentObjectAttribute, $string )
     {
@@ -369,10 +346,12 @@ class eZMultiPriceType extends eZDataType
 
     function serializeContentClassAttribute( $classAttribute, $attributeNode, $attributeParametersNode )
     {
+        /** @var eZMultiPrice $price */
         $price = $classAttribute->content();
         if ( $price )
         {
             $vatIncluded = $price->attribute( 'is_vat_included' );
+            /** @var eZVatType[] $vatTypes */
             $vatTypes = $price->attribute( 'vat_type' );
 
             $dom = $attributeParametersNode->ownerDocument;
@@ -405,6 +384,7 @@ class eZMultiPriceType extends eZDataType
 
     function unserializeContentClassAttribute( $classAttribute, $attributeNode, $attributeParametersNode )
     {
+        /** @var DOMElement $vatNode */
         $vatNode = $attributeParametersNode->getElementsByTagName( 'vat-included' )->item( 0 );
         $vatIncluded = strtolower( $vatNode->getAttribute( 'is-set' ) ) == 'true';
         if ( $vatIncluded )
@@ -413,6 +393,7 @@ class eZMultiPriceType extends eZDataType
             $vatIncluded = self::EXCLUDED_VAT;
 
         $classAttribute->setAttribute( self::INCLUDE_VAT_FIELD, $vatIncluded );
+        /** @var DOMElement $vatTypeNode */
         $vatTypeNode = $attributeParametersNode->getElementsByTagName( 'vat-type' )->item( 0 );
         $vatName = $vatTypeNode->getAttribute( 'name' );
         $vatPercentage = $vatTypeNode->getAttribute( 'percentage' );
@@ -437,11 +418,11 @@ class eZMultiPriceType extends eZDataType
         }
         $classAttribute->setAttribute( self::VAT_ID_FIELD, $vatID );
 
+        /** @var DOMElement $defaultCurrency */
         $defaultCurrency = $attributeParametersNode->getElementsByTagName( 'default-currency' )->item( 0 );
         $currencyCode = $defaultCurrency->getAttribute( 'code' );
         $classAttribute->setAttribute( self::DEFAULT_CURRENCY_CODE_FIELD, $currencyCode );
     }
-
 
     function serializeContentObjectAttribute( $package, $objectAttribute )
     {

--- a/kernel/classes/datatypes/ezobjectrelation/ezobjectrelationtype.php
+++ b/kernel/classes/datatypes/ezobjectrelation/ezobjectrelationtype.php
@@ -8,29 +8,24 @@
  * @package kernel
  */
 
-/*!
-  \class eZObjectRelationType ezobjectrelationtype.php
-  \ingroup eZDatatype
-  \brief A content datatype which handles object relations
-
-*/
-
+/**
+ * A content datatype which handles object relations
+ *
+ * @package kernel
+ */
 class eZObjectRelationType extends eZDataType
 {
     const DATA_TYPE_STRING = "ezobjectrelation";
 
-    /*!
-     Initializes with a string id and a description.
-    */
+    /**
+     * Initializes the datatype
+     */
     function eZObjectRelationType()
     {
         $this->eZDataType( self::DATA_TYPE_STRING, ezpI18n::tr( 'kernel/classes/datatypes', "Object relation", 'Datatype name' ),
                            array( 'serialize_supported' => true ) );
     }
 
-    /*!
-     Initializes the class attribute with some data.
-     */
     function initializeObjectAttribute( $contentObjectAttribute, $currentVersion, $originalContentObjectAttribute )
     {
         if ( $currentVersion != false )
@@ -40,10 +35,6 @@ class eZObjectRelationType extends eZDataType
         }
     }
 
-    /*!
-     Validates the input and returns true if the input was
-     valid for this datatype.
-    */
     function validateObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         $postVariableName = $base . "_data_object_relation_id_" . $contentObjectAttribute->attribute( "id" );
@@ -68,9 +59,6 @@ class eZObjectRelationType extends eZDataType
         return eZInputValidator::STATE_ACCEPTED;
     }
 
-    /*!
-     Fetches the http post var string input and stores it in the data instance.
-    */
     function fetchObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         $postVariableName = $base . "_data_object_relation_id_" . $contentObjectAttribute->attribute( "id" );
@@ -132,11 +120,13 @@ class eZObjectRelationType extends eZDataType
         return $haveData;
     }
 
-    /*!
-     \private
-     \return a number of how near \a $match is to \a $text, the lower the better and 0 is a perfect match.
-     \return \c false if it does not match
-    */
+    /**
+     * Returns a number of how near $match is to $text, the lower the better and 0 is a perfect match.
+     *
+     * @param string $text
+     * @param string $match
+     * @return bool|int False if it does not match
+     */
     function fuzzyTextMatch( $text, $match )
     {
         $pos = strpos( $text, $match );
@@ -149,9 +139,6 @@ class eZObjectRelationType extends eZDataType
         return false;
     }
 
-    /*!
-     Stores relation to the ezcontentobject_link table
-    */
     function storeObjectAttribute( $contentObjectAttribute )
     {
         $contentClassAttributeID = $contentObjectAttribute->ContentClassAttributeID;
@@ -159,7 +146,7 @@ class eZObjectRelationType extends eZDataType
         $contentObjectVersion = $contentObjectAttribute->Version;
 
         $obj = $contentObjectAttribute->object();
-        //get eZContentObjectVersion
+        /** @var eZContentObjectVersion $currVerobj */
         $currVerobj = $obj->version( $contentObjectVersion );
         // get array of language codes
         $transList = $currVerobj->translations( false );
@@ -236,10 +223,11 @@ class eZObjectRelationType extends eZDataType
         $classAttribute->setAttribute( 'data_int3', $content['fuzzy_match'] );
     }
 
-    /*!
-     \private
-     Delete the old version from ezcontentobject_link if count of translations > 1
-    */
+    /**
+     * Delete the old version from ezcontentobject_link if count of translations > 1
+     *
+     * @param eZContentObjectAttribute $contentObjectAttribute
+     */
     function removeContentObjectRelation( $contentObjectAttribute )
     {
         $obj = $contentObjectAttribute->object();
@@ -344,9 +332,10 @@ class eZObjectRelationType extends eZDataType
         }
     }
 
-    /*!
-     Returns the content.
-    */
+    /**
+     * @inheritdoc
+     * @return eZContentObject
+     */
     function objectAttributeContent( $contentObjectAttribute )
     {
         $objectID = $contentObjectAttribute->attribute( "data_int" );
@@ -357,10 +346,13 @@ class eZObjectRelationType extends eZDataType
         return $object;
     }
 
-    /*!
-     Sets \c grouped_input to \c true when browse mode is active or
-     a dropdown with a fuzzy match is used.
-    */
+    /**
+     * Sets grouped_input to true when browse mode is active or a dropdown with a fuzzy match is used.
+     *
+     * @param eZContentObjectAttribute $objectAttribute
+     * @param bool $mergeInfo
+     * @return array
+     */
     function objectDisplayInformation( $objectAttribute, $mergeInfo = false )
     {
         $classAttribute = $objectAttribute->contentClassAttribute();
@@ -383,6 +375,10 @@ class eZObjectRelationType extends eZDataType
         return 'int';
     }
 
+    /**
+     * @inheritdoc
+     * @return array
+     */
     function classAttributeContent( $classObjectAttribute )
     {
         $selectionType = $classObjectAttribute->attribute( "data_int1" );
@@ -436,9 +432,6 @@ class eZObjectRelationType extends eZDataType
         }
     }
 
-    /*!
-     Returns the meta data used for storing search indeces.
-    */
     function metaData( $contentObjectAttribute )
     {
         $object = $this->objectAttributeContent( $contentObjectAttribute );
@@ -465,10 +458,7 @@ class eZObjectRelationType extends eZDataType
         }
         return false;
     }
-    /*!
-     \return string representation of an contentobjectattribute data for simplified export
 
-    */
     function toString( $contentObjectAttribute )
     {
         return $contentObjectAttribute->attribute( 'data_int' );
@@ -488,9 +478,6 @@ class eZObjectRelationType extends eZDataType
         return true;
     }
 
-    /*!
-     Returns the content of the string for use as a title
-    */
     function title( $contentObjectAttribute, $name = null )
     {
         $object = $this->objectAttributeContent( $contentObjectAttribute );
@@ -529,17 +516,21 @@ class eZObjectRelationType extends eZDataType
 
     function unserializeContentClassAttribute( $classAttribute, $attributeNode, $attributeParametersNode )
     {
+        /** @var array  $content */
         $content = $classAttribute->content();
+        /** @var DOMElement $selectionTypeNode */
         $selectionTypeNode = $attributeParametersNode->getElementsByTagName( 'selection-type' )->item( 0 );
         $content['selection_type'] = 0;
         if ( $selectionTypeNode )
             $content['selection_type'] = $selectionTypeNode->getAttribute( 'id' );
 
+        /** @var DOMElement $fuzzyMatchNode */
         $fuzzyMatchNode = $attributeParametersNode->getElementsByTagName( 'fuzzy-match' )->item( 0 );
         $content['fuzzy_match'] = false;
         if ( $fuzzyMatchNode )
             $content['fuzzy_match'] = $fuzzyMatchNode->getAttribute( 'id' );
 
+        /** @var DOMElement $defaultSelectionNode */
         $defaultSelectionNode = $attributeParametersNode->getElementsByTagName( 'default-selection' )->item( 0 );
         $content['default_selection_node'] = false;
         if ( $defaultSelectionNode )
@@ -549,9 +540,13 @@ class eZObjectRelationType extends eZDataType
         $classAttribute->store();
     }
 
-    /*!
-     Export related object's remote_id.
-    */
+    /**
+     * Export related object's remote_id.
+     *
+     * @param eZPackage $package
+     * @param eZContentObjectAttribute $objectAttribute
+     * @return DOMElement
+     */
     function serializeContentObjectAttribute( $package, $objectAttribute )
     {
         $node = $this->createContentObjectAttributeDOMNode( $objectAttribute );
@@ -625,9 +620,10 @@ class eZObjectRelationType extends eZDataType
         return $attributeChanged;
     }
 
-    /*!
-     Removes objects with given ID from the relations list
-    */
+    /**
+     * @inheritdoc
+     * @return bool
+     */
     function removeRelatedObjectItem( $contentObjectAttribute, $objectID )
     {
         $contentObjectAttribute->setAttribute( "data_int", null );
@@ -638,8 +634,6 @@ class eZObjectRelationType extends eZDataType
     {
         return true;
     }
-
-    /// \privatesection
 }
 
 ?>

--- a/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
+++ b/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
@@ -8,37 +8,31 @@
  * @package kernel
  */
 
-/*!
-  \class eZObjectRelationListType ezobjectrelationlisttype.php
-  \ingroup eZDatatype
-  \brief A content datatype which handles object relations
-
-Bugs/missing/deprecated features:
-- No identifier support yet
-- Validation and fixup for "Add new object" functionality
-- Proper embed views for admin classes
-- No translation page support yet (maybe?)
-- is_modified is deprecated and is used for BC only.
-
-*/
-
+/**
+ * A content datatype which handles object relations
+ *
+ * Bugs/missing/deprecated features:
+ * - No identifier support yet
+ * - Validation and fixup for "Add new object" functionality
+ * - Proper embed views for admin classes
+ * - No translation page support yet (maybe?)
+ * - is_modified is deprecated and is used for BC only.
+ *
+ * @package kernel
+ */
 class eZObjectRelationListType extends eZDataType
 {
     const DATA_TYPE_STRING = "ezobjectrelationlist";
 
-    /*!
-     Initializes with a string id and a description.
-    */
+    /**
+     * Initializes the datatype
+     */
     function eZObjectRelationListType()
     {
         $this->eZDataType( self::DATA_TYPE_STRING, ezpI18n::tr( 'kernel/classes/datatypes', "Object relations", 'Datatype name' ),
                            array( 'serialize_supported' => true ) );
     }
 
-    /*!
-     Validates the input and returns true if the input was
-     valid for this datatype.
-    */
     function validateObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         $postVariableName = $base . "_data_object_relation_list_" . $contentObjectAttribute->attribute( "id" );
@@ -143,10 +137,6 @@ class eZObjectRelationListType extends eZDataType
         return $status;
     }
 
-    /*!
-     Validates the input and returns true if the input was
-     valid for this datatype.
-    */
     function fixupObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         $content = $contentObjectAttribute->content();
@@ -157,6 +147,7 @@ class eZObjectRelationListType extends eZDataType
             {
                 $subObjectID = $relationItem['contentobject_id'];
                 $attributeBase = $base . '_ezorl_edit_object_' . $subObjectID;
+                /** @var eZContentObject $object */
                 $object = $content['temp'][$subObjectID]['object'];
                 $requireFixup = $content['temp'][$subObjectID]['require-fixup'];
                 if ( $object and
@@ -169,9 +160,6 @@ class eZObjectRelationListType extends eZDataType
         }
     }
 
-    /*!
-     Fetches the http post var string input and stores it in the data instance.
-    */
     function fetchObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         $content = $contentObjectAttribute->content();
@@ -276,6 +264,7 @@ class eZObjectRelationListType extends eZDataType
             {
                 $subObjectID = $relationItem['contentobject_id'];
                 $attributeBase = $base . '_ezorl_edit_object_' . $subObjectID;
+                /** @var eZContentObject $object */
                 $object = $content['temp'][$subObjectID]['object'];
                 if ( $object )
                 {
@@ -311,6 +300,13 @@ class eZObjectRelationListType extends eZDataType
         return true;
     }
 
+    /**
+     * Creates a new content object and returns its ID
+     *
+     * @param eZContentObjectAttribute $contentObjectAttribute
+     * @param string $name
+     * @return bool|int
+     */
     function createNewObject( $contentObjectAttribute, $name )
     {
         $classAttribute = $contentObjectAttribute->attribute( 'contentclass_attribute' );
@@ -391,7 +387,7 @@ class eZObjectRelationListType extends eZDataType
         $contentObjectVersion = $attribute->Version;
 
         $obj = $attribute->object();
-        //get eZContentObjectVersion
+        /** @var eZContentObjectVersion $currVerobj */
         $currVerobj = $obj->version( $contentObjectVersion );
 
         // create translation List
@@ -425,6 +421,7 @@ class eZObjectRelationListType extends eZDataType
             if ( $relationItem['is_modified'] && isset( $content['temp'][$subObjectID]['object' ] ) )
             {
                 // handling sub-objects
+                /** @var eZContentObject $object */
                 $object = $content['temp'][$subObjectID]['object'];
                 if ( $object )
                 {
@@ -698,24 +695,34 @@ class eZObjectRelationListType extends eZDataType
         return false;
     }
 
+    /**
+     * @param DOMDocument $doc
+     * @param eZContentClassAttribute $classAttribute
+     */
     static function storeClassDOMDocument( $doc, $classAttribute )
     {
         $docText = self::domString( $doc );
         $classAttribute->setAttribute( 'data_text5', $docText );
     }
 
+    /**
+     * @param DOMDocument $doc
+     * @param eZContentObjectAttribute $objectAttribute
+     */
     static function storeObjectDOMDocument( $doc, $objectAttribute )
     {
         $docText = self::domString( $doc );
         $objectAttribute->setAttribute( 'data_text', $docText );
     }
 
-    /*!
-     \static
-     \return the XML structure in \a $domDocument as text.
-             It will take of care of the necessary charset conversions
-             for content storage.
-    */
+    /**
+     * Returns the XML structure in $domDocument as text.
+     *
+     * It will take of care of the necessary charset conversions for content storage.
+     *
+     * @param DOMDocument $domDocument
+     * @return string
+     */
     static function domString( $domDocument )
     {
         $ini = eZINI::instance();
@@ -736,6 +743,10 @@ class eZObjectRelationListType extends eZDataType
         return $domString;
     }
 
+    /**
+     * @param array $content
+     * @return DOMDocument
+     */
     static function createClassDOMDocument( $content )
     {
         $doc = new DOMDocument( '1.0', 'utf-8' );
@@ -769,6 +780,10 @@ class eZObjectRelationListType extends eZDataType
         return $doc;
     }
 
+    /**
+     * @param array $content
+     * @return DOMDocument
+     */
     static function createObjectDOMDocument( $content )
     {
         $doc = new DOMDocument( '1.0', 'utf-8' );
@@ -797,6 +812,9 @@ class eZObjectRelationListType extends eZDataType
         return $doc;
     }
 
+    /**
+     * @return array
+     */
     static function contentObjectArrayXMLMap()
     {
         return array( 'identifier' => 'identifier',
@@ -892,6 +910,7 @@ class eZObjectRelationListType extends eZDataType
 
                 if ( $hasAttributeInput )
                 {
+                    /** @var eZContentObject $object */
                     $object = $relationItem['object'];
                     $attributes = $object->contentObjectAttributes();
                     foreach ( $attributes as $attribute )
@@ -1093,6 +1112,7 @@ class eZObjectRelationListType extends eZDataType
     function handleCustomObjectHTTPActions( $http, $attributeDataBaseName,
                                             $customActionAttributeArray, $customActionParameters )
     {
+        /** @var eZContentObjectAttribute $contentObjectAttribute */
         $contentObjectAttribute = $customActionParameters['contentobject_attribute'];
         $content = $contentObjectAttribute->content();
         foreach( $content['relation_list'] as $relationItem )
@@ -1119,20 +1139,24 @@ class eZObjectRelationListType extends eZDataType
         }
     }
 
-    /*!
-     \static
-     \return \c true if the relation item \a $relationItem exist in the content tree.
-    */
+    /**
+     * Returns true if the relation item exists in the content tree.
+     *
+     * @param array $relationItem
+     * @return bool
+     */
     static function isItemPublished( $relationItem )
     {
         return is_numeric( $relationItem['node_id'] ) and $relationItem['node_id'] > 0;
     }
 
-    /*!
-     \private
-     Removes the relation object \a $deletionItem if the item is owned solely by this
-     version and is not published in the content tree.
-    */
+    /**
+     * Removes the relation object $deletionItem if the item is owned solely by this
+     * version and is not published in the content tree.
+     *
+     * @param eZContentObjectAttribute $contentObjectAttribute
+     * @param array $deletionItem
+     */
     static function removeRelationObject( $contentObjectAttribute, $deletionItem )
     {
         if ( self::isItemPublished( $deletionItem ) )
@@ -1140,6 +1164,7 @@ class eZObjectRelationListType extends eZDataType
             return;
         }
 
+        /** @var eZContentObject $hostObject */
         $hostObject = $contentObjectAttribute->attribute( 'object' );
         $hostObjectID = $hostObject->attribute( 'id' );
 
@@ -1165,6 +1190,7 @@ class eZObjectRelationListType extends eZDataType
             if ( $isDeletionAllowed and
                  $version->attribute( 'version' ) != $contentObjectAttribute->attribute( 'version' ) )
             {
+                /** @var eZContentObjectAttribute[] $relationAttribute */
                 $relationAttribute = eZPersistentObject::fetchObjectList( eZContentObjectAttribute::definition(),
                                                                            null,
                                                                            array( 'version' => $version->attribute( 'version' ),
@@ -1209,7 +1235,13 @@ class eZObjectRelationListType extends eZDataType
         }
     }
 
-
+    /**
+     * @param eZContentClass $class
+     * @param int $priority
+     * @param eZContentObjectAttribute $contentObjectAttribute
+     * @param int|bool $nodePlacement Node ID of the node under which the object will be placed
+     * @return array
+     */
     function createInstance( $class, $priority, $contentObjectAttribute, $nodePlacement = false )
     {
         $currentObject = $contentObjectAttribute->attribute( 'object' );
@@ -1236,8 +1268,8 @@ class eZObjectRelationListType extends eZDataType
     /**
      * Generate array with object relation info
      *
-     * @param integer $objectID The id of the object to add as relation
-     * @param integer $priority The priortity of the relation
+     * @param int $objectID The id of the object to add as relation
+     * @param int $priority The priortity of the relation
      * @param eZContentObjectAttribute $contentObjectAttribute Not used
      * @return array|null A array containing relation information or null if object does not exist
      */
@@ -1266,7 +1298,6 @@ class eZObjectRelationListType extends eZDataType
         $relationItem['object'] = $object;
         return $relationItem;
     }
-
 
     function fixRelatedObjectItem ( $contentObjectAttribute, $objectID, $mode )
     {
@@ -1304,11 +1335,19 @@ class eZObjectRelationListType extends eZDataType
         }
     }
 
+    /**
+     * @param int $objectID
+     * @param eZContentObjectAttribute $contentObjectAttribute
+     */
     function fixRelationsMove ( $objectID, $contentObjectAttribute )
     {
         $this->fixRelationsSwap( $objectID, $contentObjectAttribute );
     }
 
+    /**
+     * @param int $objectID
+     * @param eZContentObjectAttribute $contentObjectAttribute
+     */
     function fixRelationsTrash ( $objectID, $contentObjectAttribute )
     {
         $content = $contentObjectAttribute->attribute( 'content' );
@@ -1326,6 +1365,10 @@ class eZObjectRelationListType extends eZDataType
         $contentObjectAttribute->storeData();
     }
 
+    /**
+     * @param int $objectID
+     * @param eZContentObjectAttribute $contentObjectAttribute
+     */
     function fixRelationsRestore ( $objectID, $contentObjectAttribute )
     {
         $content = $contentObjectAttribute->content();
@@ -1343,12 +1386,20 @@ class eZObjectRelationListType extends eZDataType
         $contentObjectAttribute->storeData();
     }
 
+    /**
+     * @param int $objectID
+     * @param eZContentObjectAttribute $contentObjectAttribute
+     */
     function fixRelationsRemove ( $objectID, $contentObjectAttribute )
     {
         $this->removeRelatedObjectItem( $contentObjectAttribute, $objectID );
         $contentObjectAttribute->storeData();
     }
 
+    /**
+     * @param int $objectID
+     * @param eZContentObjectAttribute $contentObjectAttribute
+     */
     function fixRelationsSwap ( $objectID, $contentObjectAttribute )
     {
         $content =& $contentObjectAttribute->content();
@@ -1368,10 +1419,14 @@ class eZObjectRelationListType extends eZDataType
         $contentObjectAttribute->storeData();
     }
 
-
-    /*!
-     Returns the content.
-    */
+    /**
+     * Returns an array with related content objects
+     *
+     * @see createObjectContentStructure()
+     *
+     * @param eZContentObjectAttribute $contentObjectAttribute
+     * @return array
+     */
     function objectAttributeContent( $contentObjectAttribute )
     {
         $xmlText = $contentObjectAttribute->attribute( 'data_text' );
@@ -1386,6 +1441,12 @@ class eZObjectRelationListType extends eZDataType
         return $content;
     }
 
+    /**
+     * @see defaultClassAttributeContent()
+     *
+     * @param eZContentClassAttribute $classAttribute
+     * @return array
+     */
     function classAttributeContent( $classAttribute )
     {
         $xmlText = $classAttribute->attribute( 'data_text5' );
@@ -1397,6 +1458,12 @@ class eZObjectRelationListType extends eZDataType
         return $this->createClassContentStructure( $doc );
     }
 
+    /**
+     * Parses $xmlText and converts it to a DOMDocument
+     *
+     * @param string $xmlText
+     * @return DOMDocument
+     */
     static function parseXML( $xmlText )
     {
         $dom = new DOMDocument( '1.0', 'utf-8' );
@@ -1404,6 +1471,9 @@ class eZObjectRelationListType extends eZDataType
         return $dom;
     }
 
+    /**
+     * @return array
+     */
     function defaultClassAttributeContent()
     {
         return array( 'object_class' => '',
@@ -1413,15 +1483,23 @@ class eZObjectRelationListType extends eZDataType
                       'default_placement' => false );
     }
 
+    /**
+     * @return array
+     */
     function defaultObjectAttributeContent()
     {
         return array( 'relation_list' => array() );
     }
 
+    /**
+     * @param DOMDocument $doc
+     * @return array
+     */
     function createClassContentStructure( $doc )
     {
         $content = $this->defaultClassAttributeContent();
         $root = $doc->documentElement;
+        /** @var DOMElement $objectPlacement */
         $objectPlacement = $root->getElementsByTagName( 'contentobject-placement' )->item( 0 );
 
         if ( $objectPlacement and $objectPlacement->hasAttributes() )
@@ -1429,25 +1507,30 @@ class eZObjectRelationListType extends eZDataType
             $nodeID = $objectPlacement->getAttribute( 'node-id' );
             $content['default_placement'] = array( 'node_id' => $nodeID );
         }
+        /** @var DOMElement $constraints */
         $constraints = $root->getElementsByTagName( 'constraints' )->item( 0 );
         if ( $constraints )
         {
+            /** @var DOMElement[] $allowedClassList */
             $allowedClassList = $constraints->getElementsByTagName( 'allowed-class' );
             foreach( $allowedClassList as $allowedClass )
             {
                 $content['class_constraint_list'][] = $allowedClass->getAttribute( 'contentclass-identifier' );
             }
         }
+        /** @var DOMElement $type */
         $type = $root->getElementsByTagName( 'type' )->item( 0 );
         if ( $type )
         {
             $content['type'] = $type->getAttribute( 'value' );
         }
+        /** @var DOMElement $selectionType */
         $selectionType = $root->getElementsByTagName( 'selection_type' )->item( 0 );
         if ( $selectionType )
         {
             $content['selection_type'] = $selectionType->getAttribute( 'value' );
         }
+        /** @var DOMElement $objectClass */
         $objectClass = $root->getElementsByTagName( 'object_class' )->item( 0 );
         if ( $objectClass )
         {
@@ -1457,14 +1540,20 @@ class eZObjectRelationListType extends eZDataType
         return $content;
     }
 
+    /**
+     * @param DOMDocument $doc
+     * @return array
+     */
     function createObjectContentStructure( $doc )
     {
         $content = $this->defaultObjectAttributeContent();
         $root = $doc->documentElement;
+        /** @var DOMElement $relationList */
         $relationList = $root->getElementsByTagName( 'relation-list' )->item( 0 );
         if ( $relationList )
         {
             $contentObjectArrayXMLMap = $this->contentObjectArrayXMLMap();
+            /** @var DOMElement[] $relationItems */
             $relationItems = $relationList->getElementsByTagName( 'relation-item' );
             foreach ( $relationItems as $relationItem )
             {
@@ -1524,9 +1613,6 @@ class eZObjectRelationListType extends eZDataType
         }
     }
 
-    /*!
-     Returns the meta data used for storing search indexes.
-    */
     function metaData( $contentObjectAttribute )
     {
         $metaDataArray = $attributes = array();
@@ -1561,10 +1647,6 @@ class eZObjectRelationListType extends eZDataType
         return $metaDataArray;
     }
 
-    /*!
-     \return string representation of an contentobjectattribute data for simplified export
-
-    */
     function toString( $contentObjectAttribute )
     {
         $objectAttributeContent = $contentObjectAttribute->attribute( 'content' );
@@ -1610,10 +1692,15 @@ class eZObjectRelationListType extends eZDataType
         return true;
     }
 
-    /*!
-     Returns the content of the string for use as a title,
-     for simplicity this is the name of the first object referenced or false.
-    */
+    /**
+     * Returns the title of the current type, this is to form the title of the object.
+     *
+     * For simplicity this is the name of the first object referenced or false.
+     *
+     * @param eZContentObjectAttribute $contentObjectAttribute
+     * @param null $name
+     * @return bool|string
+     */
     function title( $contentObjectAttribute, $name = null )
     {
         $objectAttributeContent = $this->objectAttributeContent( $contentObjectAttribute );
@@ -1676,6 +1763,7 @@ class eZObjectRelationListType extends eZDataType
     function unserializeContentClassAttribute( $classAttribute, $attributeNode, $attributeParametersNode )
     {
         $content = $classAttribute->content();
+        /** @var DOMElement $defaultPlacementNode */
         $defaultPlacementNode = $attributeParametersNode->getElementsByTagName( 'default-placement' )->item( 0 );
         $content['default_placement'] = false;
 
@@ -1684,7 +1772,9 @@ class eZObjectRelationListType extends eZDataType
             $content['default_placement'] = array( 'node_id' => $defaultPlacementNode->getAttribute( 'node-id' ) );
         }
         $content['type'] = $attributeParametersNode->getElementsByTagName( 'type' )->item( 0 )->textContent;
+        /** @var DOMElement $classConstraintsNode */
         $classConstraintsNode = $attributeParametersNode->getElementsByTagName( 'class-constraints' )->item( 0 );
+        /** @var DOMElement[] $classConstraintList */
         $classConstraintList = $classConstraintsNode->getElementsByTagName( 'class-constraint' );
         $content['class_constraint_list'] = array();
         foreach ( $classConstraintList as $classConstraintNode )
@@ -1709,18 +1799,26 @@ class eZObjectRelationListType extends eZDataType
         $this->storeClassAttributeContent( $classAttribute, $content );
     }
 
-    /*!
-     For each relation export its priority and content object remote_id, like this:
-      <related-objects>
-        <relation-list>
-          <relation-item priority="1"
-                         contentobject-remote-id="faaeb9be3bd98ed09f606fc16d144eca" />
-          <relation-item priority="2"
-                         contentobject-remote-id="1bb4fe25487f05527efa8bfd394cecc7" />
-        </relation-list>
-     To do this we fetch content XML and strip all the relation attributes except of "priority" from there,
-     and add "contentobject-remote-id" attribute.
-    */
+    /**
+     * Returns a DOM representation of the content object attribute
+     *
+     * For each relation export its priority and content object remote_id, like this:
+     * <code>
+     * &lt;related-objects&gt;
+     *     &lt;relation-list>
+     *         &lt;relation-item priority="1" contentobject-remote-id="faaeb9be3bd98ed09f606fc16d144eca" /&gt;
+     *         &lt;relation-item priority="2" contentobject-remote-id="1bb4fe25487f05527efa8bfd394cecc7" /&gt;
+     *     &lt;/relation-list&gt;
+     * &lt;/related-objects&gt;
+     * </code>
+     *
+     * To do this we fetch content XML and strip all the relation attributes except of "priority" from there,
+     * and add "contentobject-remote-id" attribute.
+     *
+     * @param eZPackage $package
+     * @param eZContentObjectAttribute $objectAttribute
+     * @return DOMElement
+     */
     function serializeContentObjectAttribute( $package, $objectAttribute )
     {
         $node = $this->createContentObjectAttributeDOMNode( $objectAttribute );
@@ -1737,12 +1835,14 @@ class eZObjectRelationListType extends eZDataType
             $success = $dom->loadXML( $objectAttribute->attribute( 'data_text' ) );
         }
         $rootNode = $dom->documentElement;
+        /** @var DOMElement $relationList */
         $relationList = $rootNode->getElementsByTagName( 'relation-list' )->item( 0 );
         if ( $relationList )
         {
             $relationItems = $relationList->getElementsByTagName( 'relation-item' );
             for ( $i = 0; $i < $relationItems->length; $i++ )
             {
+                /** @var DOMElement $relationItem */
                 $relationItem = $relationItems->item( $i );
                 // Add related object remote id as attribute to the relation item.
                 $relatedObjectID = $relationItem->getAttribute( 'contentobject-id' );
@@ -1792,6 +1892,7 @@ class eZObjectRelationListType extends eZDataType
         $doc = $this->parseXML( $xmlString );
         $rootNode = $doc->documentElement;
 
+        /** @var DOMElement $relationList */
         $relationList = $rootNode->getElementsByTagName( 'relation-list' )->item( 0 );
         if ( !$relationList )
             return false;
@@ -1799,6 +1900,7 @@ class eZObjectRelationListType extends eZDataType
         $relationItems = $relationList->getElementsByTagName( 'relation-item' );
         for ( $i = $relationItems->length - 1; $i >= 0; $i-- )
         {
+            /** @var DOMElement $relationItem */
             $relationItem = $relationItems->item( $i );
             $relatedObjectRemoteID = $relationItem->getAttribute( 'contentobject-remote-id' );
             $object = eZContentObject::fetchByRemoteID( $relatedObjectRemoteID );
@@ -1824,9 +1926,6 @@ class eZObjectRelationListType extends eZDataType
         return true;
     }
 
-    /*!
-     Removes objects with given ID from the relations list
-    */
     function removeRelatedObjectItem( $contentObjectAttribute, $objectID )
     {
         $xmlText = $contentObjectAttribute->attribute( 'data_text' );
@@ -1836,9 +1935,11 @@ class eZObjectRelationListType extends eZDataType
 
         $return = false;
         $root = $doc->documentElement;
+        /** @var DOMElement $relationList */
         $relationList = $root->getElementsByTagName( 'relation-list' )->item( 0 );
         if ( $relationList )
         {
+            /** @var DOMElement[] $relationItems */
             $relationItems = $relationList->getElementsByTagName( 'relation-item' );
             if ( !empty( $relationItems ) )
             {
@@ -1860,8 +1961,6 @@ class eZObjectRelationListType extends eZDataType
     {
         return true;
     }
-
-    /// \privatesection
 }
 
 ?>

--- a/kernel/classes/datatypes/ezoption/ezoptiontype.php
+++ b/kernel/classes/datatypes/ezoption/ezoptiontype.php
@@ -8,19 +8,18 @@
  * @package kernel
  */
 
-/*!
-  \class eZOptionType ezoptiontype.php
-  \ingroup eZDatatype
-  \brief Stores option values
-
-*/
-
+/**
+ * Stores option values
+ */
 class eZOptionType extends eZDataType
 {
     const DEFAULT_NAME_VARIABLE = "_ezoption_default_name_";
 
     const DATA_TYPE_STRING = "ezoption";
 
+    /**
+     * Initializes the datatype
+     */
     function eZOptionType()
     {
         $this->eZDataType( self::DATA_TYPE_STRING, ezpI18n::tr( 'kernel/classes/datatypes', "Option", 'Datatype name' ),
@@ -49,10 +48,6 @@ class eZOptionType extends eZDataType
         }
     }
 
-    /*!
-     Validates the input and returns true if the input was
-     valid for this datatype.
-    */
     function validateObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         $count = 0;
@@ -115,18 +110,16 @@ class eZOptionType extends eZDataType
         return eZInputValidator::STATE_ACCEPTED;
     }
 
-    /*!
-     Store content
-    */
     function storeObjectAttribute( $contentObjectAttribute )
     {
         $option = $contentObjectAttribute->content();
         $contentObjectAttribute->setAttribute( "data_text", $option->xmlString() );
     }
 
-    /*!
-     Returns the content.
-    */
+    /**
+     * @inheritdoc
+     * @return eZOption
+     */
     function objectAttributeContent( $contentObjectAttribute )
     {
         $option = new eZOption( "" );
@@ -136,17 +129,11 @@ class eZOptionType extends eZDataType
         return $option;
     }
 
-    /*!
-     Returns the meta data used for storing search indeces.
-    */
     function metaData( $contentObjectAttribute )
     {
         return $contentObjectAttribute->attribute( "data_text" );
     }
 
-    /*!
-     Fetches the http post var integer input and stores it in the data instance.
-    */
     function fetchObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         $optionName = $http->postVariable( $base . "_data_option_name_" . $contentObjectAttribute->attribute( "id" ) );
@@ -176,10 +163,6 @@ class eZOptionType extends eZDataType
         return true;
     }
 
-
-    /*!
-     Fetches the http post variables for collected information
-    */
     function fetchCollectionAttributeHTTPInput( $collection, $collectionAttribute, $http, $base, $contentObjectAttribute )
     {
         if ( $http->hasPostVariable( $base . "_data_option_value_" . $contentObjectAttribute->attribute( "id" ) ) )
@@ -241,10 +224,6 @@ class eZOptionType extends eZDataType
         }
     }
 
-    /*!
-     Finds the option which has the ID that matches \a $optionID, if found it returns
-     an option structure.
-    */
     function productOptionInformation( $objectAttribute, $optionID, $productItem )
     {
         $option = $objectAttribute->attribute( 'content' );
@@ -261,9 +240,6 @@ class eZOptionType extends eZDataType
         return false;
     }
 
-    /*!
-     Returns the integer value.
-    */
     function title( $contentObjectAttribute, $name = "name" )
     {
         $option = $contentObjectAttribute->content( );
@@ -280,9 +256,6 @@ class eZOptionType extends eZDataType
         return count( $options ) > 0;
     }
 
-    /*!
-     Sets the default value.
-    */
     function initializeObjectAttribute( $contentObjectAttribute, $currentVersion, $originalContentObjectAttribute )
     {
         if ( $currentVersion == false )
@@ -341,7 +314,6 @@ class eZOptionType extends eZDataType
         return eZStringUtils::implodeStr( $optionArray, "|" );
     }
 
-
     function fromString( $contentObjectAttribute, $string )
     {
         if ( $string == '' )
@@ -362,12 +334,12 @@ class eZOptionType extends eZDataType
                                        'additional_price' => array_shift( $optionArray ) ) );
         }
 
-
         $contentObjectAttribute->setAttribute( "data_text", $option->xmlString() );
 
         return $option;
 
     }
+
     function serializeContentClassAttribute( $classAttribute, $attributeNode, $attributeParametersNode )
     {
         $defaultValue = $classAttribute->attribute( 'data_text1' );

--- a/kernel/classes/datatypes/ezpackage/ezpackagetype.php
+++ b/kernel/classes/datatypes/ezpackage/ezpackagetype.php
@@ -8,14 +8,11 @@
  * @package kernel
  */
 
-/*!
-  \class eZPackageType ezpackagetype.php
-  \ingroup eZDatatype
-  \brief The class eZPackageType does
-
-*/
-
-
+/**
+ * Datatype to store eZPackage objects
+ *
+ * @package kernel
+ */
 class eZPackageType extends eZDataType
 {
     const DATA_TYPE_STRING = 'ezpackage';
@@ -24,18 +21,15 @@ class eZPackageType extends eZDataType
     const VIEW_MODE_FIELD = 'data_int1';
     const VIEW_MODE_VARIABLE = '_ezpackage_view_mode_';
 
-    /*!
-     Constructor
-    */
+    /**
+     * Initializes the datatype
+     */
     function eZPackageType()
     {
         $this->eZDataType( self::DATA_TYPE_STRING, ezpI18n::tr( 'kernel/classes/datatypes', 'Package', 'Datatype name' ),
                            array( 'serialize_supported' => true ) );
     }
 
-    /*!
-     Sets the default value.
-    */
     function initializeObjectAttribute( $contentObjectAttribute, $currentVersion, $originalContentObjectAttribute )
     {
     }
@@ -45,9 +39,6 @@ class eZPackageType extends eZDataType
         return eZInputValidator::STATE_ACCEPTED;
     }
 
-    /*!
-     Fetches the http post var string input and stores it in the data instance.
-    */
     function fetchObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         if ( $http->hasPostVariable( $base . '_ezpackage_data_text_' . $contentObjectAttribute->attribute( 'id' ) ) )
@@ -96,10 +87,6 @@ class eZPackageType extends eZDataType
         return true;
     }
 
-    /*!
-     Does nothing since it uses the data_text field in the content object attribute.
-     See fetchObjectAttributeHTTPInput for the actual storing.
-    */
     function storeObjectAttribute( $attribute )
     {
         $ini = eZINI::instance();
@@ -155,9 +142,10 @@ class eZPackageType extends eZDataType
         return true;
     }
 
-    /*!
-     Returns the content.
-    */
+    /**
+     * @inheritdoc
+     * @return eZPackage
+     */
     function objectAttributeContent( $contentObjectAttribute )
     {
         $packageName = $contentObjectAttribute->attribute( "data_text" );
@@ -165,17 +153,11 @@ class eZPackageType extends eZDataType
         return $package;
     }
 
-    /*!
-     Returns the meta data used for storing search indeces.
-    */
     function metaData( $contentObjectAttribute )
     {
         return $contentObjectAttribute->attribute( 'data_text' );
     }
 
-    /*!
-     Returns the content of the string for use as a title
-    */
     function title( $contentObjectAttribute, $name = null )
     {
         return $contentObjectAttribute->attribute( 'data_text' );

--- a/kernel/classes/datatypes/ezprice/ezpricetype.php
+++ b/kernel/classes/datatypes/ezprice/ezpricetype.php
@@ -8,13 +8,11 @@
  * @package kernel
  */
 
-/*!
-  \class eZPriceType ezpricetype.php
-  \ingroup eZDatatype
-  \brief Stores a price (float)
-
-*/
-
+/**
+ * Stores an eZPrice object
+ *
+ * @package kernel
+ */
 class eZPriceType extends eZDataType
 {
     const DATA_TYPE_STRING = "ezprice";
@@ -25,6 +23,9 @@ class eZPriceType extends eZDataType
     const INCLUDED_VAT = 1;
     const EXCLUDED_VAT = 2;
 
+    /**
+     * Initializes the datatype
+     */
     function eZPriceType()
     {
         $this->eZDataType( self::DATA_TYPE_STRING, ezpI18n::tr( 'kernel/classes/datatypes', "Price", 'Datatype name' ),
@@ -32,10 +33,6 @@ class eZPriceType extends eZDataType
                                   'object_serialize_map' => array( 'data_float' => 'price' ) ) );
     }
 
-    /*!
-     Validates the input and returns true if the input was
-     valid for this datatype.
-    */
     function validateObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         // Check "price inc/ex VAT" and "VAT type" fields.
@@ -87,9 +84,6 @@ class eZPriceType extends eZDataType
         return $contentObjectAttribute->attribute( "data_float" );
     }
 
-    /*!
-     reimp
-    */
     function initializeObjectAttribute( $contentObjectAttribute, $currentVersion, $originalContentObjectAttribute )
     {
         if ( $currentVersion != false )
@@ -101,15 +95,13 @@ class eZPriceType extends eZDataType
         }
     }
 
-    /*!
-     Set default class attribute value
-    */
     function initializeClassAttribute( $classAttribute )
     {
         if ( $classAttribute->attribute( self::INCLUDE_VAT_FIELD ) == 0 )
             $classAttribute->setAttribute( self::INCLUDE_VAT_FIELD, self::INCLUDED_VAT );
         $classAttribute->store();
     }
+
     function fetchClassAttributeHTTPInput( $http, $base, $classAttribute )
     {
         $isVatIncludedVariable = $base . self::INCLUDE_VAT_VARIABLE . $classAttribute->attribute( 'id' );
@@ -127,9 +119,6 @@ class eZPriceType extends eZDataType
         return true;
     }
 
-    /*!
-     Fetches the http post var integer input and stores it in the data instance.
-    */
     function fetchObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         $data = $http->postVariable( $base . "_data_price_" . $contentObjectAttribute->attribute( "id" ) );
@@ -147,9 +136,10 @@ class eZPriceType extends eZDataType
         return true;
     }
 
-    /*!
-     Returns the content.
-    */
+    /**
+     * @inheritdoc
+     * @return eZPrice
+     */
     function objectAttributeContent( $contentObjectAttribute )
     {
         $classAttribute = $contentObjectAttribute->contentClassAttribute();
@@ -167,9 +157,10 @@ class eZPriceType extends eZDataType
         return $price;
     }
 
-    /*!
-     Returns class content.
-    */
+    /**
+     * @inheritdoc
+     * @return eZPrice
+     */
     function classAttributeContent( $classAttribute )
     {
         $contentObjectAttribute = false;
@@ -177,14 +168,6 @@ class eZPriceType extends eZDataType
         return $price;
     }
 
-    /**
-     * Return content action(s) which can be performed on object containing
-     * the current datatype. Return format is array of arrays with key 'name'
-     * and 'action'. 'action' can be mapped to url in datatype.ini
-     *
-     * @param eZContentClassAttribute $classAttribute
-     * @return array
-    */
     function contentActionList( $classAttribute )
     {
         $actionList = parent::contentActionList( $classAttribute );
@@ -222,12 +205,12 @@ class eZPriceType extends eZDataType
     {
 
         $price = $contentObjectAttribute->attribute( 'content' );
+        /** @var eZVatType $vatType */
         $vatType =$price->attribute( 'selected_vat_type' );
 
         $priceStr = implode( '|', array( $price->attribute( 'price' ), $vatType->attribute( 'id' ) , ($price->attribute( 'is_vat_included' ) )? 1:0 ) );
         return $priceStr;
     }
-
 
     function fromString( $contentObjectAttribute, $string )
     {
@@ -249,10 +232,12 @@ class eZPriceType extends eZDataType
 
     function serializeContentClassAttribute( $classAttribute, $attributeNode, $attributeParametersNode )
     {
+        /** @var eZPrice $price */
         $price = $classAttribute->content();
         if ( $price )
         {
             $vatIncluded = $price->attribute( 'is_vat_included' );
+            /** @var eZVatType[] $vatTypes */
             $vatTypes = $price->attribute( 'vat_type' );
 
             $dom = $attributeParametersNode->ownerDocument;
@@ -280,6 +265,7 @@ class eZPriceType extends eZDataType
 
     function unserializeContentClassAttribute( $classAttribute, $attributeNode, $attributeParametersNode )
     {
+        /** @var DOMElement $vatNode */
         $vatNode = $attributeParametersNode->getElementsByTagName( 'vat-included' )->item( 0 );
         $vatIncluded = strtolower( $vatNode->getAttribute( 'is-set' ) ) == 'true';
         if ( $vatIncluded )
@@ -288,6 +274,7 @@ class eZPriceType extends eZDataType
             $vatIncluded = self::EXCLUDED_VAT;
 
         $classAttribute->setAttribute( self::INCLUDE_VAT_FIELD, $vatIncluded );
+        /** @var DOMElement $vatTypeNode */
         $vatTypeNode = $attributeParametersNode->getElementsByTagName( 'vat-type' )->item( 0 );
         $vatName = $vatTypeNode->getAttribute( 'name' );
         $vatPercentage = $vatTypeNode->getAttribute( 'percentage' );

--- a/kernel/classes/datatypes/ezproductcategory/ezproductcategorytype.php
+++ b/kernel/classes/datatypes/ezproductcategory/ezproductcategorytype.php
@@ -8,17 +8,18 @@
  * @package kernel
  */
 
-/*!
-  \class eZProductCategoryType ezproductcategorytype.php
-  \ingroup eZDatatype
-  \brief Stores product category.
-
-*/
-
+/**
+ * Stores an eZProductCategory object
+ *
+ * @package kernel
+ */
 class eZProductCategoryType extends eZDataType
 {
     const DATA_TYPE_STRING = "ezproductcategory";
 
+    /**
+     * Initializes the datatype
+     */
     function eZProductCategoryType()
     {
         $this->eZDataType( self::DATA_TYPE_STRING, ezpI18n::tr( 'kernel/classes/datatypes', "Product category", 'Datatype name' ),
@@ -26,9 +27,6 @@ class eZProductCategoryType extends eZDataType
                                   'object_serialize_map' => array( 'data_int' => 'value' ) ) );
     }
 
-   /*!
-     Sets the default value.
-    */
     function initializeObjectAttribute( $contentObjectAttribute, $currentVersion, $originalContentObjectAttribute )
     {
         if ( $currentVersion != false )
@@ -43,9 +41,6 @@ class eZProductCategoryType extends eZDataType
         }
     }
 
-    /*!
-      Validates the http post var.
-    */
     function validateObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         if ( !$contentObjectAttribute->validateIsRequired() )
@@ -64,9 +59,6 @@ class eZProductCategoryType extends eZDataType
         return eZInputValidator::STATE_INVALID;
     }
 
-    /*!
-     Fetches the http post var and stores it in the data instance.
-    */
     function fetchObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         if ( $http->hasPostVariable( $base . "_category_id_" . $contentObjectAttribute->attribute( "id" ) ))
@@ -84,9 +76,6 @@ class eZProductCategoryType extends eZDataType
         return true;
     }
 
-   /*!
-    Fetches the http post variable for collected information
-   */
     function fetchCollectionAttributeHTTPInput( $collection, $collectionAttribute, $http, $base, $contentObjectAttribute )
     {
         if ( $http->hasPostVariable( $base . "_category_id_" . $contentObjectAttribute->attribute( "id" ) ))
@@ -129,9 +118,10 @@ class eZProductCategoryType extends eZDataType
         return 'int';
     }
 
-    /*!
-     Returns the content.
-    */
+    /**
+     * @inheritdoc
+     * @return eZProductCategory
+     */
     function objectAttributeContent( $contentObjectAttribute )
     {
         $category = eZProductCategory::fetch( $contentObjectAttribute->attribute( 'data_int' ) );
@@ -153,7 +143,6 @@ class eZProductCategoryType extends eZDataType
         }
         return '';
     }
-
 
     function fromString( $contentObjectAttribute, $string )
     {
@@ -183,9 +172,6 @@ class eZProductCategoryType extends eZDataType
         return false;
     }
 
-    /*!
-     Returns the integer value.
-    */
     function title( $contentObjectAttribute, $name = null )
     {
         $categoryID = $contentObjectAttribute->attribute( "data_int" );

--- a/kernel/classes/datatypes/ezrangeoption/ezrangeoptiontype.php
+++ b/kernel/classes/datatypes/ezrangeoption/ezrangeoptiontype.php
@@ -8,21 +8,20 @@
  * @package kernel
  */
 
-/*!
-  \class eZRangeOptionType ezrangeoptiontype.php
-  \ingroup eZDatatype
-  \brief The class eZRangeOptionType does
-
-*/
+/**
+ * Stores a eZRangeOption object
+ *
+ * @package kernel
+ */
 class eZRangeOptionType extends eZDataType
 {
     const DEFAULT_NAME_VARIABLE = "_ezrangeoption_default_name_";
 
     const DATA_TYPE_STRING = "ezrangeoption";
 
-    /*!
-     Constructor
-    */
+    /**
+     * Initializes the datatype
+     */
     function eZRangeOptionType()
     {
         $this->eZDataType( self::DATA_TYPE_STRING, ezpI18n::tr( 'kernel/classes/datatypes', "Range option", 'Datatype name' ),
@@ -68,8 +67,6 @@ class eZRangeOptionType extends eZDataType
         {
             return eZInputValidator::STATE_ACCEPTED;
         }
-
-
     }
 
     function fetchObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
@@ -104,10 +101,15 @@ class eZRangeOptionType extends eZDataType
 
     function storeObjectAttribute( $contentObjectAttribute )
     {
+        /** @var eZRangeOption $option */
         $option = $contentObjectAttribute->content();
         $contentObjectAttribute->setAttribute( "data_text", $option->xmlString() );
     }
 
+    /**
+     * @inheritdoc
+     * @return eZRangeOption
+     */
     function objectAttributeContent( $contentObjectAttribute )
     {
         $option = new eZRangeOption( "" );
@@ -128,7 +130,6 @@ class eZRangeOptionType extends eZDataType
         return implode( '|', $optionArray );
     }
 
-
     function fromString( $contentObjectAttribute, $string )
     {
         if ( $string == '' )
@@ -143,16 +144,12 @@ class eZRangeOptionType extends eZDataType
         $option->StopValue = array_shift( $optionArray );
         $option->StepValue = array_shift( $optionArray );
 
-
         $contentObjectAttribute->setAttribute( "data_text", $option->xmlString() );
 
         return $option;
 
     }
-    /*!
-     Finds the option which has the ID that matches \a $optionID, if found it returns
-     an option structure.
-    */
+
     function productOptionInformation( $objectAttribute, $optionID, $productItem )
     {
         $option = $objectAttribute->attribute( 'content' );
@@ -186,13 +183,11 @@ class eZRangeOptionType extends eZDataType
         return true;
     }
 
-    /*!
-     Sets the default value.
-    */
     function initializeObjectAttribute( $contentObjectAttribute, $currentVersion, $originalContentObjectAttribute )
     {
         if ( $currentVersion == false )
         {
+            /** @var eZRangeOption $option */
             $option = $contentObjectAttribute->content();
             $contentClassAttribute = $contentObjectAttribute->contentClassAttribute();
             if ( !$option )

--- a/kernel/classes/datatypes/ezselection/ezselectiontype.php
+++ b/kernel/classes/datatypes/ezselection/ezselectiontype.php
@@ -8,42 +8,29 @@
  * @package kernel
  */
 
-/*!
-  \class   ezselectiontype ezselectiontype.php
-  \ingroup eZDatatype
-  \brief   Handles the single and multiple selections.
-  \date    Wednesday 23 July 2003 12:48:45 pm
-  \author  B�rd Farstad
-
-*/
-
+/**
+ * Handles the single and multiple selections.
+ *
+ * @package kernel
+ */
 class eZSelectionType extends eZDataType
 {
     const DATA_TYPE_STRING = "ezselection";
 
-    /*!
-      Constructor
-    */
+    /**
+     * Initializes the datatype
+     */
     function eZSelectionType()
     {
         $this->eZDataType( self::DATA_TYPE_STRING, ezpI18n::tr( 'kernel/classes/datatypes', "Selection", 'Datatype name' ),
                            array( 'serialize_supported' => true ) );
     }
 
-    /*!
-     Validates all variables given on content class level
-     \return eZInputValidator::STATE_ACCEPTED or eZInputValidator::STATE_INVALID if
-             the values are accepted or not
-    */
     function validateClassAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         return eZInputValidator::STATE_ACCEPTED;
     }
 
-    /*!
-     Fetches all variables inputed on content class level
-     \return true if fetching of class attributes are successfull, false if not
-    */
     function fetchClassAttributeHTTPInput( $http, $base, $classAttribute )
     {
         $attributeContent = $this->classAttributeContent( $classAttribute );
@@ -136,11 +123,7 @@ class eZSelectionType extends eZDataType
         }
         return true;
     }
-    /*!
-     Validates input on content object level
-     \return eZInputValidator::STATE_ACCEPTED or eZInputValidator::STATE_INVALID if
-             the values are accepted or not
-    */
+
     function validateObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         $classAttribute = $contentObjectAttribute->contentClassAttribute();
@@ -168,10 +151,6 @@ class eZSelectionType extends eZDataType
         return eZInputValidator::STATE_ACCEPTED;
     }
 
-    /*!
-     Fetches all variables from the object
-     \return true if fetching of class attributes are successfull, false if not
-    */
     function fetchObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         if ( $http->hasPostVariable( $base . '_ezselect_selected_array_' . $contentObjectAttribute->attribute( 'id' ) ) )
@@ -206,9 +185,6 @@ class eZSelectionType extends eZDataType
         }
     }
 
-   /*!
-    Fetches the http post variables for collected information
-   */
     function fetchCollectionAttributeHTTPInput( $collection, $collectionAttribute, $http, $base, $contentObjectAttribute )
     {
         if ( $http->hasPostVariable( $base . '_ezselect_selected_array_' . $contentObjectAttribute->attribute( 'id' ) ) )
@@ -221,9 +197,6 @@ class eZSelectionType extends eZDataType
         return false;
     }
 
-    /*!
-     Sets the default value.
-    */
     function initializeObjectAttribute( $contentObjectAttribute, $currentVersion, $originalContentObjectAttribute )
     {
         if ( $currentVersion != false )
@@ -234,18 +207,20 @@ class eZSelectionType extends eZDataType
         }
     }
 
-    /*!
-     Returns the selected options by id.
-    */
+    /**
+     * @inheritdoc
+     * @return array
+     */
     function objectAttributeContent( $contentObjectAttribute )
     {
         $idString = explode( '-', $contentObjectAttribute->attribute( 'data_text' ) );
         return $idString;
     }
 
-    /*!
-     Returns the content data for the given content class attribute.
-    */
+    /**
+     * @inheritdoc
+     * @return array
+     */
     function classAttributeContent( $classAttribute )
     {
         $dom = new DOMDocument( '1.0', 'utf-8' );
@@ -256,6 +231,7 @@ class eZSelectionType extends eZDataType
             $success = $dom->loadXML( $xmlString );
             if ( $success )
             {
+                /** @var DOMElement[] $options */
                 $options = $dom->getElementsByTagName( 'option' );
 
                 foreach ( $options as $optionNode )
@@ -276,9 +252,6 @@ class eZSelectionType extends eZDataType
         return $attrValue;
     }
 
-    /*!
-     Returns the meta data used for storing search indeces.
-    */
     function metaData( $contentObjectAttribute )
     {
         $selected = $this->objectAttributeContent( $contentObjectAttribute );
@@ -328,7 +301,6 @@ class eZSelectionType extends eZDataType
         return '';
     }
 
-
     function fromString( $contentObjectAttribute, $string )
     {
         if ( $string == '' )
@@ -351,9 +323,6 @@ class eZSelectionType extends eZDataType
         return true;
     }
 
-    /*!
-     Returns the value as it will be shown if this attribute is used in the object name pattern.
-    */
     function title( $contentObjectAttribute, $name = null )
     {
         $selected = $this->objectAttributeContent( $contentObjectAttribute );
@@ -388,9 +357,6 @@ class eZSelectionType extends eZDataType
         return 'string';
     }
 
-    /*!
-     \return true if the datatype can be indexed
-    */
     function isIndexable()
     {
         return true;

--- a/kernel/classes/datatypes/ezstring/ezstringtype.php
+++ b/kernel/classes/datatypes/ezstring/ezstringtype.php
@@ -8,21 +8,16 @@
  * @package kernel
  */
 
-/*!
-  \class eZStringType ezstringtype.php
-  \ingroup eZDatatype
-  \brief A content datatype which handles text lines
-
-  It provides the functionality to work as a text line and handles
-  class definition input, object definition input and object viewing.
-
-  It uses the spare field data_text in a content object attribute for storing
-  the attribute data.
-
-*/
-
-
-
+/**
+ * A content datatype which handles text lines
+ *
+ * It provides the functionality to work as a text line and handles
+ * class definition input, object definition input and object viewing.
+ *
+ * It uses the spare field data_text in a content object attribute for storing the attribute data.
+ *
+ * @package kernel
+ */
 class eZStringType extends eZDataType
 {
     const DATA_TYPE_STRING = 'ezstring';
@@ -31,9 +26,9 @@ class eZStringType extends eZDataType
     const DEFAULT_STRING_FIELD = "data_text1";
     const DEFAULT_STRING_VARIABLE = "_ezstring_default_value_";
 
-    /*!
-     Initializes with a string id and a description.
-    */
+    /**
+     * Initializes the datatype
+     */
     function eZStringType()
     {
         $this->eZDataType( self::DATA_TYPE_STRING, ezpI18n::tr( 'kernel/classes/datatypes', 'Text line', 'Datatype name' ),
@@ -42,9 +37,6 @@ class eZStringType extends eZDataType
         $this->MaxLenValidator = new eZIntegerValidator();
     }
 
-    /*!
-     Sets the default value.
-    */
     function initializeObjectAttribute( $contentObjectAttribute, $currentVersion, $originalContentObjectAttribute )
     {
         if ( $currentVersion != false )
@@ -66,9 +58,12 @@ class eZStringType extends eZDataType
         }
     }
 
-    /*
-     Private method, only for using inside this class.
-    */
+    /**
+     * @param string $data
+     * @param eZContentObjectAttribute $contentObjectAttribute
+     * @param eZContentClassAttribute $classAttribute
+     * @return int
+     */
     function validateStringHTTPInput( $data, $contentObjectAttribute, $classAttribute )
     {
         $maxLen = $classAttribute->attribute( self::MAX_LEN_FIELD );
@@ -83,7 +78,6 @@ class eZStringType extends eZDataType
         }
         return eZInputValidator::STATE_ACCEPTED;
     }
-
 
     function validateObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
@@ -143,9 +137,6 @@ class eZStringType extends eZDataType
             return eZInputValidator::STATE_INVALID;
     }
 
-    /*!
-     Fetches the http post var string input and stores it in the data instance.
-    */
     function fetchObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         if ( $http->hasPostVariable( $base . '_ezstring_data_text_' . $contentObjectAttribute->attribute( 'id' ) ) )
@@ -157,9 +148,6 @@ class eZStringType extends eZDataType
         return false;
     }
 
-    /*!
-     Fetches the http post variables for collected information
-    */
     function fetchCollectionAttributeHTTPInput( $collection, $collectionAttribute, $http, $base, $contentObjectAttribute )
     {
         if ( $http->hasPostVariable( $base . "_ezstring_data_text_" . $contentObjectAttribute->attribute( "id" ) ) )
@@ -171,25 +159,15 @@ class eZStringType extends eZDataType
         return false;
     }
 
-    /*!
-     Does nothing since it uses the data_text field in the content object attribute.
-     See fetchObjectAttributeHTTPInput for the actual storing.
-    */
     function storeObjectAttribute( $attribute )
     {
     }
 
-    /*!
-     Simple string insertion is supported.
-    */
     function isSimpleStringInsertionSupported()
     {
         return true;
     }
 
-    /*!
-     Inserts the string \a $string in the \c 'data_text' database field.
-    */
     function insertSimpleString( $object, $objectVersion, $objectLanguage,
                                  $objectAttribute, $string,
                                  &$result )
@@ -261,25 +239,20 @@ class eZStringType extends eZDataType
         return true;
     }
 
-    /*!
-     Returns the content.
-    */
+    /**
+     * @inheritdoc
+     * @return string
+     */
     function objectAttributeContent( $contentObjectAttribute )
     {
         return $contentObjectAttribute->attribute( 'data_text' );
     }
 
-    /*!
-     Returns the meta data used for storing search indeces.
-    */
     function metaData( $contentObjectAttribute )
     {
         return $contentObjectAttribute->attribute( 'data_text' );
     }
-    /*!
-     \return string representation of an contentobjectattribute data for simplified export
 
-    */
     function toString( $contentObjectAttribute )
     {
         return $contentObjectAttribute->attribute( 'data_text' );
@@ -290,10 +263,6 @@ class eZStringType extends eZDataType
         return $contentObjectAttribute->setAttribute( 'data_text', $string );
     }
 
-
-    /*!
-     Returns the content of the string for use as a title
-    */
     function title( $contentObjectAttribute, $name = null )
     {
         return $contentObjectAttribute->attribute( 'data_text' );
@@ -349,6 +318,10 @@ class eZStringType extends eZDataType
         $classAttribute->setAttribute( self::DEFAULT_STRING_FIELD, $defaultString );
     }
 
+    /**
+     * @inheritdoc
+     * @return eZDiffTextEngine
+     */
     function diff( $old, $new, $options = false )
     {
         $diff = new eZDiff();
@@ -378,8 +351,9 @@ class eZStringType extends eZDataType
         return array();
     }
 
-    /// \privatesection
-    /// The max len validator
+    /**
+     * @var eZIntegerValidator
+     */
     public $MaxLenValidator;
 }
 

--- a/kernel/classes/datatypes/ezsubtreesubscription/ezsubtreesubscriptiontype.php
+++ b/kernel/classes/datatypes/ezsubtreesubscription/ezsubtreesubscriptiontype.php
@@ -8,19 +8,18 @@
  * @package kernel
  */
 
-/*!
-  \class eZSubtreeSubscriptionType ezsubtreesubscriptiontype.php
-  \ingroup eZDatatype
-  \brief The class eZSubtreeSubscriptionType does
-
-*/
+/**
+ * Stores an ezsubtreesubscription object
+ *
+ * @package kernel
+ */
 class eZSubtreeSubscriptionType extends eZDataType
 {
     const DATA_TYPE_STRING = "ezsubtreesubscription";
 
-    /*!
-     Constructor
-    */
+    /**
+     * Initializes the datatype
+     */
     function eZSubtreeSubscriptionType()
     {
         $this->eZDataType(  self::DATA_TYPE_STRING, ezpI18n::tr( 'kernel/classes/datatypes', "Subtree subscription", 'Datatype name' ),
@@ -28,10 +27,6 @@ class eZSubtreeSubscriptionType extends eZDataType
                                    'object_serialize_map' => array( 'data_int' => 'value' ) ) );
     }
 
-
-    /*!
-     Store content
-    */
     function onPublish( $attribute, $contentObject, $publishedNodes )
     {
         $user = eZUser::currentUser();
@@ -71,9 +66,6 @@ class eZSubtreeSubscriptionType extends eZDataType
         return true;
     }
 
-    /*!
-     Fetches the http post var integer input and stores it in the data instance.
-    */
     function fetchObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         if ( $http->hasPostVariable( $base . "_data_subtreesubscription_" . $contentObjectAttribute->attribute( "id" ) ))
@@ -99,7 +91,6 @@ class eZSubtreeSubscriptionType extends eZDataType
     {
         return $contentObjectAttribute->attribute( 'data_int' );
     }
-
 
     function fromString( $contentObjectAttribute, $string )
     {

--- a/kernel/classes/datatypes/eztext/eztexttype.php
+++ b/kernel/classes/datatypes/eztext/eztexttype.php
@@ -8,19 +8,18 @@
  * @package kernel
  */
 
-/*!
-  \class eZTextType eztexttype.php
-  \ingroup eZDatatype
-  \brief Stores a text area value
-
-*/
-
+/**
+ * Stores a text area value
+ */
 class eZTextType extends eZDataType
 {
     const DATA_TYPE_STRING = "eztext";
     const COLS_FIELD = 'data_int1';
     const COLS_VARIABLE = '_eztext_cols_';
 
+    /**
+     * Initializes the datatype
+     */
     function eZTextType()
     {
         $this->eZDataType( self::DATA_TYPE_STRING, ezpI18n::tr( 'kernel/classes/datatypes', "Text block", 'Datatype name' ),
@@ -28,9 +27,6 @@ class eZTextType extends eZDataType
                                   'object_serialize_map' => array( 'data_text' => 'text' ) ) );
     }
 
-    /*!
-     Set class attribute value for template version
-    */
     function initializeClassAttribute( $classAttribute )
     {
         if ( $classAttribute->attribute( self::COLS_FIELD ) == null )
@@ -38,9 +34,6 @@ class eZTextType extends eZDataType
         $classAttribute->store();
     }
 
-    /*!
-     Sets the default value.
-    */
     function initializeObjectAttribute( $contentObjectAttribute, $currentVersion, $originalContentObjectAttribute )
     {
         if ( $currentVersion != false )
@@ -56,10 +49,6 @@ class eZTextType extends eZDataType
         }
     }
 
-    /*!
-     Validates the input and returns true if the input was
-     valid for this datatype.
-    */
     function validateObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         $classAttribute = $contentObjectAttribute->contentClassAttribute();
@@ -109,9 +98,6 @@ class eZTextType extends eZDataType
             return eZInputValidator::STATE_INVALID;
     }
 
-    /*!
-     Fetches the http post var string input and stores it in the data instance.
-    */
     function fetchObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         if ( $http->hasPostVariable( $base . "_data_text_" . $contentObjectAttribute->attribute( "id" ) ) )
@@ -123,9 +109,6 @@ class eZTextType extends eZDataType
         return false;
     }
 
-    /*!
-     Fetches the http post variables for collected information
-    */
     function fetchCollectionAttributeHTTPInput( $collection, $collectionAttribute, $http, $base, $contentObjectAttribute )
     {
         if ( $http->hasPostVariable( $base . "_data_text_" . $contentObjectAttribute->attribute( "id" ) ) )
@@ -137,24 +120,15 @@ class eZTextType extends eZDataType
         return false;
     }
 
-    /*!
-     Store the content.
-    */
     function storeObjectAttribute( $attribute )
     {
     }
 
-    /*!
-     Simple string insertion is supported.
-    */
     function isSimpleStringInsertionSupported()
     {
         return true;
     }
 
-    /*!
-     Inserts the string \a $string in the \c 'data_text' database field.
-    */
     function insertSimpleString( $object, $objectVersion, $objectLanguage,
                                  $objectAttribute, $string,
                                  &$result )
@@ -166,9 +140,10 @@ class eZTextType extends eZDataType
         return true;
     }
 
-    /*!
-     Returns the content.
-    */
+    /**
+     * @inheritdoc
+     * @return string
+     */
     function objectAttributeContent( $contentObjectAttribute )
     {
         return $contentObjectAttribute->attribute( "data_text" );
@@ -186,18 +161,11 @@ class eZTextType extends eZDataType
         return false;
     }
 
-    /*!
-     Returns the meta data used for storing search indeces.
-    */
     function metaData( $contentObjectAttribute )
     {
         return $contentObjectAttribute->attribute( "data_text" );
     }
 
-    /*!
-     \return string representation of an contentobjectattribute data for simplified export
-
-    */
     function toString( $contentObjectAttribute )
     {
         return $contentObjectAttribute->attribute( 'data_text' );
@@ -213,9 +181,6 @@ class eZTextType extends eZDataType
         return trim( $contentObjectAttribute->attribute( 'data_text' ) ) != '';
     }
 
-    /*!
-     Returns the text.
-    */
     function title( $data_instance, $name = null )
     {
         return $data_instance->attribute( "data_text" );

--- a/kernel/classes/datatypes/eztime/eztimetype.php
+++ b/kernel/classes/datatypes/eztime/eztimetype.php
@@ -8,13 +8,11 @@
  * @package kernel
  */
 
-/*!
-  \class eZTimeType eztimetype.php
-  \ingroup eZDatatype
-  \brief Stores a time value
-
-*/
-
+/**
+ * Stores an eZTime object
+ *
+ * @package kernel
+ */
 class eZTimeType extends eZDataType
 {
     const DATA_TYPE_STRING = "eztime";
@@ -23,15 +21,22 @@ class eZTimeType extends eZDataType
     const DEFAULT_EMTPY = 0;
     const DEFAULT_CURRENT_DATE = 1;
 
+    /**
+     * Initializes the datatype
+     */
     function eZTimeType()
     {
         $this->eZDataType( self::DATA_TYPE_STRING, ezpI18n::tr( 'kernel/classes/datatypes', "Time", 'Datatype name' ),
                            array( 'serialize_supported' => true ) );
     }
 
-    /*!
-     Private method only for use inside this class
-    */
+    /**
+     * @param int|string $hours
+     * @param int|string $minute
+     * @param int|string $second
+     * @param eZContentObjectAttribute $contentObjectAttribute
+     * @return int
+     */
     function validateTimeHTTPInput( $hours, $minute, $second, $contentObjectAttribute )
     {
         $state = eZDateTimeValidator::validateTime( $hours, $minute, $second );
@@ -148,9 +153,6 @@ class eZTimeType extends eZDataType
             return eZInputValidator::STATE_INVALID;
     }
 
-   /*!
-    Fetches the http post variables for collected information
-   */
     function fetchCollectionAttributeHTTPInput( $collection, $collectionAttribute, $http, $base, $contentObjectAttribute )
     {
         $classAttribute = $contentObjectAttribute->contentClassAttribute();
@@ -177,9 +179,10 @@ class eZTimeType extends eZDataType
         return false;
     }
 
-    /*!
-     Returns the content.
-    */
+    /**
+     * @inheritdoc
+     * @return array
+     */
     function objectAttributeContent( $contentObjectAttribute )
     {
         $stamp = $contentObjectAttribute->attribute( 'data_int' );
@@ -216,10 +219,6 @@ class eZTimeType extends eZDataType
         return 'int';
     }
 
-    /*!
-     \return string representation of an contentobjectattribute data for simplified export
-
-    */
     function toString( $contentObjectAttribute )
     {
         $time = $contentObjectAttribute->attribute( 'content' );
@@ -255,9 +254,6 @@ class eZTimeType extends eZDataType
         return true;
     }
 
-    /*!
-     Set class attribute value for template version
-    */
     function initializeClassAttribute( $classAttribute )
     {
         if ( $classAttribute->attribute( self::DEFAULT_FIELD ) == null )
@@ -265,9 +261,6 @@ class eZTimeType extends eZDataType
         $classAttribute->store();
     }
 
-    /*!
-     Sets the default value.
-    */
     function initializeObjectAttribute( $contentObjectAttribute, $currentVersion, $originalContentObjectAttribute )
     {
         if ( $currentVersion != false )
@@ -304,17 +297,11 @@ class eZTimeType extends eZDataType
         return false;
     }
 
-    /*!
-     Returns the meta data used for storing search indeces.
-    */
     function metaData( $contentObjectAttribute )
     {
         return (int)$contentObjectAttribute->attribute( 'data_int' );
     }
 
-    /*!
-     Returns the date.
-    */
     function title( $contentObjectAttribute, $name = null )
     {
         $timestamp = $contentObjectAttribute->attribute( 'data_int' );
@@ -359,6 +346,7 @@ class eZTimeType extends eZDataType
 
     function unserializeContentClassAttribute( $classAttribute, $attributeNode, $attributeParametersNode )
     {
+        /** @var DOMElement $defaultNode */
         $defaultNode = $attributeParametersNode->getElementsByTagName( 'default-value' )->item( 0 );
         $defaultValue = strtolower( $defaultNode->getAttribute( 'type' ) );
         switch ( $defaultValue )
@@ -380,12 +368,6 @@ class eZTimeType extends eZDataType
         }
     }
 
-    /*!
-     \param package
-     \param content attribute
-
-     \return a DOM representation of the content object attribute
-    */
     function serializeContentObjectAttribute( $package, $objectAttribute )
     {
         $node = $this->createContentObjectAttributeDOMNode( $objectAttribute );
@@ -402,11 +384,6 @@ class eZTimeType extends eZDataType
         return $node;
     }
 
-    /*!
-     \param package
-     \param contentobject attribute object
-     \param ezdomnode object
-    */
     function unserializeContentObjectAttribute( $package, $objectAttribute, $attributeNode )
     {
         $timeNode = $attributeNode->getElementsByTagName( 'time' )->item( 0 );

--- a/kernel/classes/datatypes/ezurl/ezurltype.php
+++ b/kernel/classes/datatypes/ezurl/ezurltype.php
@@ -8,21 +8,16 @@
  * @package kernel
  */
 
-/*!
-  \class eZURLType ezurltype.php
-  \ingroup eZDatatype
-  \brief A content datatype which handles urls
-
-*/
-
-
+/**
+ * A content datatype which handles urls
+ */
 class eZURLType extends eZDataType
 {
     const DATA_TYPE_STRING = 'ezurl';
 
-    /*!
-     Initializes with a url id and a description.
-    */
+    /**
+     * Initializes the datatype
+     */
     function eZURLType()
     {
         $this->eZDataType( self::DATA_TYPE_STRING, ezpI18n::tr( 'kernel/classes/datatypes', 'URL', 'Datatype name' ),
@@ -30,9 +25,6 @@ class eZURLType extends eZDataType
         $this->MaxLenValidator = new eZIntegerValidator();
     }
 
-    /*!
-     Sets the default value.
-    */
     function initializeObjectAttribute( $contentObjectAttribute, $currentVersion, $originalContentObjectAttribute )
     {
         if ( $currentVersion != false )
@@ -56,10 +48,6 @@ class eZURLType extends eZDataType
         }
     }
 
-    /*!
-     Validates the input and returns true if the input was
-     valid for this datatype.
-    */
     function validateObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         if ( $http->hasPostVariable( $base . "_ezurl_url_" . $contentObjectAttribute->attribute( "id" ) )  and
@@ -116,9 +104,6 @@ class eZURLType extends eZDataType
         $db->commit();
     }
 
-    /*!
-     Fetches the http post var url input and stores it in the data instance.
-    */
     function fetchObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         if ( $http->hasPostVariable( $base . '_ezurl_url_' . $contentObjectAttribute->attribute( 'id' ) ) and
@@ -136,9 +121,6 @@ class eZURLType extends eZDataType
         return false;
     }
 
-    /*!
-      Makes some post-store operations. Called by framework after store of eZContentObjectAttribute object.
-    */
     function postStore( $objectAttribute )
     {
         // Update url-object link
@@ -158,9 +140,12 @@ class eZURLType extends eZDataType
         }
     }
 
-    /*!
-      Store the URL in the URL database and store the reference to it.
-    */
+    /**
+     * Stores the URL in the URL database and store the reference to it.
+     *
+     * @param eZContentObjectAttribute $attribute
+     * @return void
+     */
     function storeObjectAttribute( $attribute )
     {
         $urlValue = $attribute->content();
@@ -178,7 +163,6 @@ class eZURLType extends eZDataType
         {
             $attribute->setAttribute( 'data_int', 0 );
         }
-
     }
 
     function storeClassAttribute( $attribute, $version )
@@ -194,9 +178,10 @@ class eZURLType extends eZDataType
         return eZInputValidator::STATE_ACCEPTED;
     }
 
-    /*!
-     Returns the content.
-    */
+    /**
+     * @inheritdoc
+     * @return string|bool
+     */
     function objectAttributeContent( $contentObjectAttribute )
     {
         if ( !$contentObjectAttribute->attribute( 'data_int' ) )
@@ -222,17 +207,11 @@ class eZURLType extends eZDataType
         return false;
     }
 
-    /*!
-     Returns the meta data used for storing search indeces.
-    */
     function metaData( $contentObjectAttribute )
     {
         return $contentObjectAttribute->attribute( 'data_text' );
     }
 
-    /*!
-     Returns the content of the url for use as a title
-    */
     function title( $contentObjectAttribute, $name = null )
     {
         return  $contentObjectAttribute->attribute( 'data_text' );
@@ -258,7 +237,6 @@ class eZURLType extends eZDataType
         }
         return $exportData;
     }
-
 
     function fromString( $contentObjectAttribute, $string )
     {
@@ -293,12 +271,6 @@ class eZURLType extends eZDataType
         }
     }
 
-    /*!
-     \param package
-     \param content attribute
-
-     \return a DOM representation of the content object attribute
-    */
     function serializeContentObjectAttribute( $package, $objectAttribute )
     {
         $node = $this->createContentObjectAttributeDOMNode( $objectAttribute );
@@ -328,11 +300,6 @@ class eZURLType extends eZDataType
         return $node;
     }
 
-    /*!
-     \param package
-     \param contentobject attribute object
-     \param domnode object
-    */
     function unserializeContentObjectAttribute( $package, $objectAttribute, $attributeNode )
     {
         $urlNode = $attributeNode->getElementsByTagName( 'url' )->item( 0 );

--- a/kernel/classes/datatypes/ezuser/ezusertype.php
+++ b/kernel/classes/datatypes/ezuser/ezusertype.php
@@ -8,17 +8,18 @@
  * @package kernel
  */
 
-/*!
-  \class eZUserType ezusertype.php
-  \brief The class eZUserType handles user accounts and association with content objects
-  \ingroup eZDatatype
-
-*/
-
+/**
+ * The class eZUserType handles user accounts and association with content objects
+ *
+ * @package kernel
+ */
 class eZUserType extends eZDataType
 {
     const DATA_TYPE_STRING = "ezuser";
 
+    /**
+     * Initializes the datatype
+     */
     function eZUserType( )
     {
         $this->eZDataType( self::DATA_TYPE_STRING, ezpI18n::tr( 'kernel/classes/datatypes', "User account", 'Datatype name' ),
@@ -26,9 +27,6 @@ class eZUserType extends eZDataType
                                   'serialize_supported' => true ) );
     }
 
-    /*!
-     Delete stored object attribute
-    */
     function deleteStoredObjectAttribute( $contentObjectAttribute, $version = null )
     {
         $db = eZDB::instance();
@@ -45,10 +43,6 @@ class eZUserType extends eZDataType
         }
     }
 
-    /*!
-     Validates the input and returns true if the input was
-     valid for this datatype.
-    */
     function validateObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         if ( $http->hasPostVariable( $base . "_data_user_login_" . $contentObjectAttribute->attribute( "id" ) ) &&
@@ -173,9 +167,6 @@ class eZUserType extends eZDataType
         return eZInputValidator::STATE_ACCEPTED;
     }
 
-    /*!
-     Fetches the http post var integer input and stores it in the data instance.
-    */
     function fetchObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         if ( $http->hasPostVariable( $base . "_data_user_login_" . $contentObjectAttribute->attribute( "id" ) ) )
@@ -247,9 +238,6 @@ class eZUserType extends eZDataType
         $contentObjectAttribute->setContent( $user );
     }
 
-    /*!
-     Returns the object title.
-    */
     function title( $contentObjectAttribute, $name = "login" )
     {
         $user = $this->objectAttributeContent( $contentObjectAttribute );
@@ -268,9 +256,10 @@ class eZUserType extends eZDataType
         return false;
     }
 
-    /*!
-     Returns the user object.
-    */
+    /**
+     * @inheritdoc
+     * @return eZUser
+     */
     function objectAttributeContent( $contentObjectAttribute )
     {
         $userID = $contentObjectAttribute->attribute( "contentobject_id" );
@@ -288,11 +277,15 @@ class eZUserType extends eZDataType
         return true;
     }
 
-    /*!
-     We can only remove the user attribute if:
-     - The current user, anonymous user and administrator user is not using this class
-     - There are more classes with the ezuser datatype
-    */
+    /**
+     * We can only remove the user attribute if:
+     * - The current user, anonymous user and administrator user is not using this class
+     * - There are more classes with the ezuser datatype
+     *
+     * @param eZContentClassAttribute $contentClassAttribute
+     * @param bool $includeAll
+     * @return array|bool
+     */
     function classAttributeRemovableInformation( $contentClassAttribute, $includeAll = true )
     {
         $result  = array( 'text' => ezpI18n::tr( 'kernel/classes/datatypes',
@@ -352,9 +345,6 @@ class eZUserType extends eZDataType
         return $result;
     }
 
-    /*!
-     Returns the meta data used for storing search indeces.
-    */
     function metaData( $contentObjectAttribute )
     {
         $metaString = "";
@@ -396,7 +386,8 @@ class eZUserType extends eZDataType
      * </code>
      *
      * @uses eZUser::isEnabled()
-     * @param object $contentObjectAttribute A contentobject attribute of type user_account.
+     *
+     * @param eZContentObjectAttribute $contentObjectAttribute A contentobject attribute of type user_account.
      * @return string The string definition.
      */
     function toString( $contentObjectAttribute )
@@ -406,6 +397,7 @@ class eZUserType extends eZDataType
         {
             $GLOBALS['eZUserObject_' . $userID] = eZUser::fetch( $userID );
         }
+        /** @var eZUser $user */
         $user = $GLOBALS['eZUserObject_' . $userID];
 
         $userInfo = array(
@@ -431,9 +423,9 @@ class eZUserType extends eZDataType
      * foo|foo@ez.no|1234|md5_password|0
      * </code>
      *
-     * @param object $contentObjectAttribute A contentobject attribute of type user_account.
+     * @param eZContentObjectAttribute $contentObjectAttribute A contentobject attribute of type user_account.
      * @param string $string The string as described in the example.
-     * @return object The newly created eZUser object
+     * @return eZUser The newly created eZUser object
      */
     function fromString( $contentObjectAttribute, $string )
     {
@@ -479,12 +471,6 @@ class eZUserType extends eZDataType
         return $user;
     }
 
-    /*!
-     \param package
-     \param content attribute
-
-     \return a DOM representation of the content object attribute
-    */
     function serializeContentObjectAttribute( $package, $objectAttribute )
     {
         $node = $this->createContentObjectAttributeDOMNode( $objectAttribute );
@@ -504,11 +490,6 @@ class eZUserType extends eZDataType
         return $node;
     }
 
-    /*!
-     \param package
-     \param contentobject attribute object
-     \param ezdomnode object
-    */
     function unserializeContentObjectAttribute( $package, $objectAttribute, $attributeNode )
     {
         $userNode = $attributeNode->getElementsByTagName( 'account' )->item( 0 );

--- a/kernel/classes/datatypes/ezxmltext/ezxmltexttype.php
+++ b/kernel/classes/datatypes/ezxmltext/ezxmltexttype.php
@@ -8,77 +8,75 @@
  * @package kernel
  */
 
-/*!
-  \class eZXMLTextType ezxmltexttype
-  \ingroup eZDatatype
-  \brief The class eZXMLTextType haneles XML formatted datatypes
-
-The formatted datatypes store the data in XML. A typical example of this is shown below:
-\code
-<?xml version="1.0" encoding="utf-8" ?>
-<section xmlns:image="http://ez.no/namespaces/ezpublish3/image/"
-         xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/">
-<header>This is a level one header</header>
-<paragraph>
-This is a <emphasize>block</emphasize> of text.
-</paragraph>
-  <section>
-  <header class="foo">This is a level two header has classification "foo"</header>
-  <paragraph>
-  This is the second paragraph with <bold class="foo">bold text which has classification "foo"</bold>
-  </paragraph>
-  <header>This is a level two header</header>
-  <paragraph>
-    <line>Paragraph can have table</line>
-    <table class="foo" border='1' width='100%'>
-      <tr>
-        <th class="foo"><paragraph>table header of class "foo"</paragraph></th>
-        <td xhtml:width="66" xhtml:colspan="2" xhtml:rowspan="2">
-          <paragraph>table cell text</paragraph>
-        </td>
-      </tr>
-    </table>
-  </paragraph>
-  <paragraph>
-    <line>This is the first line with <anchor name="first">anchor</anchor></line>
-    <line>This is the second line with <link target="_self" id="1">link</link></line>
-    <line>This is the third line.</line>
-  </paragraph>
-  <paragraph>
-    <ul class="foo">
-       <li>List item 1</li>
-       <li>List item 2</li>
-    </ul>
-  </paragraph>
-  <paragraph>
-    <ol>
-       <li>Ordered list item 1</li>
-       <li>ordered list item 2</li>
-    </ol>
-  </paragraph>
-  <paragraph>
-    <line>Paragraph can have both inline custom tag <custom name="myInlineTag">text</custom> and block custom tag</line>
-    <custom name="myBlockTag">
-      <paragraph>
-        block text
-      </paragraph>
-    </custom>
-  </paragraph>
-  <paragraph>
-    Paragraph can have image object with link <object id="55" size="large" align="center" image:ezurl_id="4" />
-  </paragraph>
-  <paragraph>
-    You can use literal tag to write html code if you have done some changes in override system.
-    <literal class="html">&lt;font color=&quot;red&quot;&gt;red text&lt;/font&gt;</literal>
-  </paragraph>
-  <header>This is a level two header</header>
-  </section>
-</section>
-
-\endcode
-
-*/
-
+/**
+ * The class eZXMLTextType haneles XML formatted datatypes
+ *
+ * The formatted datatypes store the data in XML. A typical example of this is shown below:
+ *
+ * <code>
+ * <?xml version="1.0" encoding="utf-8" ?>
+ * <section xmlns:image="http://ez.no/namespaces/ezpublish3/image/"
+ *     xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/">
+ * <header>This is a level one header</header>
+ *     <paragraph>
+ *         This is a <emphasize>block</emphasize> of text.
+ *     </paragraph>
+ *     <section>
+ *         <header class="foo">This is a level two header has classification "foo"</header>
+ *         <paragraph>
+ *             This is the second paragraph with <bold class="foo">bold text which has classification "foo"</bold>
+ *         </paragraph>
+ *         <header>This is a level two header</header>
+ *         <paragraph>
+ *             <line>Paragraph can have table</line>
+ *             <table class="foo" border='1' width='100%'>
+ *                 <tr>
+ *                     <th class="foo"><paragraph>table header of class "foo"</paragraph></th>
+ *                     <td xhtml:width="66" xhtml:colspan="2" xhtml:rowspan="2">
+ *                         <paragraph>table cell text</paragraph>
+ *                     </td>
+ *                 </tr>
+ *             </table>
+ *         </paragraph>
+ *         <paragraph>
+ *             <line>This is the first line with <anchor name="first">anchor</anchor></line>
+ *             <line>This is the second line with <link target="_self" id="1">link</link></line>
+ *             <line>This is the third line.</line>
+ *         </paragraph>
+ *         <paragraph>
+ *             <ul class="foo">
+ *                 <li>List item 1</li>
+ *                 <li>List item 2</li>
+ *             </ul>
+ *         </paragraph>
+ *         <paragraph>
+ *             <ol>
+ *                 <li>Ordered list item 1</li>
+ *                 <li>ordered list item 2</li>
+ *             </ol>
+ *         </paragraph>
+ *         <paragraph>
+ *             <line>Paragraph can have both inline custom tag <custom name="myInlineTag">text</custom> and block custom tag</line>
+ *             <custom name="myBlockTag">
+ *                 <paragraph>
+ *                     block text
+ *                 </paragraph>
+ *             </custom>
+ *         </paragraph>
+ *         <paragraph>
+ *             Paragraph can have image object with link <object id="55" size="large" align="center" image:ezurl_id="4" />
+ *         </paragraph>
+ *         <paragraph>
+ *             You can use literal tag to write html code if you have done some changes in override system.
+ *             <literal class="html">&lt;font color=&quot;red&quot;&gt;red text&lt;/font&gt;</literal>
+ *         </paragraph>
+ *         <header>This is a level two header</header>
+ *     </section>
+ * </section>
+ * </code>
+ *
+ * @package kernel
+ */
 class eZXMLTextType extends eZDataType
 {
     const DATA_TYPE_STRING = "ezxmltext";
@@ -95,15 +93,15 @@ class eZXMLTextType extends eZDataType
     // timestamp is less than this it needs to be upgraded until it is correct.
     const VERSION_TIMESTAMP = 1045487555; // AS 21-09-2007: should be the same as VERSION_30_TIMESTAMP
 
+    /**
+     * Initializes the datatype
+     */
     function eZXMLTextType()
     {
         $this->eZDataType( self::DATA_TYPE_STRING, ezpI18n::tr( 'kernel/classes/datatypes', "XML block", 'Datatype name' ),
                            array( 'serialize_supported' => true ) );
     }
 
-    /*!
-     Set class attribute value for template version
-    */
     function initializeClassAttribute( $classAttribute )
     {
         if ( $classAttribute->attribute( self::COLS_FIELD ) == null )
@@ -111,9 +109,6 @@ class eZXMLTextType extends eZDataType
         $classAttribute->store();
     }
 
-    /*!
-     Sets the default value.
-    */
     function initializeObjectAttribute( $contentObjectAttribute, $currentVersion, $originalContentObjectAttribute )
     {
         if ( $currentVersion != false )
@@ -142,7 +137,7 @@ class eZXMLTextType extends eZDataType
      *
      * @param eZContentObjectAttribute $contentObjectAttribute
      * @param eZContentObject $object
-     * @param array $publishedNodes
+     * @param eZContentObjectTreeNode[] $publishedNodes
      * @return boolean
      */
     function onPublish( $contentObjectAttribute, $object, $publishedNodes )
@@ -177,6 +172,7 @@ class eZXMLTextType extends eZDataType
             $urlIdArray = array();
             foreach ( $dom->getElementsByTagName( 'link' ) as $link )
             {
+                /** @var DOMElement $link */
                 // We are looking for external 'http://'-style links, not the internal
                 // object or node links.
                 if ( $link->hasAttribute( 'url_id' ) )
@@ -218,6 +214,7 @@ class eZXMLTextType extends eZDataType
 
     /**
      * Extracts ids of embedded/linked objects in an eZXML DOMNodeList
+     *
      * @param DOMNodeList $domNodeList
      * @return array
      */
@@ -226,6 +223,7 @@ class eZXMLTextType extends eZDataType
         $embeddedObjectIdArray = array();
         foreach( $domNodeList as $embed )
         {
+            /** @var DOMElement $embed */
             if ( $embed->hasAttribute( 'object_id' ) )
             {
                 $embeddedObjectIdArray[] = $embed->getAttribute( 'object_id' );
@@ -241,10 +239,6 @@ class eZXMLTextType extends eZDataType
         return $embeddedObjectIdArray;
     }
 
-    /*!
-     Validates the input and returns true if the input was
-     valid for this datatype.
-    */
     function validateObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         /// Get object for input validation
@@ -274,9 +268,6 @@ class eZXMLTextType extends eZDataType
         return false;
     }
 
-    /*!
-     Fetches the http post var string input and stores it in the data instance.
-    */
     function fetchObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         // To do: Data should be saved here.
@@ -286,18 +277,10 @@ class eZXMLTextType extends eZDataType
         return true;
     }
 
-    /*!
-     Initializes the object attribute with some data after object attribute is already stored.
-     It means that for initial version you allready have an attribute_id and you can store data somewhere using this id.
-     \note Default implementation does nothing.
-    */
     function postInitializeObjectAttribute( $objectAttribute, $currentVersion, $originalContentObjectAttribute )
     {
     }
 
-    /*!
-     Store the content.
-    */
     function storeObjectAttribute( $attribute )
     {
         $attribute->setAttribute( 'data_int', self::VERSION_TIMESTAMP );
@@ -353,11 +336,14 @@ class eZXMLTextType extends eZDataType
         return $inputHandler->informationTemplateSuffix( $contentobjectAttribute );
     }
 
-    /*!
-     \return the RAW XML text from the attribute \a $contentobjectAttribute.
-             If the XML format is older than the current one it will
-             be upgraded to the current before being returned.
-    */
+    /**
+     * Returns the RAW XML text from the attribute $contentobjectAttribute.
+     *
+     * If the XML format is older than the current one it will be upgraded to the current before being returned.
+     *
+     * @param eZContentObjectAttribute $contentObjectAttribute
+     * @return string
+     */
     static function rawXMLText( $contentObjectAttribute )
     {
         $text = $contentObjectAttribute->attribute( 'data_text' );
@@ -372,29 +358,29 @@ class eZXMLTextType extends eZDataType
         return $text;
     }
 
-    /*!
-     \static
-     \return the XML structure in \a $domDocument as text.
-             It will take of care of the necessary charset conversions
-             for content storage.
-    */
+    /**
+     * Returns the XML structure in$domDocument as text.
+     *
+     * It will take of care of the necessary charset conversions for content storage.
+     *
+     * @param DOMDocument $domDocument
+     * @return string
+     */
     static function domString( $domDocument )
     {
         return $domDocument->saveXML();
     }
 
-    /*!
-     Returns the content.
-    */
+    /**
+     * @inheritdoc
+     * @return eZXMLText
+     */
     function objectAttributeContent( $contentObjectAttribute )
     {
         $xmlText = new eZXMLText( eZXMLTextType::rawXMLText( $contentObjectAttribute ), $contentObjectAttribute );
         return $xmlText;
     }
 
-    /*!
-     Returns the meta data used for storing search indeces.
-    */
     function metaData( $contentObjectAttribute )
     {
         $metaData = "";
@@ -445,10 +431,6 @@ class eZXMLTextType extends eZDataType
         return $retString;
     }
 
-    /*!
-     \return string representation of an contentobjectattribute data for simplified export
-
-    */
     function toString( $contentObjectAttribute )
     {
         return $contentObjectAttribute->attribute( 'data_text' );
@@ -459,10 +441,6 @@ class eZXMLTextType extends eZDataType
         return $contentObjectAttribute->setAttribute( 'data_text', $string );
     }
 
-
-    /*!
-     Returns the text.
-    */
     function title( $contentObjectAttribute, $value = null )
     {
         $text = eZXMLTextType::rawXMLText( $contentObjectAttribute );
@@ -515,9 +493,11 @@ class eZXMLTextType extends eZDataType
         return false;
     }
 
-    /*!
-     Makes sure content/datatype/.../ezxmltags/... are included.
-    */
+    /**
+     * Makes sure content/datatype/.../ezxmltags/... are included.
+     *
+     * @return array
+     */
     function templateList()
     {
         return array( array( 'regexp',
@@ -546,9 +526,6 @@ class eZXMLTextType extends eZDataType
         $inputHandler->customObjectAttributeHTTPAction( $http, $action, $contentObjectAttribute );
     }
 
-    /*!
-     \return a DOM representation of the content object attribute
-    */
     function serializeContentObjectAttribute( $package, $objectAttribute )
     {
 
@@ -586,6 +563,7 @@ class eZXMLTextType extends eZDataType
     {
         foreach ( $nodeList as $node )
         {
+            /** @var DOMElement $node */
             $linkID = $node->getAttribute( 'url_id' );
             $isObject = ( $node->localName == 'object' );
             $objectID = $isObject ? $node->getAttribute( 'id' ) : $node->getAttribute( 'object_id' );
@@ -631,10 +609,6 @@ class eZXMLTextType extends eZDataType
         }
     }
 
-    /*!
-     \param contentobject attribute object
-     \param domnode object
-    */
     function unserializeContentObjectAttribute( $package, $objectAttribute, $attributeNode )
     {
         /* For all links found in the XML, do the following:
@@ -648,6 +622,7 @@ class eZXMLTextType extends eZDataType
 
         foreach ( $linkNodes as $linkNode )
         {
+            /** @var DOMElement $linkNode */
             $href = $linkNode->getAttribute( 'href' );
             if ( !$href )
                 continue;
@@ -711,6 +686,13 @@ class eZXMLTextType extends eZDataType
         }
     }
 
+    /**
+     * Return true if the node list has been modified
+     *
+     * @param DOMNodeList $nodeList
+     * @param eZContentObjectAttribute $objectAttribute
+     * @return bool
+     */
     static function transformRemoteLinksToLinks( DOMNodeList $nodeList, $objectAttribute )
     {
         $modified = false;
@@ -718,6 +700,7 @@ class eZXMLTextType extends eZDataType
         $contentObject = $objectAttribute->attribute( 'object' );
         foreach ( $nodeList as $node )
         {
+            /** @var DOMElement $node*/
             $objectRemoteID = $node->getAttribute( 'object_remote_id' );
             $nodeRemoteID = $node->getAttribute( 'node_remote_id' );
             if ( $objectRemoteID )
@@ -769,9 +752,12 @@ class eZXMLTextType extends eZDataType
         return $modified;
     }
 
-    /*!
-     Delete stored object attribute, this will clean up the ezurls and ezobjectlinks
-    */
+    /**
+     * Deletes stored object attribute, this will clean up the ezurls and ezobjectlinks
+     *
+     * @param eZContentObjectAttribute $contentObjectAttribute
+     * @param int $version
+     */
     function deleteStoredObjectAttribute( $contentObjectAttribute, $version = null )
     {
         $contentObjectAttributeID = $contentObjectAttribute->attribute( "id" );
@@ -820,6 +806,10 @@ class eZXMLTextType extends eZDataType
         }
     }
 
+    /**
+     * @inheritdoc
+     * @return eZDiffXMLTextEngine
+     */
     function diff( $old, $new, $options = false )
     {
         $diff = new eZDiff();

--- a/kernel/classes/ezdatatype.php
+++ b/kernel/classes/ezdatatype.php
@@ -8,46 +8,45 @@
  * @package kernel
  */
 
-/*! \defgroup eZDataType Content datatypes */
-
-/*!
-  \class eZDataType ezdatatype.php
-  \ingroup eZKernel
-  \brief Base class for content datatypes
-
-  Defines both the interface for datatypes as well as functions
-  for registering, quering and fetching datatypes.
-
-  Each new datatype will inherit this class and define some functions
-  as well as three templates. A datatype has three roles, it handles
-  definition of content class attributes, editing of a content object
-  attribute and viewing of a content object attribute. The content class
-  attribute definition part is optional while object attribute edit and
-  view must be implemented for the datatype to be usable.
-
-  If the datatype handles class attribute definition it must define one
-  or more of these functions: storeClassAttribute, validateClassAttributeHTTPInput,
-  fixupClassAttributeHTTPInput, fetchClassAttributeHTTPInput. See each function
-  for more details. The class attribute definition usually defines the
-  default data and/or the validation rules for an object attribute.
-
-  Object attribute editing must define these functions: storeObjectAttribute,
-  validateObjectAttributeHTTPInput, fixupObjectAttributeHTTPInput,
-  fetchObjectAttributeHTTPInput, initializeObjectAttribute. If the attribute
-  wants to have a custom action it must implement the customObjectAttributeHTTPAction
-  function. See each function for more details.
-
-  Each datatype initializes itself with a datatype string id (ezstring, ezinteger)
-  and a descriptive name. The datatype string id must be unique for the whole
-  system and should have a prefix, for instance we in eZ Systems use ez as our prefix.
-*/
-
+/**
+ * Base class for content datatypes
+ *
+ * Defines both the interface for datatypes as well as functions
+ * for registering, quering and fetching datatypes.
+ * Each new datatype will inherit this class and define some functions
+ * as well as three templates. A datatype has three roles, it handles
+ * definition of content class attributes, editing of a content object
+ * attribute and viewing of a content object attribute. The content class
+ * attribute definition part is optional while object attribute edit and
+ * view must be implemented for the datatype to be usable.
+ *
+ * If the datatype handles class attribute definition it must define one
+ * or more of these functions: storeClassAttribute, validateClassAttributeHTTPInput,
+ * fixupClassAttributeHTTPInput, fetchClassAttributeHTTPInput. See each function
+ * for more details. The class attribute definition usually defines the
+ * default data and/or the validation rules for an object attribute.
+ *
+ * Object attribute editing must define these functions: storeObjectAttribute,
+ * validateObjectAttributeHTTPInput, fixupObjectAttributeHTTPInput,
+ * fetchObjectAttributeHTTPInput, initializeObjectAttribute. If the attribute
+ * wants to have a custom action it must implement the customObjectAttributeHTTPAction
+ * function. See each function for more details.
+ *
+ * Each datatype initializes itself with a datatype string id (ezstring, ezinteger)
+ * and a descriptive name. The datatype string id must be unique for the whole
+ * system and should have a prefix, for instance we in eZ Systems use ez as our prefix.
+ *
+ * @package kernel
+ */
 class eZDataType
 {
-    /*!
-     Initializes the datatype with the string id \a $dataTypeString and
-     the name \a $name.
-    */
+    /**
+     * Initializes the datatype with the string id $dataTypeString and the name $name.
+     *
+     * @param $dataTypeString
+     * @param $name
+     * @param array $properties
+     */
     function eZDataType( $dataTypeString, $name, $properties = array() )
     {
         $this->DataTypeString = $dataTypeString;
@@ -74,64 +73,87 @@ class eZDataType
                                                  'object_serialize_map' => $objectSerializeMap );
     }
 
-    /*!
-     \return the template name to use for viewing the attribute.
-     \note Default is to return the datatype string which is OK
-           for most datatypes, if you want dynamic templates
-           reimplement this function and return a template name.
-     \note The returned template name does not include the .tpl extension.
-     \sa editTemplate, informationTemplate
-    */
+    /**
+     * Returns the template name to use for viewing the attribute.
+     *
+     * Default is to return the datatype string which is OK for most datatypes, if you want dynamic templates
+     * reimplement this function and return a template name.
+     *
+     * The returned template name does not include the .tpl extension.
+     *
+     * @see editTemplate()
+     * @see informationTemplate()
+     *
+     * @param eZContentObjectAttribute $contentobjectAttribute
+     * @return string
+     */
     function viewTemplate( $contentobjectAttribute )
     {
         return $this->DataTypeString;
     }
 
-    /*!
-     \return the template name to use for editing the attribute.
-     \note Default is to return the datatype string which is OK
-           for most datatypes, if you want dynamic templates
-           reimplement this function and return a template name.
-     \note The returned template name does not include the .tpl extension.
-     \sa viewTemplate, informationTemplate
-    */
+    /**
+     * Returns the template name to use for editing the attribute.
+     *
+     * Default is to return the datatype string which is OK for most datatypes, if you want dynamic templates
+     * reimplement this function and return a template name.
+     *
+     * The returned template name does not include the .tpl extension.
+     *
+     * @see viewTemplate()
+     * @see informationTemplate()
+     *
+     * @param eZContentObjectAttribute $contentobjectAttribute
+     * @return mixed
+     */
     function editTemplate( $contentobjectAttribute )
     {
         return $this->DataTypeString;
     }
 
-    /*!
-     \return the template name to use for information collection for the attribute.
-     \note Default is to return the datatype string which is OK
-           for most datatypes, if you want dynamic templates
-           reimplement this function and return a template name.
-     \note The returned template name does not include the .tpl extension.
-     \sa viewTemplate, editTemplate
-    */
+    /**
+     * Returns the template name to use for information collection for the attribute.
+     *
+     * Default is to return the datatype string which is OK for most datatypes, if you want dynamic templates
+     * reimplement this function and return a template name.
+     *
+     * The returned template name does not include the .tpl extension.
+     *
+     * @see viewTemplate()
+     * @see editTemplate()
+     *
+     * @param eZContentObjectAttribute $contentobjectAttribute
+     * @return mixed
+     */
     function informationTemplate( $contentobjectAttribute )
     {
         return $this->DataTypeString;
     }
 
-    /*!
-     \return the template name to use for result view of an information collection attribute.
-     \note Default is to return the datatype string which is OK
-           for most datatypes, if you want dynamic templates
-           reimplement this function and return a template name.
-     \note The returned template name does not include the .tpl extension.
-     \note \a $collectionAttribute can in some cases be a eZContentObjectAttribute, so any
-           datatype that overrides this must be able to handle both types.
-    */
+    /**
+     * Returns the template name to use for result view of an information collection attribute.
+     *
+     * Default is to return the datatype string which is OK for most datatypes, if you want dynamic templates
+     * reimplement this function and return a template name.
+     *
+     * The returned template name does not include the .tpl extension.
+     *
+     * @param eZContentObjectAttribute $collectionAttribute
+     * @return string
+     */
     function resultTemplate( &$collectionAttribute )
     {
         return $this->DataTypeString;
     }
 
-    /*!
-     \static
-     Crates a datatype instance of the datatype string id \a $dataTypeString.
-     \note It only creates one instance for each datatype.
-    */
+    /**
+     * Creates a datatype instance of the datatype string id $dataTypeString.
+     *
+     * It only creates one instance for each datatype.
+     *
+     * @param $dataTypeString
+     * @return eZDataType
+     */
     static function create( $dataTypeString )
     {
         $def = null;
@@ -155,11 +177,13 @@ class eZDataType
         return null;
     }
 
-    /*!
-     \static
-     \return a list of datatypes which has been registered.
-     \note This will instantiate all datatypes.
-    */
+    /**
+     * Returns a list of datatypes which has been registered.
+     *
+     * This will instantiate all datatypes.
+     *
+     * @return eZDataType[]
+     */
     static function registeredDataTypes()
     {
         $types = isset( $GLOBALS["eZDataTypes"] ) ? $GLOBALS["eZDataTypes"] : null;
@@ -180,12 +204,13 @@ class eZDataType
         return null;
     }
 
-    /*!
-     \static
-     Registers the datatype with string id \a $dataTypeString and
-     class name \a $className. The class name is used for instantiating
-     the class and should be in lowercase letters.
-    */
+    /**
+     * Registers the datatype with string id $dataTypeString and class name $className.
+     * The class name is used for instantiating the class and should be in lowercase letters.
+     *
+     * @param string $dataTypeString
+     * @param string $className
+     */
     static function register( $dataTypeString, $className )
     {
         $types =& $GLOBALS["eZDataTypes"];
@@ -194,9 +219,11 @@ class eZDataType
         $types[$dataTypeString] = $className;
     }
 
-    /*!
-     \return the data type identification string.
-    */
+    /**
+     * Returns the data type identification string.
+     *
+     * @return string
+     */
     function isA()
     {
         return $this->Attributes["information"]["string"];
@@ -212,25 +239,33 @@ class eZDataType
         return $this->Attributes['properties']['translation_allowed'];
     }
 
-    /*!
-     \return the attributes for this datatype.
-    */
+    /**
+     * Returns the attributes for this datatype.
+     *
+     * @return array
+     */
     function attributes()
     {
         return array_keys( $this->Attributes );
     }
 
-    /*!
-     \return true if the attribute \a $attr exists in this object.
-    */
+    /**
+     * Returns true if the attribute \a $attr exists in this object.
+     *
+     * @param string $attr
+     * @return bool
+     */
     function hasAttribute( $attr )
     {
         return isset( $this->Attributes[$attr] );
     }
 
-    /*!
-     \return the data for the attribute \a $attr or null if it does not exist.
-    */
+    /**
+     * Returns the data for the attribute \a $attr or null if it does not exist.
+     *
+     * @param string $attr
+     * @return mixed
+     */
     function attribute( $attr )
     {
         if ( isset( $this->Attributes[$attr] ) )
@@ -243,57 +278,61 @@ class eZDataType
         return $attributeData;
     }
 
-    /*!
-     \return \c true if the datatype support insertion of HTTP files or \c false (default) otherwise.
-
-     \sa insertHTTPFile()
-    */
+    /**
+     * Returns true if the datatype support insertion of HTTP files or false (default) otherwise.
+     *
+     * @see insertHTTPFile()
+     * @return bool
+     */
     function isHTTPFileInsertionSupported()
     {
         return false;
     }
 
-    /*!
-     \return \c true if the datatype support insertion of files or \c false (default) otherwise.
-
-     \sa insertRegularFile()
-    */
+    /**
+     * Returns true if the datatype support insertion of files or false (default) otherwise.
+     *
+     * @see insertRegularFile()
+     *
+     * @return bool
+     */
     function isRegularFileInsertionSupported()
     {
         return false;
     }
 
-    /*!
-     \return \c true if the datatype support insertion of simple strings or \c false (default) otherwise.
-
-     \sa insertSimpleString()
-    */
+    /**
+     * Returns true if the datatype support insertion of simple strings or false (default) otherwise.
+     *
+     * @see insertSimpleString()
+     *
+     * @return bool
+     */
     function isSimpleStringInsertionSupported()
     {
         return false;
     }
 
-    /*!
-     \virtual
-     Inserts the HTTP file \a $httpFile to the content object attribute \a $objectAttribute.
-
-     \param $object The contentobject in which the attribute is contained
-     \param $objectVersion The current version of the object it is being worked on
-     \param $objectLanguage The current language being worked on
-     \param $objectAttribute The attribute which will get the file
-     \param $httpFile Object of type eZHTTPFile which contains information on the uploaded file
-     \param $mimeData MIME-Type information on the file, can be used to figure out a storage name
-     \param[out] $result Array which will be filled with information on the process, it will contain:
-                 - errors - Array with error elements, each element is an array with \c 'description' containing the text
-                 - require_storage - \c true if the attribute must be stored after this call, or \c false if not required at all
-
-     \return \c true if the file was stored correctly in the attribute or \c false if something failed.
-     \note The datatype will return \c null (the default) if does not support HTTP files.
-     \note \a $result will not be defined if the return value is \c null
-     \note The \a $httpFile must not be stored prior to calling this, the datatype will handle this internally
-
-     \sa isHTTPFileInsertionSupported()
-    */
+    /**
+     * Inserts the HTTP file $httpFile to the content object attribute $objectAttribute.
+     *
+     * The datatype will return null (the default) if does not support HTTP files.
+     * $result will not be defined if the return value is null
+     * The $httpFile must not be stored prior to calling this, the datatype will handle this internally
+     *
+     * @see isHTTPFileInsertionSupported()
+     *
+     * @param eZContentObject $object The contentobject in which the attribute is contained
+     * @param int $objectVersion The current version of the object it is being worked on
+     * @param string $objectLanguage The current language being worked on
+     * @param eZContentObjectAttribute $objectAttribute The attribute which will get the file
+     * @param eZHTTPFile $httpFile Contains information on the uploaded file
+     * @param array $mimeData MIME-Type information on the file, can be used to figure out a storage name
+     * @param array $result Array which will be filled with information on the process, it will contain the following fields:
+     *                      "errors": Array with error elements, each element is an array with \c 'description' containing the text
+     *                      "require_storage": true if the attribute must be stored after this call, or false if not required at all
+     * @return bool|null true if the file was stored correctly in the attribute, false if something failed, null (default) if the datatype does not support HTTP files.
+     */
     function insertHTTPFile( $object, $objectVersion, $objectLanguage,
                              $objectAttribute, $httpFile, $mimeData,
                              &$result )
@@ -302,25 +341,21 @@ class eZDataType
         return null;
     }
 
-    /*!
-     \virtual
-     Inserts the file named \a $filePath to the content object attribute \a $objectAttribute.
-
-     \param $object The contentobject in which the attribute is contained
-     \param $objectVersion The current version of the object it is being worked on
-     \param $objectLanguage The current language being worked on
-     \param $objectAttribute The attribute which will get the file
-     \param $filePath Full path including the filename
-     \param[out] $result Array which will be filled with information on the process, it will contain:
-                 - errors - Array with error elements, each element is an array with \c 'description' containing the text
-                 - require_storage - \c true if the attribute must be stored after this call, or \c false if not required at all
-
-     \return \c true if the file was stored correctly in the attribute or \c false if something failed.
-     \note The datatype will return \c null (the default) if does not support HTTP files.
-     \note \a $result will not be defined if the return value is \c null
-
-     \sa isRegularFileInsertionSupported()
-    */
+    /**
+     * Inserts the file named \a $filePath to the content object attribute \a $objectAttribute.
+     *
+     * $result will not be defined if the return value is null
+     *
+     * @param eZContentObject $object The contentobject in which the attribute is contained
+     * @param int $objectVersion The current version of the object it is being worked on
+     * @param string $objectLanguage The current language being worked on
+     * @param eZContentObjectAttribute $objectAttribute The attribute which will get the file
+     * @param string $filePath Full path including the filename
+     * @param array $result Array which will be filled with information on the process, it will contain the following fields:
+     *                      "errors": Array with error elements, each element is an array with \c 'description' containing the text
+     *                      "require_storage": true if the attribute must be stored after this call, or false if not required at all
+     * @return bool|null true if the file was stored correctly in the attribute, false if something failed, null (default) if the datatype does not support files.
+     */
     function insertRegularFile( $object, $objectVersion, $objectLanguage,
                                 $objectAttribute, $filePath,
                                 &$result )
@@ -329,25 +364,23 @@ class eZDataType
         return null;
     }
 
-    /*!
-     \virtual
-     Inserts the string \a $string to the content object attribute \a $objectAttribute.
-
-     \param $object The contentobject in which the attribute is contained
-     \param $objectVersion The current version of the object it is being worked on
-     \param $objectLanguage The current language being worked on
-     \param $objectAttribute The attribute which will get the file
-     \param $filePath Full path including the filename
-     \param[out] $result Array which will be filled with information on the process, it will contain:
-                 - errors - Array with error elements, each element is an array with \c 'description' containing the text
-                 - require_storage - \c true if the attribute must be stored after this call, or \c false if not required at all
-
-     \return \c true if the file was stored correctly in the attribute or \c false if something failed.
-     \note The datatype will return \c null (the default) if does not support HTTP files.
-     \note \a $result will not be defined if the return value is \c null
-
-     \sa isSimpleStringInsertionSupported()
-    */
+    /**
+     * Inserts the string $string to the content object attribute $objectAttribute.
+     *
+     * The datatype will return null (the default) if does not support string insertion
+     *
+     * @see isSimpleStringInsertionSupported()
+     *
+     * @param eZContentObject $object The contentobject in which the attribute is contained
+     * @param int $objectVersion The current version of the object it is being worked on
+     * @param string $objectLanguage The current language being worked on
+     * @param eZContentObjectAttribute $objectAttribute The attribute which will get the file
+     * @param string $string The string to insert
+     * @param array $result Array which will be filled with information on the process, it will contain the following fields:
+     *                      "errors": Array with error elements, each element is an array with \c 'description' containing the text
+     *                      "require_storage": true if the attribute must be stored after this call, or false if not required at all
+     * @return bool|null true if the file was stored correctly in the attribute, false if something failed, null (default) if the datatype does not support string insertion.
+     */
     function insertSimpleString( $object, $objectVersion, $objectLanguage,
                                  $objectAttribute, $string,
                                  &$result )
@@ -356,119 +389,97 @@ class eZDataType
         return null;
     }
 
-    /*!
-     \virtual
-     Checks if the datatype supports returning file information.
-
-     \param $object The contentobject in which the attribute is contained
-     \param $objectVersion The current version of the object it is being worked on
-     \param $objectLanguage The current language being worked on
-     \param $objectAttribute The attribute which stored the file
-
-     \return \c true if file information is supported or \c false if it doesn't.
-    */
+    /**
+     * Checks if the datatype supports returning file information.
+     *
+     * @param eZContentObject $object The contentobject in which the attribute is contained
+     * @param int $objectVersion The current version of the object it is being worked on
+     * @param string $objectLanguage The current language being worked on
+     * @param eZContentObjectAttribute $objectAttribute The attribute which stores the file
+     * @return bool true if file information is supported or false if it doesn't.
+     */
     function hasStoredFileInformation( $object, $objectVersion, $objectLanguage,
                                        $objectAttribute )
     {
         return false;
     }
 
-    /*!
-     \virtual
-     This function is called when someone tries to download the file.
-
-     \param $object The contentobject in which the attribute is contained
-     \param $objectVersion The current version of the object it is being worked on
-     \param $objectLanguage The current language being worked on
-     \param $objectAttribute The attribute which stored the file
-
-     \return \c true if any action has been don or \c false if hasn't.
-    */
+    /**
+     * This function is called when someone tries to download the file.
+     *
+     * @param eZContentObject $object The contentobject in which the attribute is contained
+     * @param int $objectVersion The current version of the object it is being worked on
+     * @param string $objectLanguage The current language being worked on
+     * @param eZContentObjectAttribute $objectAttribute The attribute which stores the file
+     * @return bool true if any action has been don or false if hasn't.
+     */
     function handleDownload( $object, $objectVersion, $objectLanguage,
                              $objectAttribute )
     {
         return false;
     }
 
-    /*!
-     \virtual
-     Returns file information for the filed stored by the attribute.
-
-     \param $object The contentobject in which the attribute is contained
-     \param $objectVersion The current version of the object it is being worked on
-     \param $objectLanguage The current language being worked on
-     \param $objectAttribute The attribute which stored the file
-
-     \return An array structure with information or \c false (default) if no
-             information could be found.
-             The structure must contain:
-             - filepath - The full path to the file
-
-             The structure can contain:
-             - filename - The name of the file, if not supplied it will
-                           be figured out from the filepath
-             - filesize - The size of the file, if not supplied it will
-                           be figured out from the filepath
-             - mime_type - The MIME type for the file, if not supplied it will
-                           be figured out from the filepath
-    */
+    /**
+     * Returns file information for the filed stored by the attribute.
+     *
+     * @param eZContentObject $object The contentobject in which the attribute is contained
+     * @param int $objectVersion The current version of the object it is being worked on
+     * @param string $objectLanguage The current language being worked on
+     * @param eZContentObjectAttribute $objectAttribute The attribute which stored the file
+     * @return array|bool   An array structure with information or false (default) if no information could be found.
+     *                      The structure must contain:
+     *                      - filepath - The full path to the file
+     *                      The structure can contain:
+     *                      - filename - The name of the file, if not supplied it will be figured out from the filepath
+     *                      - filesize - The size of the file, if not supplied it will be figured out from the filepath
+     *                      - mime_type - The MIME type for the file, if not supplied it will be figured out from the filepath
+     */
     function storedFileInformation( $object, $objectVersion, $objectLanguage,
                                     $objectAttribute )
     {
         return false;
     }
 
-    /*!
-     Fetches the product option information for option with ID \a $optionID and returns this information.
-     This will be called from the basket when a new product with an option is added, it is then up to the
-     specific datatype to return proper data. It will also be used to recalcuate prices.
-
-     \param $objectAttribute The attribute that the datatype controls.
-     \param $optionID The ID of the option which information should be returned from.
-     \param $productItem The product item object which contains the option, is available for reading only.
-     \return An array structure which contains:
-             - id - The unique ID of the selected option, this must be unique in the attribute and will later on
-                    be used to recalculate prices.
-             - name - The name of the option list
-             - value - The display string of the selected option
-             - additional_price - A value which is added to the total product price, set to 0 or \c false if no price is used.
-             If the option could not be found it should return \c false, if not supported it should return \c null.
-     \sa handleProductOption
-    */
+    /**
+     * Fetches the product option information for option with ID $optionID and returns this information.
+     *
+     * This will be called from the basket when a new product with an option is added, it is then up to the
+     * specific datatype to return proper data. It will also be used to recalcuate prices.
+     *
+     * @see handleProductOption()
+     *
+     * @param eZContentObjectAttribute $objectAttribute The attribute that the datatype controls.
+     * @param string $optionID The ID of the option which information should be returned from.
+     * @param mixed $productItem The product item object which contains the option, is available for reading only.
+     * @return array|bool|null  false, If the option could not be found, null if the data type doesn't support product options, otherwise
+     *                          An array structure which contains:
+     *                          - id - The unique ID of the selected option, this must be unique in the attribute and will later on be used to recalculate prices.
+     *                          - name - The name of the option list
+     *                          - value - The display string of the selected option
+     *                          - additional_price - A value which is added to the total product price, set to 0 or \c false if no price is used.
+     */
     function productOptionInformation( $objectAttribute, $optionID, $productItem )
     {
         eZDebug::writeWarning( "The datatype " . get_class( $this ) . " for attribute ID " . $objectAttribute->attribute( 'id' ) . " does not support product options", __METHOD__ );
         return null;
     }
 
-    /*!
-      \virtual
-      Will return information on how the datatype should be represented in
-      the various display modes when used by an object.
-
-      If this method is reimplemented the implementor must call this method
-      with the new info array as second parameter.
-
-      \param $objectAttribute The content object attribute to return info for.
-      \param $mergeInfo A structure that must match the returned array, or \c false to ignore.
-                        Any entries here will override the default.
-      \return An array structure which contains:
-              - \c edit
-                - \c grouped_input - If \c true then the datatype has lots of input elements
-                                     that should be grouped. (e.g. in a fieldset)
-                                     EditSettings/GroupedInput in datatype.ini is used to
-                                     automatically determine this field
-                .
-              - \c view
-              - \c collection
-                - \c grouped_input - If \c true then the datatype has lots of input elements
-                                     that should be grouped. (e.g. in a fieldset)
-                                     CollectionSettings/GroupedInput in datatype.ini is used to
-                                     automatically determine this field and will override
-                                     the default and datatype setting if used.
-                .
-              - \c result
-    */
+    /**
+     * Will return information on how the datatype should be represented in the various display modes when used by an object.
+     *
+     * If this method is reimplemented the implementor must call this method with the new info array as second parameter.
+     *
+     * @param eZContentObjectAttribute $objectAttribute The content object attribute to return info for.
+     * @param array|bool $mergeInfo A structure that must match the returned array, or false to ignore. Any entries here will override the default.
+     * @return array    An array structure which contains:
+     *                  - edit
+     *                  -- grouped_input -  If true then the datatype has lots of input elements that should be grouped. (e.g. in a fieldset)
+     *                                      EditSettings/GroupedInput in datatype.ini is used to automatically determine this field
+     *                  - view
+     *                  - collection
+     *                  -- grouped_input -  If true then the datatype has lots of input elements that should be grouped. (e.g. in a fieldset)
+     *                                      CollectionSettings/GroupedInput in datatype.ini is used to automatically determine this field and will override the default and datatype setting if used.
+     */
     function objectDisplayInformation( $objectAttribute, $mergeInfo = false )
     {
         $datatype = $objectAttribute->attribute( 'data_type_string' );
@@ -515,27 +526,19 @@ class eZDataType
         return $info;
     }
 
-    /*!
-      \virtual
-      Will return information on how the datatype should be represented in
-      the various display modes when used by a class.
-
-      If this method is reimplemented the implementor must call this method
-      with the new info array as second parameter.
-
-      \param $classAttribute The content class attribute to return info for.
-      \param $mergeInfo A structure that must match the returned array, or \c false to ignore.
-                        Any entries here will override the default.
-      \return An array structure which contains:
-              - \c edit
-                - \c grouped_input - If \c true then the datatype has lots of input elements
-                                     that should be grouped. (e.g. in a fieldset)
-                                     ClassEditSettings/GroupedInput in datatype.ini is used to
-                                     automatically determine this field and will override
-                                     the default and datatype setting if used.
-                .
-              - \c view
-    */
+    /**
+     * Will return information on how the datatype should be represented in the various display modes when used by a class.
+     *
+     * If this method is reimplemented the implementor must call this method with the new info array as second parameter.
+     *
+     * @param eZContentClassAttribute $classAttribute The content class attribute to return info for.
+     * @param array|bool $mergeInfo A structure that must match the returned array, or \c false to ignore. Any entries here will override the default.
+     * @return array    An array structure which contains:
+     *                  - edit
+     *                  -- grouped_input -  If true then the datatype has lots of input elements that should be grouped. (e.g. in a fieldset)
+     *                                      ClassEditSettings/GroupedInput in datatype.ini is used to automatically determine this field and will override the default and datatype setting if used.
+     *                  - view
+     */
     function classDisplayInformation( $classAttribute, $mergeInfo = false )
     {
         $datatype = $classAttribute->attribute( 'data_type_string' );
@@ -571,109 +574,132 @@ class eZDataType
         return $info;
     }
 
-    /*!
-     Returns the content data for the given content object attribute.
-    */
+    /**
+     * Returns the content data for the given content object attribute.
+     *
+     * @param eZContentObjectAttribute $objectAttribute
+     * @return mixed
+     */
     function objectAttributeContent( $objectAttribute )
     {
         $retValue = '';
         return $retValue;
     }
 
-    /*!
-     \return \c true if the datatype finds any content in the attribute \a $contentObjectAttribute.
-    */
+    /**
+     * Returns true if the datatype finds any content in the attribute $contentObjectAttribute.
+     *
+     * @param eZContentObjectAttribute $contentObjectAttribute
+     * @return bool
+     */
     function hasObjectAttributeContent( $contentObjectAttribute )
     {
         return false;
     }
 
-    /*!
-     Returns the content data for the given content class attribute.
-    */
+    /**
+     * Returns the content data for the given content class attribute.
+     *
+     * @param eZContentClassAttribute $classAttribute
+     * @return string
+     */
     function classAttributeContent( $classAttribute )
     {
         return '';
     }
 
-    /*!
-     Stores the datatype data to the database which is related to the
-     object attribute.
-     \return True if the value was stored correctly.
-     \note The method is entirely up to the datatype, for instance
-           it could reuse the available types in the the attribute or
-           store in a separate object.
-     \sa fetchObjectAttributeHTTPInput
-    */
+    /**
+     * Stores the datatype data to the database which is related to the object attribute.
+     *
+     * The method is entirely up to the datatype, for instance it could reuse the available types
+     * in the the attribute or store in a separate object.
+     *
+     * Might be transaction unsafe.
+     *
+     * @param eZContentObjectAttribute $objectAttribute
+     * @return bool|void True if the value was stored correctly.
+     */
     function storeObjectAttribute( $objectAttribute )
     {
     }
 
-    /*!
-     Performs necessary actions with attribute data after object is published,
-     it means that you have access to published nodes.
-     \return True if the value was stored correctly.
-     \note The method is entirely up to the datatype, for instance
-           it could reuse the available types in the the attribute or
-           store in a separate object.
-
-     \note Might be transaction unsafe.
-    */
+    /**
+     * Performs necessary actions with attribute data after object is published, it means that you have access to published nodes.
+     *
+     * The method is entirely up to the datatype, for instance it could reuse the available types
+     * in the the attribute or store in a separate object.
+     *
+     * Might be transaction unsafe.
+     *
+     * @param eZContentObjectAttribute $contentObjectAttribute
+     * @param eZContentObject $contentObject
+     * @param eZContentObjectTreeNode[] $publishedNodes
+     * @return bool|void True if the value was stored correctly.
+     */
     function onPublish( $contentObjectAttribute, $contentObject, $publishedNodes )
     {
     }
 
-    /*!
-     Similar to the storeClassAttribute but is called before the
-     attribute itself is stored and can be used to set values in the
-     class attribute.
-     \return True if the value was stored correctly.
-     \sa fetchClassAttributeHTTPInput
-    */
+    /**
+     * Similar to the storeClassAttribute but is called before the attribute itself is stored and
+     * can be used to set values in the class attribute.
+     *
+     * @see storeClassAttribute()
+     *
+     * @param eZContentClassAttribute $classAttribute
+     * @param int $version
+     * @return bool|void True if the value was stored correctly.
+     */
     function preStoreClassAttribute( $classAttribute, $version )
     {
     }
 
-    /*!
-     Stores the datatype data to the database which is related to the
-     class attribute. The \a $version parameter determines which version
-     is currently being stored, 0 is the real version while 1 is the
-     temporary version.
-     \return True if the value was stored correctly.
-     \note The method is entirely up to the datatype, for instance
-           it could reuse the available types in the the attribute or
-           store in a separate object.
-     \note This function is called after the attribute data has been stored.
-           If you need to alter attribute data use preStoreClassAttribute instead.
-     \sa fetchClassAttributeHTTPInput
-    */
+    /**
+     * Stores the datatype data to the database which is related to the
+     * class attribute. The \a $version parameter determines which version
+     * is currently being stored, 0 is the real version while 1 is the temporary version.
+     *
+     * The method is entirely up to the datatype, for instance it could reuse the available types
+     * in the the attribute or store in a separate object.
+     *
+     * This function is called after the attribute data has been stored.
+     * If you need to alter attribute data use preStoreClassAttribute instead.
+     *
+     * @param eZContentClassAttribute $classAttribute
+     * @param int $version
+     * @return bool|void True if the value was stored correctly.
+     */
     function storeClassAttribute( $classAttribute, $version )
     {
     }
 
 
     /**
-     * @note Transaction unsafe. If you call several transaction unsafe methods you must enclose
-     *       the calls within a db transaction; thus within db->begin and db->commit.
+     * Transaction unsafe. If you call several transaction unsafe methods you must enclose
+     * the calls within a db transaction; thus within db->begin and db->commit.
      *
      * @param eZContentClassAttribute $classAttribute Content class attribute of the datatype
+     * @return bool|void
      */
     function storeDefinedClassAttribute( $classAttribute )
     {
     }
 
     /**
-     * @note Transaction unsafe. If you call several transaction unsafe methods you must enclose
-     *       the calls within a db transaction; thus within db->begin and db->commit.
+     * Transaction unsafe. If you call several transaction unsafe methods you must enclose
+     * the calls within a db transaction; thus within db->begin and db->commit.
+     *
      * @param eZContentClassAttribute $classAttribute Content class attribute of the datatype
+     * @return bool|void
      */
     function storeModifiedClassAttribute( $classAttribute )
     {
     }
 
     /**
-     * @note Transaction unsafe. If you call several transaction unsafe methods you must enclose
-     *       the calls within a db transaction; thus within db->begin and db->commit.
+     * Transaction unsafe. If you call several transaction unsafe methods you must enclose
+     * the calls within a db transaction; thus within db->begin and db->commit.
+     *
      * @param eZContentClassAttribute $classAttribute Content class attribute of the datatype
      * @param int $version Version of the attribute to be stored
      */
@@ -711,6 +737,7 @@ class eZDataType
      * Hook function which is called before an content class attribute is stored
      *
      * @see eZContentClassAttribute::storeVersioned()
+     *
      * @param eZContentClassAttribute $classAttribute Content class attribute of the datatype
      * @param int $version Version of the attribute to be stored
      */
@@ -728,49 +755,72 @@ class eZDataType
         }
     }
 
-    /*!
-     Validates the input for a class attribute and returns a validation
-     state as defined in eZInputValidator.
-     \note Default implementation does nothing and returns accepted.
-    */
+    /**
+     * Validates the input for a class attribute and returns a validation state as defined in eZInputValidator.
+     *
+     * Default implementation does nothing and returns accepted.
+     *
+     * @param eZHTTPTool $http
+     * @param string $base
+     * @param eZContentClassAttribute $classAttribute
+     * @return int
+     */
     function validateClassAttributeHTTPInput( $http, $base, $classAttribute )
     {
         return eZInputValidator::STATE_ACCEPTED;
     }
 
-    /*!
-     Tries to do a fixup on the input text so that it's acceptable as
-     class attribute input.
-     \note Default implementation does nothing and returns accepted.
-    */
+    /**
+     * Tries to do a fixup on the input text so that it's acceptable as class attribute input.
+     *
+     * Default implementation does nothing and returns accepted.
+     *
+     * @param eZHTTPTool $http
+     * @param string $base
+     * @param eZContentClassAttribute $classAttribute
+     * @return int
+     */
     function fixupClassAttributeHTTPInput( $http, $base, $classAttribute )
     {
         return eZInputValidator::STATE_ACCEPTED;
     }
 
-    /*!
-     Fetches the HTTP input for the content class attribute.
-     \note Default implementation does nothing.
-    */
+    /**
+     * Fetches the HTTP input for the content class attribute.
+     *
+     * Default implementation does nothing.
+     *
+     * @param eZHTTPTool $http
+     * @param string $base
+     * @param eZContentClassAttribute $classAttribute
+     */
     function fetchClassAttributeHTTPInput( $http, $base, $classAttribute )
     {
     }
 
-    /*!
-     Executes a custom action for a class attribute which was defined on the web page.
-     \note Default implementation does nothing.
-    */
+    /**
+     * Executes a custom action for a class attribute which was defined on the web page.
+     *
+     * Default implementation does nothing.
+     *
+     * @param eZHTTPTool $http
+     * @param string $action
+     * @param eZContentClassAttribute $classAttribute
+     */
     function customClassAttributeHTTPAction( $http, $action, $classAttribute )
     {
     }
 
-    /*!
-     Matches the action against the action name \a $actionName
-     and extracts the value from the action puts it into \a $value.
-     \return \c true if the action matched and a value was found,
-             \c false otherwise.
-     \node If no match is made or no value found the \a $value parameter is not modified.
-    */
+    /**
+     * Matches the action against the action name $actionName and extracts the value from the action puts it into $value.
+     *
+     * If no match is made or no value found the $value parameter is not modified.
+     *
+     * @param string $action
+     * @param string $actionName
+     * @param string $value
+     * @return bool true if the action matched and a value was found, false otherwise.
+     */
     function fetchActionValue( $action, $actionName, &$value )
     {
         if ( preg_match( "#^" . $actionName . "_(.+)$#", $action, $matches ) )
@@ -781,158 +831,232 @@ class eZDataType
         return false;
     }
 
-    /*!
-     Validates the input for an object attribute and returns a validation
-     state as defined in eZInputValidator.
-     \note Default implementation does nothing and returns accepted.
-    */
+    /**
+     * Validates the input for an object attribute and returns a validation state as defined in eZInputValidator.
+     *
+     * Default implementation does nothing and returns accepted.
+     *
+     * @param eZHTTPTool $http
+     * @param string $base
+     * @param eZContentObjectAttribute $objectAttribute
+     * @return int
+     */
     function validateObjectAttributeHTTPInput( $http, $base, $objectAttribute )
     {
         return eZInputValidator::STATE_ACCEPTED;
     }
 
-    /*!
-     Tries to do a fixup on the input text so that it's acceptable as
-     object attribute input.
-     \note Default implementation does nothing.
-    */
+    /**
+     * Tries to do a fixup on the input text so that it's acceptable as object attribute input.
+     *
+     * Default implementation does nothing.
+     *
+     * @param eZHTTPTool $http
+     * @param string $base
+     * @param eZContentObjectAttribute $objectAttribute
+     */
     function fixupObjectAttributeHTTPInput( $http, $base, $objectAttribute )
     {
     }
 
-    /*!
-     Fetches the HTTP input for the content object attribute.
-     \note Default implementation does nothing.
-    */
+    /**
+     * Fetches the HTTP input for the content object attribute.
+     *
+     * Default implementation does nothing.
+     *
+     * @param eZHTTPTool $http
+     * @param string $base
+     * @param eZContentObjectAttribute $objectAttribute
+     */
     function fetchObjectAttributeHTTPInput( $http, $base, $objectAttribute )
     {
     }
 
-    /*!
-     Validates the input for an object attribute and returns a validation
-     state as defined in eZInputValidator.
-     \note Default implementation does nothing and returns accepted.
-    */
+    /**
+     * Validates the input for an object attribute and returns a validation state as defined in eZInputValidator.
+     *
+     * Default implementation does nothing and returns accepted.
+     *
+     * @param eZHTTPTool $http
+     * @param string $base
+     * @param eZContentObjectAttribute $objectAttribute
+     * @return int
+     */
     function validateCollectionAttributeHTTPInput( $http, $base, $objectAttribute )
     {
         return eZInputValidator::STATE_ACCEPTED;
     }
 
-    /*!
-     Tries to do a fixup on the input text so that it's acceptable as
-     object attribute input.
-     \note Default implementation does nothing.
-    */
+    /**
+     * Tries to do a fixup on the input text so that it's acceptable as object attribute input.
+     *
+     * Default implementation does nothing.
+     *
+     * @param eZHTTPTool $http
+     * @param string $base
+     * @param eZContentObjectAttribute $objectAttribute
+     */
     function fixupCollectionAttributeHTTPInput( $http, $base, $objectAttribute )
     {
     }
 
-    /*!
-     Fetches the HTTP collected information for the content object attribute.
-     \note Default implementation does nothing.
-
-     \return true if variable was successfully fetched.
-    */
+    /**
+     * Fetches the HTTP collected information for the content object attribute.
+     *
+     * Default implementation does nothing.
+     *
+     * @param mixed $collection
+     * @param eZContentObjectAttribute $collectionAttribute
+     * @param eZHTTPTool $http
+     * @param string $base
+     * @param eZContentObjectAttribute $objectAttribute
+     * @return void|bool true if variable was successfully fetched.
+     */
     function fetchCollectionAttributeHTTPInput( $collection, $collectionAttribute, $http, $base, $objectAttribute )
     {
     }
 
-    /*!
-     Executes a custom action for an object attribute which was defined on the web page.
-     \note Default implementation does nothing.
-    */
+    /**
+     * Executes a custom action for an object attribute which was defined on the web page.
+     *
+     * Default implementation does nothing.
+     *
+     * @param eZHTTPTool $http
+     * @param string $action
+     * @param eZContentObjectAttribute $objectAttribute
+     * @param array $parameters
+     */
     function customObjectAttributeHTTPAction( $http, $action, $objectAttribute, $parameters )
     {
     }
 
-    /*!
-     Takes care of custom action handling, this means checking if a custom action request
-     must be sent to a contentobject attribute. This function is only useful for
-     datatypes that must do custom action handling for sub objects and attributes.
-     \note Default implementation does nothing.
-    */
+    /**
+     * Takes care of custom action handling, this means checking if a custom action request
+     * must be sent to a contentobject attribute. This function is only useful for
+     * datatypes that must do custom action handling for sub objects and attributes.
+     *
+     * Default implementation does nothing.
+     *
+     * @param eZHTTPTool $http
+     * @param string $attributeDataBaseName
+     * @param array $customActionAttributeArray
+     * @param array $customActionParameters
+     */
     function handleCustomObjectHTTPActions( $http, $attributeDataBaseName,
                                             $customActionAttributeArray, $customActionParameters )
     {
     }
 
-    /*!
-     Initializes the class attribute with some data.
-     \note Default implementation does nothing.
-    */
+    /**
+     * Initializes the class attribute with some data.
+     *
+     * @param eZContentClassAttribute $classAttribute
+     */
     function initializeClassAttribute( $classAttribute )
     {
     }
 
-    /*!
-     Clones the date from the old class attribute to the new one.
-     \note Default implementation does nothing which is good enough for datatypes which does not use external tables.
-    */
+    /**
+     * Clones the date from the old class attribute to the new one.
+     *
+     * Default implementation does nothing which is good enough for datatypes which does not use external tables.
+     *
+     * @param eZContentClassAttribute $oldClassAttribute
+     * @param eZContentClassAttribute $newClassAttribute
+     */
     function cloneClassAttribute( $oldClassAttribute, $newClassAttribute )
     {
     }
 
-    /*!
-     Initializes the object attribute with some data.
-     \note Default implementation does nothing.
-    */
+    /**
+     * Initializes the object attribute with some data.
+     *
+     * Default implementation does nothing.
+     *
+     * @param eZContentObjectAttribute $objectAttribute
+     * @param int $currentVersion
+     * @param eZContentObjectAttribute $originalContentObjectAttribute
+     */
     function initializeObjectAttribute( $objectAttribute, $currentVersion, $originalContentObjectAttribute )
     {
     }
 
-    /*!
-     Tries to do a repair on the content object attribute \a $contentObjectAttribute and returns \c true if it succeeds.
-     \return \c false if it fails or \c null if it is not supported to do a repair.
-    */
+    /**
+     * Tries to do a repair on the content object attribute \a $contentObjectAttribute and returns \c true if it succeeds.
+     *
+     * @param eZContentObjectAttribute $contentObjectAttribute
+     * @return bool|null False if it fails or null if it is not supported to do a repair.
+     */
     function repairContentObjectAttribute( $contentObjectAttribute )
     {
         return null;
     }
 
-    /*!
-     Initializes the object attribute with some data after object attribute is already stored. It means that for initial version you allready have an attribute_id and you can store data somewhere using this id.
-     \note Default implementation does nothing.
-    */
+    /**
+     * Initializes the object attribute with some data after object attribute is already stored. It means that for initial version you allready have an attribute_id and you can store data somewhere using this id.
+     *
+     * Default implementation does nothing.
+     *
+     * @param eZContentObjectAttribute $objectAttribute
+     * @param int $currentVersion
+     * @param eZContentObjectAttribute $originalContentObjectAttribute
+     */
     function postInitializeObjectAttribute( $objectAttribute, $currentVersion, $originalContentObjectAttribute )
     {
     }
 
-    /*
-     Makes some post-store operations. Called by framework after store of eZContentObjectAttribute object.
-    */
+    /**
+     * Makes some post-store operations. Called by framework after store of eZContentObjectAttribute object.
+     *
+     * @param eZContentObjectAttribute $objectAttribute
+     */
     function postStore( $objectAttribute )
     {
     }
 
-    /*!
-     Do any necessary changes to stored object attribute when moving an object to trash.
-     \note Default implementation does nothing.
-    */
+    /**
+     * Do any necessary changes to stored object attribute when moving an object to trash.
+     *
+     * Default implementation does nothing.
+     *
+     * @param eZContentObjectAttribute $objectAttribute
+     * @param int|null $version
+     */
     function trashStoredObjectAttribute( $objectAttribute, $version = null )
     {
     }
 
     /**
      * Restores the content object attribute $objectAttribute from trash
+     *
      * Default implementation does nothing
+     *
      * @param eZContentObjectAttribute $objectAttribute
      */
     public function restoreTrashedObjectAttribute( $objectAttribute )
     {
     }
 
-    /*!
-     Clean up stored object attribute
-     \note Default implementation does nothing.
-    */
+    /**
+     * Clean up stored object attribute
+     *
+     * Default implementation does nothing.
+     *
+     * @param eZContentObjectAttribute $objectAttribute
+     * @param int $version
+     */
     function deleteStoredObjectAttribute( $objectAttribute, $version = null )
     {
     }
 
-    /*!
-     Clean up stored class attribute
-     \note Default implementation does nothing.
-    */
+    /**
+     * Clean up stored class attribute
+     *
+     * Default implementation does nothing.
+     *
+     * @param eZContentClassAttribute $classAttribute
+     * @param int $version
+     */
     function deleteStoredClassAttribute( $classAttribute, $version = null )
     {
     }
@@ -963,183 +1087,247 @@ class eZDataType
         return $actionList;
     }
 
-    /*!
-     \return true if the data type can do information collection
-    */
+    /**
+     * Returns true if the data type can do information collection
+     *
+     * @return bool
+     */
     function hasInformationCollection()
     {
         return false;
     }
 
-    /*!
-     Returns the title of the current type, this is to form
-     the title of the object.
-    */
+    /**
+     * Returns the title of the current type, this is to form the title of the object.
+     *
+     * @param eZContentObjectAttribute $objectAttribute
+     * @param string $name
+     * @return string
+     */
     function title( $objectAttribute, $name = null )
     {
         return "";
     }
 
-    /*!
-     \return true if the datatype can be indexed
-    */
+    /**
+     * Returns true if the datatype can be indexed
+     *
+     * @return bool
+     */
     function isIndexable()
     {
         return false;
     }
 
-    /*!
-     \return true if the datatype requires validation during add to basket procedure
-    */
+    /**
+     * Returns true if the datatype requires validation during add to basket procedure
+     *
+     * @return bool
+     */
     function isAddToBasketValidationRequired()
     {
         return false;
     }
-    /*!
-     Validates the input for an object attribute during add to basket process
-     and returns a validation state as defined in eZInputValidator.
-     \note Default implementation does nothing and returns accepted.
-    */
+
+    /**
+     * Validates the input for an object attribute during add to basket process and returns a validation state as defined in eZInputValidator.
+     *
+     * Default implementation does nothing and returns accepted.
+     *
+     * @param eZContentObjectAttribute $objectAttribute
+     * @param array $data
+     * @param array $errors
+     * @return int
+     */
     function validateAddToBasket( $objectAttribute, $data, &$errors )
     {
         return eZInputValidator::STATE_ACCEPTED;
     }
 
-    /*!
-     Queries the datatype if the attribute containing this datatype can be
-     removed from the class. This can be used by datatypes to ensure
-     that very important datatypes that could cause system malfunction is
-     not removed.
-     The datatype will only need to reimplemented this if it wants to
-     do some checking, the default returns \c true.
-
-     \return \c true if the class attribute can be removed or \c false.
-     \sa classAttributeRemovableInformation()
-     \note The default code will call classAttributeRemovableInformation with
-          $includeAll set to \c false, if it returns false or an empty \c 'list'
-          it will return \c true.
-    */
+    /**
+     * Queries the datatype if the attribute containing this datatype can be removed from the class.
+     * This can be used by datatypes to ensure that very important datatypes that could cause system
+     * malfunction is not removed.
+     *
+     * The datatype will only need to reimplemented this if it wants to do some checking, the default returns true.
+     *
+     * The default code will call {@see classAttributeRemovableInformation()} with $includeAll set to false,
+     * if it returns false or an empty 'list' it will return true.
+     *
+     * @see classAttributeRemovableInformation()
+     *
+     * @param eZContentClassAttribute $classAttribute
+     * @return bool True if the class attribute can be removed or false if not
+     */
     function isClassAttributeRemovable( $classAttribute )
     {
         $info = $this->classAttributeRemovableInformation( $classAttribute, false );
         return ( $info === false or count( $info['list'] ) == 0 );
     }
 
-    /*!
-     If the call to isClassAttributeRemovable() returns \c false then this
-     can be called to figure out why it cannot be removed, e.g to give
-     information to the user.
-     \return An array structure with information, or \c false if no info is available
-             - text - Plain text explaining why it can't be removed
-             - list - A list of reasons with details on why it can be removed
-                      - identifier - The identifier of the reason (optional)
-                      - text - Plain text explaning the reason
-     \param $includeAll Controls whether the returned information will contain all
-                        sources for not being to remove or just the first that it finds.
-    */
+    /**
+     * If the call to {@see isClassAttributeRemovable()} returns false then this can be called to figure out
+     * why it cannot be removed, e.g to give information to the user.
+     *
+     * @param eZContentClassAttribute $classAttribute
+     * @param bool $includeAll Controls whether the returned information will contain all sources for not being to remove or just the first that it finds.
+     * @return array|bool   An array structure with information, or false if no info is available:
+     *                      - text - Plain text explaining why it can't be removed
+     *                      - list - A list of reasons with details on why it can be removed
+     *                      -- identifier - The identifier of the reason (optional)
+     *                      -- text - Plain text explaning the reason
+     */
     function classAttributeRemovableInformation( $classAttribute, $includeAll = true )
     {
         return false;
     }
 
-    /*!
-     \return true if the datatype can be used as an information collector
-    */
+    /**
+     * Returns true if the datatype can be used as an information collector
+     *
+     * @return bool
+     */
     function isInformationCollector()
     {
         return false;
     }
 
-    /*!
-     \return the sort key for the datatype. This is used for sorting on attribute level.
-    */
+    /**
+     * Returns the sort key for the datatype. This is used for sorting on attribute level.
+     *
+     * @param eZContentObjectAttribute $objectAttribute
+     * @return string
+     */
     function sortKey( $objectAttribute )
     {
         return "";
     }
 
-    /*!
-     \returns the type of the sort key int|string
-      False is returned if sorting is not supported
-    */
+    /**
+     * Returns the type of the sort key int|string
+     *
+     * @return string| bool "int" or "string", false is returned if sorting is not supported
+     */
     function sortKeyType()
     {
         return false;
     }
 
+    /**
+     * Returns true if the current datatype has a custom sorting. If so,
+     * the method (@see customSortingSQL()} has to be customized
+     *
+     * @see customSortingSQL()
+     *
+     * @return bool
+     */
     function customSorting()
     {
         return false;
     }
 
+    /**
+     * @param array $params
+     * @return array|bool
+     */
     function customSortingSQL( $params )
     {
         return false;
     }
 
-    /*!
-     \return the text which should be indexed in the search engine. An associative array can
-      be returned to enable searching in specific parts of the data. E.g. array( 'first_column' => "foo",
-     'second_column' => "bar" );
-    */
+    /**
+     * Returns the text which should be indexed in the search engine. An associative array can
+     * be returned to enable searching in specific parts of the data. E.g.
+     * <code>
+     * array(
+     *     'first_column' => "foo",
+     *     'second_column' => "bar",
+     * );
+     * </code>
+     *
+     * @param eZContentObjectAttribute $contentObjectAttribute
+     * @return string|array
+     */
     function metaData( $contentObjectAttribute )
     {
         return '';
     }
-    /*!
-     \return string representation of an contentobjectattribute data for simplified export
+
+    /**
+     * Returns the string representation of a contentobjectattribute data for simplified export
+     *
+     * @param eZContentObjectAttribute $objectAttribute
+     * @return string
      */
     function toString( $objectAttribute )
     {
         return '';
     }
+
+    /**
+     * Creates the content attribute's data from its string representation
+     *
+     * @param eZContentObjectAttribute $objectAttribute
+     * @param string $string
+     * @return mixed
+     */
     function fromString( $objectAttribute, $string )
     {
     }
 
-    /*!
-     Can be called to figure out if a datatype has certain special templates that it relies on.
-     This can for instance be used to figure out which override templates to include in a package.
-     \return An array with template files that this datatype relies on.
-             Each element can be one of the following types:
-             - string - The filepath of the template
-             - array - Advanced matching criteria, element 0 determines the type:
-               - 'regexp' - A regular expression, element 1 is the regexp string (PREG)
-             If \c false is returned it means there are no relations to any templates.
-     \note All matching is done relative from templates directory in the given design.
-     \note The templates that are found in content/datatype/* should not be included.
-    */
+    /**
+     * Can be called to figure out if a datatype has certain special templates that it relies on.
+     * This can for instance be used to figure out which override templates to include in a package.
+     *
+     * All matching is done relative from templates directory in the given design.
+     * The templates that are found in content/datatype/* should not be included.
+     *
+     * @return array|bool   An array with template files that this datatype relies on. Each element can be one of the following types:
+     *                      - string - The filepath of the template
+     *                      - array - Advanced matching criteria, element 0 determines the type:
+                            -- 'regexp' - A regular expression, element 1 is the regexp string (PREG)
+     *                      If false is returned it means there are no relations to any templates.
+     */
     function templateList()
     {
         return false;
     }
 
-    /*!
-     Adds the necessary dom structure to the attribute parameters.
-     \note The default is to add unsupported='true' to the attribute node,
-           meaning that the datatype does not support serializing.
-    */
+    /**
+     * Adds the necessary dom structure to the attribute parameters.
+     *
+     * The default is to add unsupported='true' to the attribute node, meaning that the datatype does not support serializing.
+     *
+     * @param eZContentClassAttribute $classAttribute
+     * @param eZContentObjectTreeNode $attributeNode
+     * @param DOMElement $attributeParametersNode
+     */
     function serializeContentClassAttribute( $classAttribute, $attributeNode, $attributeParametersNode )
     {
         if ( !$this->Attributes['properties']['serialize_supported'] )
             $attributeNode->setAttribute( 'unsupported', 'true' );
     }
 
-    /*!
-     Extracts values from the attribute parameters and sets it in the class attribute.
-     \note This function is called after the attribute has been stored and a second store is
-           called after this function is done.
-    */
+    /**
+     * Extracts values from the attribute parameters and sets it in the class attribute.
+     *
+     * This function is called after the attribute has been stored and a second store is called after this function is done.
+     *
+     * @param eZContentClassAttribute $classAttribute
+     * @param eZContentObjectTreeNode $attributeNode
+     * @param DOMElement $attributeParametersNode
+     */
     function unserializeContentClassAttribute( $classAttribute, $attributeNode, $attributeParametersNode )
     {
     }
 
-    /*!
-     \param package
-     \param objectAttribute content attribute
-
-     \return a DOM representation of the content object attribute
-    */
+    /**
+     * Returns a DOM representation of the content object attribute
+     *
+     * @param eZPackage $package
+     * @param eZContentObjectAttribute $objectAttribute
+     * @return DOMElement
+     */
     function serializeContentObjectAttribute( $package, $objectAttribute )
     {
         $dom = new DOMDocument( '1.0', 'utf-8' );
@@ -1185,13 +1373,13 @@ class eZDataType
         return $node;
     }
 
-    /*!
-     Unserialize contentobject attribute
-
-     \param package
-     \param objectAttribute contentobject attribute object
-     \param attributeNode ezdomnode object
-    */
+    /**
+     * Unserialize contentobject attribute
+     *
+     * @param eZPackage $package
+     * @param eZContentObjectAttribute $objectAttribute
+     * @param DOMElement $attributeNode
+     */
     function unserializeContentObjectAttribute( $package, $objectAttribute, $attributeNode )
     {
         if ( $this->Attributes["properties"]['object_serialize_map'] )
@@ -1226,10 +1414,13 @@ class eZDataType
         }
     }
 
-    /*
-        Post unserialize. Called after all related objects are created.
-        \return true means that attribute has been modified and should be stored
-    */
+    /**
+     * Post unserialize. Called after all related objects are created.
+     *
+     * @param eZPackage $package
+     * @param eZContentObjectAttribute $objectAttribute
+     * @return bool true means that attribute has been modified and should be stored
+     */
     function postUnserializeContentObjectAttribute( $package, $objectAttribute )
     {
         return false;
@@ -1244,7 +1435,7 @@ class eZDataType
      * filled with 'key' or 'val', depending on is_numeric( key ) value
      *
      * @return array
-     */ 
+     */
     static function allowedTypes()
     {
         $allowedTypes =& $GLOBALS["eZDataTypeAllowedTypes"];
@@ -1261,6 +1452,9 @@ class eZDataType
         return $allowedTypes;
     }
 
+    /**
+     * Loads and registers all enabled datatypes
+     */
     static function loadAndRegisterAllTypes()
     {
         $allowedTypes = eZDataType::allowedTypes();
@@ -1271,7 +1465,7 @@ class eZDataType
     }
 
     /**
-     * Load and register the datatype $type
+     * Loads and registers the datatype $type
      *
      * Since 5.2 there is no need to do file_exists and include calls
      * if datatype is defined in the following way:
@@ -1297,6 +1491,7 @@ class eZDataType
             return false;
         }
 
+        $baseDirectory = eZExtension::baseDirectory();
         $contentINI = eZINI::instance( 'content.ini' );
         $availableDataTypes = $contentINI->variable( 'DataTypeSettings', 'AvailableDataTypes' );
         if ( array_key_exists( $type, $availableDataTypes ) )
@@ -1351,28 +1546,38 @@ class eZDataType
         return true;
     }
 
-    /*!
-     Removes objects with given ID from the relations list
-     \note Default implementation does nothing.
-    */
+    /**
+     * Removes objects with given ID from the relations list
+     *
+     * Default implementation does nothing.
+     *
+     * @param eZContentObjectAttribute $contentObjectAttribute
+     * @param int $objectID
+     */
     function removeRelatedObjectItem( $contentObjectAttribute, $objectID )
     {
     }
 
-    /*!
-    Fixes objects with given ID in the relations list according to what is done with object
-     \note Default implementation does nothing.
-    */
+    /**
+     * Fixes objects with given ID in the relations list according to what is done with object
+     *
+     * Default implementation does nothing.
+     *
+     * @param eZContentObjectAttribute $contentObjectAttribute
+     * @param int $objectID
+     * @param string $mode
+     */
     function fixRelatedObjectItem( $contentObjectAttribute, $objectID, $mode )
     {
     }
+
     /**
-     * Create empty content object attribute DOM node.
+     * Creates an empty content object attribute DOM node.
      *
-     * The result is intended to be used in a datatype's
-     * serializeContentObjectAttribute() method.
+     * The result is intended to be used in a datatype's serializeContentObjectAttribute() method.
      *
-     * \return "Empty" DOM node
+     * @param eZContentObjectAttribute $objectAttribute
+     * @return DOMElement "Empty" DOM node
      */
     function createContentObjectAttributeDOMNode( $objectAttribute )
     {
@@ -1388,11 +1593,16 @@ class eZDataType
         return $node;
     }
 
-    /*!
-      Method used by content diff system to retrieve changes in attributes.
-      This method implements the default behaviour, which is to show old and
-      new version values of the object.
-    */
+    /**
+     * Method used by content diff system to retrieve changes in attributes.
+     *
+     * This method implements the default behaviour, which is to show old and new version values of the object.
+     *
+     * @param mixed $old
+     * @param mixed $new
+     * @param array|bool $options
+     * @return eZDiffContent
+     */
     function diff( $old, $new, $options = false )
     {
         $diff = new eZDiff();
@@ -1402,18 +1612,27 @@ class eZDataType
         return $diffObject;
     }
 
-    /*!
-      Returns dba-data file name of the specific datatype.
-      This one is the default dba-data file name for all datatypes
-    */
+    /**
+     * Returns dba-data file name of the specific datatype.
+     *
+     * This one is the default dba-data file name for all datatypes
+     *
+     * @return string
+     */
     function getDBAFileName()
     {
         return 'share/db_data.dba';
     }
 
     /*!
-      Returns dba-data file path (relative to the system root folder) for the specific datatype.
+
     */
+    /**
+     * Returns dba-data file path (relative to the system root folder) for the specific datatype.
+     *
+     * @param bool $checkExtensions
+     * @return bool|string
+     */
     function getDBAFilePath( $checkExtensions = true )
     {
          $fileName = 'kernel/classes/datatypes/' . $this->DataTypeString . '/' . $this->getDBAFileName();
@@ -1424,10 +1643,11 @@ class eZDataType
          return $fileName;
     }
 
-    /*!
-      Returns dba-data file extension path (relative to the system root folder) for the specific datatype.
-      \return the first path that is found for the datatype. If not found, it will return false.
-    */
+    /**
+     * Returns dba-data file extension path (relative to the system root folder) for the specific datatype.
+     *
+     * @return bool|string The first path that is found for the datatype. If not found, it will return false.
+     */
     function getDBAExtensionFilePath()
     {
         $activeExtensions = eZExtension::activeExtensions();
@@ -1447,12 +1667,16 @@ class eZDataType
         return $fileName;
     }
 
-    /*!
-      Used by setup-wizard to update database data using per datatype dba file
-      which is usually placed in share subfolder of the datatype and (share/db_data.dba)
-      Any reimplementation of this method must return true if import is succesfully done,
-      otherwise false.
-    */
+    /**
+     * Used by setup-wizard to update database data using per datatype dba file
+     * which is usually placed in share subfolder of the datatype and (share/db_data.dba)
+     *
+     * Any reimplementation of this method must return true if import is succesfully done,
+     * otherwise false.
+     *
+     * @param bool|string $dbaFilePath
+     * @return bool
+     */
     function importDBDataFromDBAFile( $dbaFilePath = false )
     {
         // If no file path is passed then get the common dba-data file name for the datatype
@@ -1496,30 +1720,45 @@ class eZDataType
         return $result;
     }
 
-    /*!
-      \private
-      Used by updateDBDataByDBAFile() method
-      Must return true if successfull, or false otherwise.
-    */
+    /**
+     * Used by updateDBDataByDBAFile() method
+     *
+     * Must return true if successfull, or false otherwise.
+     *
+     * @see updateDBDataByDBAFile()
+     *
+     * @return bool
+     */
     function cleanDBDataBeforeImport()
     {
         return true;
     }
 
+    /**
+     * @param eZContentClassAttribute $classAttribute
+     * @return array
+     */
     function batchInitializeObjectAttributeData( $classAttribute )
     {
         return array();
     }
 
+    /**
+     * @return bool
+     */
     function supportsBatchInitializeObjectAttribute()
     {
         return false;
     }
 
-    /// \privatesection
-    /// The datatype string ID, used for uniquely identifying a datatype
+    /**
+     * @var string The datatype string ID, used for uniquely identifying a datatype
+     */
     public $DataTypeString;
-    /// The descriptive name of the datatype, usually used for displaying to the user
+
+    /**
+     * @var string The descriptive name of the datatype, usually used for displaying to the user
+     */
     public $Name;
 }
 


### PR DESCRIPTION
- The most relevant changes have been made in `eZDataType`
- All other datatypes inherit the PHPDocs automatically, that's why the old doxygen docs have been removed
- Other descriptions have mostly been copied 1:1
- Where no descriptions have been present, I tried to add a small one or kept it empty except the `@param` and `@return` definitions

**No other code changes have been made**

Cheers
:octocat: Jérôme
