### PR TITLE
Fix EZP-21155: DebugByUser is not working correctly in preview

### DIFF
--- a/kernel/content/versionview.php
+++ b/kernel/content/versionview.php
@@ -235,6 +235,8 @@ if ( $access['type'] === eZSiteAccess::TYPE_URI )
 
 eZSiteAccess::load( $access );
 
+eZDebug::checkDebugByUser();
+
 // Change content object default language
 $GLOBALS['eZContentObjectDefaultLanguage'] = $LanguageCode;
 eZTranslatorManager::resetTranslations();


### PR DESCRIPTION
# Description

When debugByUser was used, a user could see the debug in the preview, even if it was not activated for him.

The debugByUser setting was erased when loading  the new site access. I added an update of the setting right after that.
# Test

Manual test on firefox.
