### PR TITLE
EZP-21234 : No need to use template/compiled as compilation template fol...

### DIFF
--- a/bin/php/eztc.php
+++ b/bin/php/eztc.php
@@ -24,7 +24,7 @@ $script->startup();
 $options = $script->getOptions( "[compile-directory:][www-dir:][index-file:][access-path:][force][full-url][no-full-url]",
                                 "",
                                 array( 'force' => "Force compilation of template whether it has changed or not",
-                                       'compile-directory' => "Where to place compiled files,\ndefault is template in current cache directory",
+                                       'compile-directory' => "Where to place compiled files,\ndefault is template/compiled in current cache directory",
                                        'full-url' => "Makes sure generated urls have http:// in them (i.e. global), used mainly by sites that include the eZ Publish HTML (e.g payment gateways)",
                                        'no-full-url' => "Makes sure generated urls are relative to the site. (default)",
                                        'www-dir' => "The part before the index.php in your URL, you should supply this if you are running in non-virtualhost mode",

--- a/kernel/classes/datatypes/ezpackage/ezpackagetype.php
+++ b/kernel/classes/datatypes/ezpackage/ezpackagetype.php
@@ -131,7 +131,7 @@ class eZPackageType extends eZDataType
         {
             $cacheDir =  eZSys::cacheDirectory();
         }
-        $compiledTemplateDir = $cacheDir ."/template";
+        $compiledTemplateDir = $cacheDir ."/" . eZTemplateCompiler::compilationDefaultDirectory();
         eZDir::unlinkWildcard( $compiledTemplateDir . "/", "*pagelayout*.*" );
 
         // Expire template block cache

--- a/kernel/visual/menuconfig.php
+++ b/kernel/visual/menuconfig.php
@@ -85,7 +85,7 @@ if ( $module->isCurrentAction( 'Store' ) )
     {
         $cacheDir =  eZSys::cacheDirectory();
     }
-    $compiledTemplateDir = $cacheDir ."/template";
+    $compiledTemplateDir = $cacheDir ."/" . eZTemplateCompiler::compilationDefaultDirectory();
     eZDir::unlinkWildcard( $compiledTemplateDir . "/", "*pagelayout*.*" );
 
     // Expire template block cache

--- a/kernel/visual/toolbar.php
+++ b/kernel/visual/toolbar.php
@@ -387,7 +387,7 @@ function removeRelatedCache( $siteAccess )
     {
         $cacheDir =  eZSys::cacheDirectory();
     }
-    $compiledTemplateDir = $cacheDir . "/template";
+    $compiledTemplateDir = $cacheDir . "/" . eZTemplateCompiler::compilationDefaultDirectory();
     eZDir::unlinkWildcard( $compiledTemplateDir . "/", "*pagelayout*.*" );
     eZCache::clearByTag( 'template-block' );
 

--- a/lib/eztemplate/classes/eztemplatecompiler.php
+++ b/lib/eztemplate/classes/eztemplatecompiler.php
@@ -297,10 +297,25 @@ class eZTemplateCompiler
             }
             else
             {
-                $compilationDirectory = eZDir::path( array( eZSys::cacheDirectory(), 'template' ) );
+                $compilationDirectory = eZDir::path( array( eZSys::cacheDirectory(), self::compilationDefaultDirectory() ) );
             }
         }
         return $compilationDirectory;
+    }
+
+    /**
+     * Return the default directory for compiled templates
+     * @return mixed|string
+     */
+    public static function compilationDefaultDirectory()
+    {
+        $ini = eZINI::instance();
+        if ( $ini->hasVariable( 'TemplateSettings', 'DefaultCompiledTemplatesDir' ) )
+        {
+            return $ini->variable( 'TemplateSettings', 'DefaultCompiledTemplatesDir' );
+        }
+
+        return 'template/compiled';
     }
 
     /*!

--- a/settings/site.ini
+++ b/settings/site.ini
@@ -1036,6 +1036,8 @@ TemplateCompile=enabled
 ShareCompiledTemplates=disabled
 # Where to store shared compiled templates
 SharedCompiledTemplatesDir=
+# Name of the default compiled template directory
+DefaultCompiledTemplatesDir=template/compiled
 # Controls whether further optimizations should be performed on compiled
 # templates
 TemplateOptimization=enabled


### PR DESCRIPTION
...der

As @patrickallaert said in a current PR, each cache directory means a lstat executed. Compiled templates are written in cache_dir/template/compiled.

It should be cache_dir/template.
