### PR TITLE
Fix EZP-21396: exif Warning in php 5.3.3 Rhel

### DIFF
--- a/lib/ezimage/classes/ezexifimageanalyzer.php
+++ b/lib/ezimage/classes/ezexifimageanalyzer.php
@@ -38,7 +38,7 @@ class eZEXIFImageAnalyzer
         {
             if ( function_exists( 'exif_read_data' ) )
             {
-                $exifData = exif_read_data( $filename, "COMPUTED,IFD0,COMMENT,EXIF", true );
+                $exifData = @exif_read_data( $filename, "COMPUTED,IFD0,COMMENT,EXIF", true );
                 if ( $exifData )
                 {
                     $info = array();


### PR DESCRIPTION
When testing EZP-21358 - ezjscAjaxContent : Image's exif fields MakerNote and UserComment must be base64 encoded on RHEL 6.4 using php 5.3.3 I got the following php warning when uploading a non utf-8 content in exif I got the following php warning:

```
Warning: exif_read_data(Jazz-auf-dem-Trammplatz_reference.jpg): Process tag(x0001=UndefinedTa): Illegal format code 0x0000, suppose BYTE in /var/www/apache2php53/ezp47/.run/lib/ezimage/classes/ezexifimageanalyzer.php on line 41 

Call Stack: 0.0001 636856 
1. {main}() /var/www/apache2php53/ezp47/.run/index.php:0 0.0240 2402488 
2. eZModule->run() /var/www/apache2php53/ezp47/.run/index.php:723 0.0241 2413104 
3. eZProcess::run() /var/www/apache2php53/ezp47/.run/lib/ezutils/classes/ezmodule.php:1598 0.0241 2413472 
4. eZProcess->runFile() /var/www/apache2php53/ezp47/.run/lib/ezutils/classes/ezprocess.php:21 0.0388 2567368 
5. include('/var/www/apache2php53/ezp47/.run/extension/ezoe/modules/ezoe/relations.php') /var/www/apache2php53/ezp47/.run/lib/ezutils/classes/ezprocess.php:46 0.0608 3583328 
6. ezjscAjaxContent::nodeEncode() /var/www/apache2php53/ezp47/.run/extension/ezoe/modules/ezoe/relations.php:258 0.0608 3583408 
7. ezjscAjaxContent::simplify() /var/www/apache2php53/ezp47/.run/extension/ezjscore/classes/ezjscajaxcontent.php:152 0.0765 4672024 
8. eZImageAliasHandler->attribute() /var/www/apache2php53/ezp47/.run/extension/ezjscore/classes/ezjscajaxcontent.php:444 0.0765 4672024 
9. eZImageAliasHandler->imageAlias() /var/www/apache2php53/ezp47/.run/kernel/classes/datatypes/ezimage/ezimagealiashandler.php:103 0.0766 4672648 
10. eZImageManager->createImageAlias() /var/www/apache2php53/ezp47/.run/kernel/classes/datatypes/ezimage/ezimagealiashandler.php:412 0.5608 5165800 
11. eZImageManager->convert() /var/www/apache2php53/ezp47/.run/lib/ezimage/classes/ezimagemanager.php:871 0.5608 5167040 
12. eZImageManager::analyzeImage() /var/www/apache2php53/ezp47/.run/lib/ezimage/classes/ezimagemanager.php:1040 0.5610 5168800 
13. eZEXIFImageAnalyzer->process() /var/www/apache2php53/ezp47/.run/lib/ezimage/classes/ezimagemanager.php:1003 0.5610 5169040 
14. exif_read_data() /var/www/apache2php53/ezp47/.run/lib/ezimage/classes/ezexifimageanalyzer.php:41
```

This PR will fix this
