### PR TITLE
Fix EZP-19856: [HTTP].ContentLanguage settings in locale files updated; ...

### DIFF
--- a/share/locale/cat-ES.ini
+++ b/share/locale/cat-ES.ini
@@ -13,7 +13,7 @@ Allowed[]=iso-8859-14
 Allowed[]=iso-8859-15
 
 [HTTP]
-ContentLanguage=cat-ES
+ContentLanguage=ca
 
 [Currency]
 Symbol=EUR

--- a/share/locale/cro-HR.ini
+++ b/share/locale/cro-HR.ini
@@ -27,7 +27,7 @@ Allowed[]=cp850
 Allowed[]=dec-mcs
 
 [HTTP]
-ContentLanguage=hr-HR
+ContentLanguage=hr
 
 [Currency]
 Symbol=kn

--- a/share/locale/cze-CZ.ini
+++ b/share/locale/cze-CZ.ini
@@ -12,7 +12,7 @@ Allowed[]=windows-1250
 Allowed[]=utf-8
 
 [HTTP]
-ContentLanguage=cs-CZ
+ContentLanguage=cs
 
 [Currency]
 Symbol=Kč

--- a/share/locale/dan-DK.ini
+++ b/share/locale/dan-DK.ini
@@ -26,7 +26,7 @@ Allowed[]=cp850
 Allowed[]=dec-mcs
 
 [HTTP]
-ContentLanguage=da-DK
+ContentLanguage=da
 
 [Currency]
 Symbol=kr

--- a/share/locale/dut-NL.ini
+++ b/share/locale/dut-NL.ini
@@ -14,7 +14,7 @@ Allowed[]=cp1252
 
 
 [HTTP]
-ContentLanguage=dut-NL
+ContentLanguage=nl
 
 [Currency]
 Symbol=€

--- a/share/locale/ell-GR.ini
+++ b/share/locale/ell-GR.ini
@@ -27,7 +27,7 @@ Allowed[]=cp1253
 #Allowed[]=dec-mcs
 
 [HTTP]
-ContentLanguage=ell-GR
+ContentLanguage=el
 
 [Currency]
 Symbol=€

--- a/share/locale/epo-EO.ini
+++ b/share/locale/epo-EO.ini
@@ -12,7 +12,7 @@ Allowed[]=utf-8
 Allowed[]=iso-8859-3
 
 [HTTP]
-ContentLanguage=epo-EO
+ContentLanguage=eo
 
 [Currency]
 Symbol=€

--- a/share/locale/esl-MX.ini
+++ b/share/locale/esl-MX.ini
@@ -13,7 +13,7 @@ Allowed[]=iso-8859-14
 Allowed[]=iso-8859-15
 
 [HTTP]
-ContentLanguage=mx-esl
+ContentLanguage=es-MX
 
 [Currency]
 Symbol=$

--- a/share/locale/fre-BE.ini
+++ b/share/locale/fre-BE.ini
@@ -27,7 +27,7 @@ Allowed[]=cp850
 Allowed[]=dec-mcs
 
 [HTTP]
-ContentLanguage=fr-BE
+ContentLanguage=fr
 
 [Currency]
 Symbol=€

--- a/share/locale/fre-FR.ini
+++ b/share/locale/fre-FR.ini
@@ -27,7 +27,7 @@ Allowed[]=cp850
 Allowed[]=dec-mcs
 
 [HTTP]
-ContentLanguage=fr-FR
+ContentLanguage=fr
 
 [Currency]
 Symbol=€

--- a/share/locale/ger-DE.ini
+++ b/share/locale/ger-DE.ini
@@ -13,7 +13,7 @@ Allowed[]=cp1250
 
 
 [HTTP]
-ContentLanguage=de-DE
+ContentLanguage=de
 
 [Currency]
 Symbol=€

--- a/share/locale/heb-IL.ini
+++ b/share/locale/heb-IL.ini
@@ -16,7 +16,7 @@ Allowed[]=macHebrew
 Allowed[]=cp1255
 
 [HTTP]
-ContentLanguage=heb-IL
+ContentLanguage=he
 
 [Currency]
 Symbol=ג×

--- a/share/locale/hin-IN.ini
+++ b/share/locale/hin-IN.ini
@@ -9,7 +9,7 @@ InternationalLanguageName=Hindi (India)
 Preferred=utf-8
 
 [HTTP]
-ContentLanguage=hi-HI
+ContentLanguage=hi
 
 [Currency]
 Symbol=Rs

--- a/share/locale/hun-HU.ini
+++ b/share/locale/hun-HU.ini
@@ -13,7 +13,7 @@ Allowed[]=iso-8859-2
 Allowed[]=cp1252
 
 [HTTP]
-ContentLanguage=hun-HU
+ContentLanguage=hu
 
 [Currency]
 Symbol=Ft

--- a/share/locale/ind-ID.ini
+++ b/share/locale/ind-ID.ini
@@ -11,7 +11,7 @@ Preferred=utf-8
 Allowed[]=iso-8859-1
 
 [HTTP]
-ContentLanguage=ind-ID
+ContentLanguage=id
 
 [Currency]
 Symbol=Rp

--- a/share/locale/ita-IT.ini
+++ b/share/locale/ita-IT.ini
@@ -14,7 +14,7 @@ Allowed[]=cp1252
 Allowed[]=cp1250
 
 [HTTP]
-ContentLanguage=it-IT
+ContentLanguage=it
 
 [Currency]
 Symbol=€

--- a/share/locale/jpn-JP.ini
+++ b/share/locale/jpn-JP.ini
@@ -8,7 +8,7 @@ InternationalLanguageName=Japanese
 Preferred=utf-8
 
 [HTTP]
-ContentLanguage=ja-JP
+ContentLanguage=ja
 
 [Currency]
 Symbol=円

--- a/share/locale/jpn-JP@international.ini
+++ b/share/locale/jpn-JP@international.ini
@@ -8,7 +8,7 @@ InternationalLanguageName=Japanese
 Preferred=utf-8
 
 [HTTP]
-ContentLanguage=ja-JP
+ContentLanguage=ja
 
 [Currency]
 Symbol=¥

--- a/share/locale/kor-KR.ini
+++ b/share/locale/kor-KR.ini
@@ -8,7 +8,7 @@ InternationalLanguageName=Korean
 Preferred=utf-8
 
 [HTTP]
-ContentLanguage=ko-KR
+ContentLanguage=ko
 
 [Currency]
 Symbol=KRW

--- a/share/locale/nno-NO.ini
+++ b/share/locale/nno-NO.ini
@@ -26,7 +26,7 @@ Allowed[]=cp850
 Allowed[]=dec-mcs
 
 [HTTP]
-ContentLanguage=no-nynorsk
+ContentLanguage=nn
 
 [Currency]
 Symbol=kr

--- a/share/locale/nor-NO.ini
+++ b/share/locale/nor-NO.ini
@@ -26,7 +26,7 @@ Allowed[]=cp850
 Allowed[]=dec-mcs
 
 [HTTP]
-ContentLanguage=no-bokmaal
+ContentLanguage=nb
 
 [Currency]
 Symbol=kr

--- a/share/locale/pol-PL.ini
+++ b/share/locale/pol-PL.ini
@@ -15,7 +15,7 @@ Allowed[]=cp1250
 Allowed[]=cp852
 
 [HTTP]
-ContentLanguage=pl-PL
+ContentLanguage=pl
 
 [Currency]
 Symbol=zł

--- a/share/locale/por-MZ.ini
+++ b/share/locale/por-MZ.ini
@@ -17,7 +17,7 @@ Allowed[]=cp1252
 Allowed[]=cp1250
 
 [HTTP]
-ContentLanguage=pt-PT
+ContentLanguage=pt-MZ
 
 [Currency]
 Symbol= 

--- a/share/locale/por-PT.ini
+++ b/share/locale/por-PT.ini
@@ -16,7 +16,7 @@ Allowed[]=cp1252
 Allowed[]=cp1250
 
 [HTTP]
-ContentLanguage=pt-PT
+ContentLanguage=pt
 
 [Currency]
 Symbol=EUR

--- a/share/locale/rus-RU.ini
+++ b/share/locale/rus-RU.ini
@@ -15,7 +15,7 @@ Allowed[]=iso-8859-5
 Allowed[]=cp1251
 
 [HTTP]
-ContentLanguage=ru-RU
+ContentLanguage=ru
 
 [Currency]
 Symbol=р.

--- a/share/locale/ser-SR.ini
+++ b/share/locale/ser-SR.ini
@@ -28,7 +28,7 @@ Allowed[]=dec-mcs
 
 
 [HTTP]
-ContentLanguage=sr-SR
+ContentLanguage=sr-Latn
 
 [Currency]
 Symbol=DIN

--- a/share/locale/srp-RS.ini
+++ b/share/locale/srp-RS.ini
@@ -28,7 +28,7 @@ Allowed[]=dec-mcs
 
 
 [HTTP]
-ContentLanguage=sr-SR
+ContentLanguage=sr-Cyrl
 
 [Currency]
 Symbol=DIN

--- a/share/locale/swe-SE.ini
+++ b/share/locale/swe-SE.ini
@@ -25,7 +25,7 @@ Allowed[]=cp850
 Allowed[]=dec-mcs
 
 [HTTP]
-ContentLanguage=swe-SE
+ContentLanguage=sv
 
 [Currency]
 Symbol=kr

--- a/share/locale/tur-TR.ini
+++ b/share/locale/tur-TR.ini
@@ -30,7 +30,7 @@ Allowed[]=cp850
 Allowed[]=dec-mcs
 
 [HTTP]
-ContentLanguage=tur-TR
+ContentLanguage=tr
 
 [Currency]
 Symbol=ytl

--- a/share/locale/ukr-UA.ini
+++ b/share/locale/ukr-UA.ini
@@ -15,7 +15,7 @@ Allowed[]=iso-8859-5
 Allowed[]=cp1251
 
 [HTTP]
-ContentLanguage=ua-UA
+ContentLanguage=uk
 
 [Currency]
 Symbol=грн.


### PR DESCRIPTION
...closes #671

I tried to to simplify ContentLanguage codes using IANA (http://www.iana.org/assignments/language-subtag-registry/language-subtag-registry) document and W3C recommendations (http://www.w3.org/International/questions/qa-choosing-language-tags). Not all have been shortened to 2 characters.

For the possible discussion: I had doubts about (\* means chosen):
*`zh-CN` or `zh` or `cmn` or `zh-Hans` (China)
*`es-ES` or `es-ES` (Spain)
*`es-MX` or `es-419` (Mexico)
*`fr` or `fr-BE` (wikipedia http://en.wikipedia.org/wiki/Belgian_French sais "Belgian French and the French of northern France are almost identical, but there are a few distinct phonological and lexical differences.") (Belgium)
*`fr-CA` or `fr` (Canada)
*`pt-MZ` or `pt` (Mozambique)
*`sr-Latn` and *`sr-Cyrl` or `sr` (Serbia)
