### PR TITLE
Fixed EZP-21037: content staging error synchronizing a subtree

### DIFF
--- a/kernel/classes/ezcontentobject.php
+++ b/kernel/classes/ezcontentobject.php
@@ -1445,9 +1445,8 @@ class eZContentObject extends eZPersistentObject
         $db->begin();
 
         // This is part of the new 3.8 code.
-        foreach ( array_keys( $nodeAssignmentList ) as $key )
+        foreach ( $nodeAssignmentList as $nodeAssignment )
         {
-            $nodeAssignment = $nodeAssignmentList[$key];
             // Only copy assignments which has a remote_id since it will be used in template code.
             if ( $nodeAssignment->attribute( 'remote_id' ) == 0 )
             {
@@ -1676,7 +1675,7 @@ class eZContentObject extends eZPersistentObject
                 $nodes = $this->assignedNodes();
                 foreach( $nodes as $node )
                 {
-                    $remoteID = 0;
+                    $remoteID = eZRemoteIdUtility::generate( 'object' );
                     // Remove assignments which conflicts with existing nodes, but keep remote_id
                     if ( isset( $parentMap[$node->attribute( 'parent_node_id' )] ) )
                     {
@@ -1685,9 +1684,14 @@ class eZContentObject extends eZPersistentObject
                         $remoteID = $copiedNodeAssignment->attribute( 'remote_id' );
                         $copiedNodeAssignment->purge();
                     }
-                    $newNodeAssignment = $contentObjectVersion->assignToNode( $node->attribute( 'parent_node_id' ), $node->attribute( 'is_main' ), 0,
-                                                                              $node->attribute( 'sort_field' ), $node->attribute( 'sort_order' ),
-                                                                              $remoteID );
+                    $contentObjectVersion->assignToNode(
+                        $node->attribute( 'parent_node_id' ),
+                        $node->attribute( 'is_main' ),
+                        0,
+                        $node->attribute( 'sort_field' ),
+                        $node->attribute( 'sort_order' ),
+                        $remoteID
+                    );
                 }
             }
 

--- a/kernel/content/copysubtree.php
+++ b/kernel/content/copysubtree.php
@@ -289,20 +289,6 @@ function copyPublishContentObject( $sourceObject,
             eZDebug::writeError( "Cannot find source parent node in list of nodes already copied.",
                                  "Subtree Copy Error!" );
         }
-        // Create unique remote_id
-        $newRemoteID = eZRemoteIdUtility::generate( 'node' );
-        $oldRemoteID = $newNode->attribute( 'remote_id' );
-        $newNode->setAttribute( 'remote_id', $newRemoteID );
-        // Change parent_remote_id for object assignments
-        foreach ( $objAssignments as $assignment )
-        {
-            if ( $assignment->attribute( 'parent_remote_id' ) == $oldRemoteID )
-            {
-                 $assignment->setAttribute( 'parent_remote_id', $newRemoteID );
-                 $assignment->store();
-            }
-        }
-        $newNode->store();
     }
 
     // if $keepCreator == true then keep owner of contentobject being


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-21037

The node assignment copies were given a new remote ID _after_ publishing.
This caused staging to create the sync event with out-of-sync data.

The patch ensures that each copied node assignment get a new remote ID upfront.
