### PR TITLE
Fix EZP-21237: Debug by user feature blocks the login process

### DIFF
--- a/kernel/private/classes/ezpkernelweb.php
+++ b/kernel/private/classes/ezpkernelweb.php
@@ -277,12 +277,6 @@ class ezpKernelWeb implements ezpWebBasedKernelHandler
 
         $this->mobileDeviceDetect = new ezpMobileDeviceDetect( ezpMobileDeviceDetectFilter::getFilter() );
         // eZSession::setSessionArray( $mainRequest->session );
-
-        /**
-         * Check for activating Debug by user ID (Final checking. The first was in eZDebug::updateSettings())
-         * @uses eZUser::instance() So needs to be executed after eZSession::start()|lazyStart()
-         */
-        eZDebug::checkDebugByUser();
     }
 
     /**
@@ -1180,6 +1174,12 @@ class ezpKernelWeb implements ezpWebBasedKernelHandler
         );
 
         $this->isInitialized = true;
+
+        /**
+         * Check for activating Debug by user ID (Final checking. The first was in eZDebug::updateSettings())
+         * @uses eZUser::instance() So needs to be executed after eZSession::start()|lazyStart()
+         */
+        eZDebug::checkDebugByUser();
     }
 
     /**


### PR DESCRIPTION
`eZDebug::checkDebugByUser()` call was made in `ezpKernelWeb::__construct()`, so before session is initialized. This has for consequence to always load anonymous user when using this feature.

Moved the call in `ezpKernelWeb::requestInit()`
