### PR TITLE
EZP-21156 : clear cache in another transaction

### DIFF
--- a/kernel/classes/ezcontentclass.php
+++ b/kernel/classes/ezcontentclass.php
@@ -1046,9 +1046,7 @@ You will need to change the class of the node by using the swap functionality.' 
 
         $db->commit();
 
-        $db->begin();
         eZContentCacheManager::clearAllContentCache();
-        $db->commit();
     }
 
     function setVersion( $version, $set_childs = false )


### PR DESCRIPTION
Well, the idea is to the content clear cache after.

So if something fails, the contentclass storing would be correct.
