### PR TITLE
Added vendor and composer.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ bin/win32
 support/ezlupdate-qt4.5/ezlupdate/Makefile
 support/ezlupdate-qt4.5/ezlupdate/moc
 support/ezlupdate-qt4.5/ezlupdate/obj
+/vendor
+composer.lock
+


### PR DESCRIPTION
- The slash at the beginning of `/vendors` allows 3rd party extensions to have a vendors dir
- The composer.lock file is generated by running `composer install/update` and could land in the repository by accident
