### PR TITLE
Fix for EZP-21305: Allow object relation attribute to be used in object name pattern as first condition in fallback

### DIFF
--- a/kernel/classes/eznamepatternresolver.php
+++ b/kernel/classes/eznamepatternresolver.php
@@ -241,7 +241,7 @@ class eZNamePatternResolver
             }
             else
             {
-                if ( isset( $this->attributeArray[$tokenPart] ) && strlen( $this->attributeArray[$tokenPart] ) > 0 )
+                if ( isset( $this->attributeArray[$tokenPart] ) && $this->attributeArray[$tokenPart] !== '' && $this->attributeArray[$tokenPart] !== false )
                 {
                     $replaceString = $this->attributeArray[$tokenPart];
                     // We want to stop after the first matching token part / identifier is found


### PR DESCRIPTION
In eZNamePatternResolver, resolveToken() makes sure that the object title is not null and not an empty string. Presumably this was done instead of a straight boolean check in order to allow an object title of "0".  However, in such selective checking, there should be an extra check that the title value is not false.

With this fix, an object relation attribute, whose empty title returns false, can properly be used as the first condition in a fallback in an object name pattern.
