### PR TITLE
EZP-20957: Removed misplaced semicolon which breaks the flow

### DIFF
--- a/kernel/private/classes/clusterfilehandlers/dfsbackends/mysqli.php
+++ b/kernel/private/classes/clusterfilehandlers/dfsbackends/mysqli.php
@@ -1655,7 +1655,7 @@ class eZDFSFileHandlerMySQLiBackend implements eZClusterEventNotifier
             if ( !$res )
                 return false;
             $row = mysqli_fetch_row( $res );
-            if ( isset( $row[0] ) and $row[0] == $generatingFileMtime )
+            if ( isset( $row[0] ) && $row[0] == $generatingFileMtime )
             {
                 return true;
             }


### PR DESCRIPTION
The semicolon causes the method to always return true at this place.

``` php
if ( isset( $row[0] ) and $row[0] == $generatingFileMtime );
{
    return true;
}
```

See https://jira.ez.no/browse/EZP-20957
