### PR TITLE
Fix EZP-20888: session is created regardless of ForceStart value

### DIFF
--- a/kernel/common/ezurloperator.php
+++ b/kernel/common/ezurloperator.php
@@ -806,6 +806,7 @@ CODEPIECE;
                         case eZURLOperator::HTTP_OPERATOR_TYPE_SESSION:
                         {
                             $hasSessionVariable = $http->hasSessionVariable( $httpName, false );
+                            // if null, session has not started, useful if using lazy loading
                             if ( $hasSessionVariable === null )
                             {
                                 $operatorValue = null;

--- a/tests/tests/kernel/common/ezurloperator_test.php
+++ b/tests/tests/kernel/common/ezurloperator_test.php
@@ -55,7 +55,11 @@ class eZURLOperatorTest extends ezpTestCase
             case 'get'    : $_GET[$argument]     = $expectedResult; break;
             case 'post'   : $_POST[$argument]    = $expectedResult; break;
             case 'cookie' : $_COOKIE[$argument]  = $expectedResult; break;
-            case 'session': $_SESSION[$argument] = $expectedResult; break;
+            case 'session':
+                $_SESSION[$argument] = $expectedResult;
+                // session is lazy loaded, expected result is null (session has not started) to be returned
+                $expectedResult = null;
+                break;
         }
 
         $operatorParameters = array(


### PR DESCRIPTION
# Description

Sessions were created even with the forcestart value disabled.
We added the false boolean as mentioned in https://github.com/ezsystems/ezpublish-legacy/pull/639
New tests have been added to match what $http->hasSessionVariable returns
# Test

Manual tests on FF and chrome using private browsing.
