### PR TITLE
Fix EZP-21336: In IE8, every publish adds another empty paragraph at the end

### DIFF
--- a/extension/ezoe/ezxmltext/handlers/input/ezoexmlinput.php
+++ b/extension/ezoe/ezxmltext/handlers/input/ezoexmlinput.php
@@ -588,11 +588,20 @@ class eZOEXMLInput extends eZXMLInputHandler
             if ( $lastChild && $lastChild->nodeName === 'paragraph' )
             {
                 $textChild = $lastChild->lastChild;
-                // $textChild->textContent == " " : string(2) whitespace in Opera
-                if ( !$textChild ||
-                     ( $lastChild->childNodes->length == 1 &&
-                       $textChild->nodeType == XML_TEXT_NODE &&
-                       ( $textChild->textContent == " " || $textChild->textContent == ' ' || $textChild->textContent == '' || $textChild->textContent == '&nbsp;' ) ) )
+                if (
+                    !$textChild ||
+                    (
+                        $lastChild->childNodes->length == 1 &&
+                        $textChild->nodeType == XML_TEXT_NODE &&
+                        (
+                            $textChild->textContent == " " || // that's a non breaking space (Opera)
+                            $textChild->textContent == ' ' ||
+                            $textChild->textContent == '' ||
+                            $textChild->textContent == '&nbsp;' ||
+                            $textChild->textContent == "\xC2\xA0" // utf8 non breaking space
+                        )
+                    )
+                )
                 {
                     $parent->removeChild( $lastChild );
                 }


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-21336
# Description

In IE8 in some conditions, the last _empty_ paragraph added to avoid some issues in TinyMCE is not removed before storing the eZXML. As a result, the XML block is growing on each publish operation.
I was not able to reproduce this issue on my system, I suspect this is also related to a very specific version of IE8 and/or PHP and its linked libraries.
# Tests

manual tests on my system (no regression) + test by the 2nd line
