### PR TITLE
Replaced calls to deprecated eZSearch::removeObject() with eZSearch::removeObjectById()

### DIFF
--- a/bin/php/updatesearchindex.php
+++ b/bin/php/updatesearchindex.php
@@ -135,7 +135,7 @@ do
     {
         if ( $needRemoveWithUpdate || !$cleanupSearch )
         {
-            $searchEngine->removeObject( $object, false );
+            $searchEngine->removeObjectById( $object->attribute( "id" ), false );
         }
         if ( !$searchEngine->addObject( $object, false ) )
         {

--- a/kernel/classes/ezcontentobject.php
+++ b/kernel/classes/ezcontentobject.php
@@ -1664,7 +1664,7 @@ class eZContentObject extends eZPersistentObject
 
         eZContentObject::fixReverseRelations( $delID, 'remove' );
 
-        eZSearch::removeObject( $this );
+        eZSearch::removeObjectById( $delID );
 
         // Check if deleted object is in basket/wishlist
         $sql = 'SELECT DISTINCT ezproductcollection_item.productcollection_id
@@ -1771,7 +1771,7 @@ class eZContentObject extends eZPersistentObject
 
 
             $this->setAttribute( 'status', eZContentObject::STATUS_ARCHIVED );
-            eZSearch::removeObject( $this );
+            eZSearch::removeObjectById( $delID );
             $this->store();
             eZContentObject::fixReverseRelations( $delID, 'trash' );
             // Delete stored attribute from other tables
@@ -1797,7 +1797,7 @@ class eZContentObject extends eZPersistentObject
 
                     $node->removeNodeFromTree( true );
                     $this->setAttribute( 'status', eZContentObject::STATUS_ARCHIVED );
-                    eZSearch::removeObject( $this );
+                    eZSearch::removeObjectById( $delID );
                     $this->store();
                     eZContentObject::fixReverseRelations( $delID, 'trash' );
                     $db->commit();

--- a/kernel/classes/ezsearch.php
+++ b/kernel/classes/ezsearch.php
@@ -68,7 +68,7 @@ class eZSearch
 
         if ( $searchEngine instanceof ezpSearchEngine )
         {
-            return $searchEngine->removeObject( $contentObject, $commit );
+            return $searchEngine->removeObjectById( $contentObject->attribute( "id" ), $commit );
         }
 
         return false;

--- a/kernel/content/ezcontentoperationcollection.php
+++ b/kernel/content/ezcontentoperationcollection.php
@@ -575,7 +575,7 @@ class eZContentOperationCollection
         if ( eZSearch::needRemoveWithUpdate() )
         {
             eZDebug::accumulatorStart( 'remove_object', 'search_total', 'remove object' );
-            eZSearch::removeObject( $object, $needCommit );
+            eZSearch::removeObjectById( $objectID, $needCommit );
             eZDebug::accumulatorStop( 'remove_object' );
         }
 


### PR DESCRIPTION
For once, the title says it all :).

Cheers!
:octocat: Jérôme
