### PR TITLE
Fix EZP-20992: Wrong scope in contentViewGenerateError when using DFS and user-permissions

### DIFF
--- a/kernel/classes/eznodeviewfunctions.php
+++ b/kernel/classes/eznodeviewfunctions.php
@@ -608,6 +608,7 @@ class eZNodeviewfunctions
                     'kernel',
                     $errorParameters
                 ),
+            'scope' => 'viewcache',
             'store' => $store,
             'binarydata' => serialize( $content ),
         );


### PR DESCRIPTION
This patch fixes the issue that a wrong scope is used when generating view caches for error pages (`UNKNOWN_SCOPE` instead of `viewcache`).

Please see the [corresponding JIRA issue](https://jira.ez.no/browse/EZP-20992) for more detailed information. Thanks to @m-keil for the detailed description and fix.
