### PR TITLE
Fixed EZP-21220: Parsing error in REST with "Content-type: application/json; charset=utf-8"

### DIFF
--- a/kernel/private/rest/classes/request/rest_request.php
+++ b/kernel/private/rest/classes/request/rest_request.php
@@ -198,7 +198,7 @@ class ezpRestRequest extends ezcMvcRequest
     {
         if ( $this->originalProtocol === 'http-post' )
         {
-            if ( $this->raw['CONTENT_TYPE'] === 'application/json' )
+            if ( strpos( $this->raw['CONTENT_TYPE'], 'application/json' ) === 0 )
             {
                 return json_decode( $this->body, true );
             }


### PR DESCRIPTION
Issue: https://jira.ez.no/browse/EZP-21220

Very obviously `"application/json; charset=utf-8" !== "application/json"`!
