### PR TITLE
Fix EZP-20676: JS error inserting embed-inline tag on empty XML block in ezoe

### DIFF
--- a/extension/ezoe/design/standard/templates/ezoe/tag_embed_objects.tpl
+++ b/extension/ezoe/design/standard/templates/ezoe/tag_embed_objects.tpl
@@ -46,7 +46,7 @@ tinyMCEPopup.onInit.add( eZOEPopupUtils.BIND( eZOEPopupUtils.init, window, {
     {
         if ( contentType === 'images' || compatibilityMode === 'enabled' )
             return '<img id="__mce_tmp" src="JavaScript:void(0);" />';
-        if ( jQuery('#embed_inline_source').attr( 'checked' ) )
+        if ( jQuery('#embed_inline_source').prop( 'checked' ) )
            return '<span id="__mce_tmp">ezembed</span>';
         return '<div id="__mce_tmp"></div>';
     },


### PR DESCRIPTION
JIRA issue: https://jira.ez.no/browse/EZP-20676
# Description

An embed inline element is represented as a span element. The problem is that this element is first added empty (and then filled with the preview of the embed view) and since this element is empty, TinyMCE removes it. So this patch simply adds a fake content before the span is actually filled.
The second commit just fixes an API change of jQuery that was hidding this issue in version >= 5.1...

Edit: this PR is a replacement for and closes #597 which requires a TinyMCE change.
# Test

Manual tests in Chrome, Firefox and IE 8 and 9.
