### PR TITLE
Adding HTTP Headers "No-Cache" while using stale cache

### DIFF
--- a/kernel/private/classes/clusterfilehandlers/ezdfsfilehandler.php
+++ b/kernel/private/classes/clusterfilehandlers/ezdfsfilehandler.php
@@ -405,8 +405,7 @@ class eZDFSFileHandler implements eZClusterFileHandlerInterface, ezpDatabaseBase
         $ret = $this->_processCache( $retrieveCallback, $generateCallback, $ttl, $expiry, $extraData );
         if ( $this->useStaleCache )
         {
-            header( "Cache­-Control: no­-cache" );
-            header( "Pragma: no-­cache" );
+            header( "Cache­-Control: max-age=300, s-maxage=300" );
         }
         return $ret;
     }


### PR DESCRIPTION
If we use the Cluster eZDFSFileHandler, eZ enables thes StaleCache feature to give old cache of contents when a client ask a page whose new cache is generating...
But if we use eZ behind a Reverse Proxy like Varnish, the proxy will store the obsolete content within its own cache, unless we tell him to not do it.

This PR adds a HTTP Header when the page is rendered from stale cache so that Varnish will not store the wrong content into its own cache.
