### PR TITLE
Fixed EZP-21037: content staging error synchronizing a subtree (part 2)

### DIFF
--- a/bin/php/ezsubtreecopy.php
+++ b/bin/php/ezsubtreecopy.php
@@ -199,20 +199,6 @@ function copyPublishContentObject( $sourceObject,
         {
             die( "Copy Subtree Error: Algoritm ERROR! Cannot find source parent node ID in source parent node ID's list of contentobject being copied." );
         }
-        // Create unique remote_id
-        $newRemoteID = eZRemoteIdUtility::generate( 'node' );
-        $oldRemoteID = $newNode->attribute( 'remote_id' );
-        $newNode->setAttribute( 'remote_id', $newRemoteID );
-        // Change parent_remote_id for object assignments
-        foreach ( $objAssignments as $assignment )
-        {
-            if ( $assignment->attribute( 'parent_remote_id' ) == $oldRemoteID )
-            {
-                 $assignment->setAttribute( 'parent_remote_id', $newRemoteID );
-                 $assignment->store();
-            }
-        }
-        $newNode->store();
     }
 
     // Update "is_invisible" attribute for the newly created node.


### PR DESCRIPTION
The duplicated part of the code removed in
kernel/content/copysubtree.php were not removed in
bin/php/ezsubtreecopy.php

This is the continuation of @bdunogier's work in https://github.com/ezsystems/ezpublish-legacy/pull/699
