### PR TITLE
Fix EZP-20482: In IE8, "Enter" key does not work when creating a custom tag

### DIFF
--- a/extension/ezoe/design/standard/javascript/ezoe/popup_utils.js
+++ b/extension/ezoe/design/standard/javascript/ezoe/popup_utils.js
@@ -50,6 +50,8 @@ var eZOEPopupUtils = {
         editorSelectedText: false,
         // Same as above but with markup
         editorSelectedHtml: false,
+        // the selected node in the editor, set on init
+        editorSelectedNode: false,
         // generates class name for tr elements in browse / search / bookmark list
         browseClassGenerator: function(){ return ''; },
         // generates browse link for a specific mode
@@ -109,6 +111,7 @@ var eZOEPopupUtils = {
             if ( jQuery.trim( selectedHtml ) !== '' )
                 s.editorSelectedHtml = selectedHtml;
         }
+        s.editorSelectedNode = ed.selection.getNode();
         
         if ( s.onInit && s.onInit.call )
             s.onInit.call( eZOEPopupUtils, s.editorElement, s.tagName, ed );
@@ -308,7 +311,8 @@ var eZOEPopupUtils = {
      */
     insertTagCleanly: function( ed, tag, content, args )
     {
-        var edCurrentNode = ed.selection.getNode(), newElement = edCurrentNode.ownerDocument.createElement( tag );
+        var edCurrentNode = eZOEPopupUtils.settings.editorSelectedNode ? eZOEPopupUtils.settings.editorSelectedNode : ed.selection.getNode(),
+            newElement = edCurrentNode.ownerDocument.createElement( tag );
         if ( tag !== 'img' ) newElement.innerHTML = content;
 
         if ( edCurrentNode.nodeName === 'TD' )


### PR DESCRIPTION
JIRA issue: https://jira.ez.no/browse/EZP-20482
# Description

In IE8, if you try to submit the custom tag form in Online Editor with the enter key, the custom tag is not created. This is due to the fact that in such case, IE8 changes the current selection to set it to the currently focused input. [TinyMCE popup code has a workaround to this issue](https://github.com/tinymce/tinymce/blob/3.4.x/jscripts/tiny_mce/classes/Popup.js#L302) which is not available in eZOEPopupUtils.

This patch adds a similar workaround so that the selected node inside the editor is kept when the tinymce's popup is opened.
# Tests

manual tests on adding custom tags and others elements in IE8, IE9, Chrome and Firefox using the Enter key and the mouse.
