### PR TITLE
Fix EZP-21226: ezchecktranslation.php is not handling translatorcomment & location nodes

### DIFF
--- a/bin/php/ezchecktranslation.php
+++ b/bin/php/ezchecktranslation.php
@@ -140,11 +140,11 @@ function handleMessageNode( $contextName, $message, $cli, $data, $requireTransla
             }
             else if ( $message_child->localName == "location" )
             {
-                //Ignore it.
+                // Ignore it.
             }
             else if ( $message_child->localName == "translatorcomment" )
             {
-                //Ignore it.
+                // Ignore it.
             }
             else
             {


### PR DESCRIPTION
Here is a little fix so the script ezchecktranslation won't show anymore useless warning.
