### PR TITLE
eZDBInterface: Constructor and class var refactoring

### DIFF
--- a/lib/ezdb/classes/ezdbinterface.php
+++ b/lib/ezdb/classes/ezdbinterface.php
@@ -220,7 +220,13 @@ class eZDBInterface
      *
      * @var int
      */
-    protected $SlowSQLTimeout = 0;
+    public $SlowSQLTimeout = 0;
+
+    /**
+     * This controls if the queries should have an analysis done for the debug output (Requires SQLOutput=enabled)
+     * @var bool
+     */
+    public $QueryAnalysisOutput = false;
 
     /**
      * The total number of milliseconds the timer took


### PR DESCRIPTION
Greetings!

I have tried to be as atomic as possible with the commits to make it easier to follow the changes. Here is a summary:
1. Moved the class variables from the bottom of the class to the top
2. Added class variables which have previously been set dynamically
3. <del>Changed the access of the class variables to what has beed defined in the `@access` PHPDoc properties</del>
4. Default values are now set directly in the class variables instead of in the constructor
5. Added checks in the constructor, if a key in the `$parameters` array is actually present before using it

If (2) is too intrusive to make you accept this PR, I would like to revert the changes instead of rejecting the PR.

Cheers
:octocat: Jérôme
