### PR TITLE
Fix EZP-21358: ezjscAjaxContent: Image's exif fields MakerNote and UserComment must be base64 encoded

### DIFF
--- a/doc/bc/5.2/changes-5.2.txt
+++ b/doc/bc/5.2/changes-5.2.txt
@@ -74,6 +74,10 @@ Change of behavior
   mechanism. Autoload generator add these clasess to the autoload array, so there's no 
   need to do any of the file_exists or include calls.
 
+- Fix EZP-21358: ezjscAjaxContent: Image's exif fields MakerNote and UserComment must be base64 encoded
+
+  ezjscAjaxContent now returns image's exif fields MakerNote and UserComment base64 encoded.
+
 
 Removed features
 ----------------

--- a/extension/ezjscore/classes/ezjscajaxcontent.php
+++ b/extension/ezjscore/classes/ezjscajaxcontent.php
@@ -459,10 +459,18 @@ class ezjscAjaxContent
                         $imageArray,
                         function ( &$element, $key )
                         {
+                            // These fields can contain non utf-8 content
+                            // badly handled by mb_check_encoding
+                            // so they are just encoded in base64
+                            // see https://jira.ez.no/browse/EZP-21358
+                            if ( $key == "MakerNote" || $key == "UserComment")
+                            {
+                                $element =  base64_encode( (string)$element );
+                            }
                             // json_encode/xmlEncode need UTF8 encoded strings
                             // (exif) metadata might not be for instance
                             // see https://jira.ez.no/browse/EZP-19929
-                            if ( !mb_check_encoding( $element, 'UTF-8' ) )
+                            else if ( !mb_check_encoding( $element, 'UTF-8' ) )
                             {
                                 $element = mb_convert_encoding(
                                     (string)$element, 'UTF-8'


### PR DESCRIPTION
# Description

Issue : https://jira.ez.no/browse/EZP-21358

ezjscAjaxContent now returns image's exif fields MakerNote and UserComment base64 encoded.
# Test

Manual test on FF and chrome
