### PR TITLE
Fix EZP-21006: Setupwizard trows PHP warnings & eZ errors on MySQL 5.6

### DIFF
--- a/kernel/setup/steps/ezstep_create_sites.php
+++ b/kernel/setup/steps/ezstep_create_sites.php
@@ -493,7 +493,8 @@ class eZStepCreateSites extends eZStepInstaller
                         if ( $db->databaseName() == 'mysql' )
                         {
                             $engines = $db->arrayQuery( 'SHOW ENGINES' );
-                            foreach( $engines as $engine ) {
+                            foreach( $engines as $engine )
+                            {
                                 if ( $engine['Engine'] == 'InnoDB' && in_array( $engine['Support'], array( 'YES', 'DEFAULT' ) ) )
                                 {
                                     $params['table_type'] = 'innodb';


### PR DESCRIPTION
Since MySQL 5.6.1, the server variable `have_innodb` has been removed. The command `SHOW ENGINES` instead is supported since MySQL 4.1.

See http://dev.mysql.com/doc/refman/5.6/en/server-system-variables.html#sysvar_have_innodb

This patch replaces the server variable check with the recommended way through `SHOW ENGINES`.

I did think about `strtolower`ing the keys and values, but I checked that the spelling has always been the same since MySQL 4.1.

Cheers
:octocat: Jérôme
https://jira.ez.no/browse/EZP-21006
