### PR TITLE
Fix EZP-21046: DFS cluster cache not expiring in one node

### DIFF
--- a/kernel/private/classes/clusterfilehandlers/ezdfsfilehandler.php
+++ b/kernel/private/classes/clusterfilehandlers/ezdfsfilehandler.php
@@ -465,7 +465,7 @@ class eZDFSFileHandler implements eZClusterFileHandlerInterface, ezpDatabaseBase
                     }
 
                     // check if FS file is older than DB file
-                    if ( !$this->useStaleCache && $this->isLocalFileExpired( $this->metaData['mtime'], $curtime, $ttl ) )
+                    if ( !$this->useStaleCache && $this->isDBFileExpired( $this->metaData['mtime'], $curtime, $ttl ) )
                     {
                         eZDebugSetting::writeDebug( 'kernel-clustering', "Local file (mtime=" . @filemtime( $this->filePath ) . ") is older than DB, checking with DB", __METHOD__ );
                         $forceDB = true;


### PR DESCRIPTION
# Description

The cache was cleared only if the local file (based on it's timestamp) was expired. It was causing problems when multiple nodes were used because the timestamp of the file was not the same on the node (since it was freshly copied) and on the DFS.

We are now looking if the file is expired using the database instead of the file system. It looks like this bug has been introduced as some sort of IDE completion mistake since the comment above the line was right and the method to do the job existed.

I would really appreciate some quick feedback from you guys, because I have the whole setup working like a charm on my computer right now and it would be stupid to break it before this one is merged and closed :)
# Test
- I emptied the pagelayout and created a single cache-block showing the current date
- Cleared the cache
- Generated the cache opening the page
- Updated the timestamp in the database to day way back in the past
- Reloaded the page, the old cache was still provided (because it's using the time stamp of the file not the DB)
- After the patch the cache is generated as expected using DB timestamp.

I also ran the unit test with no errors.
