### PR TITLE
Implement EZP-21323: Add link to older packages in setup wizard

### DIFF
--- a/design/standard/stylesheets/setup2.css
+++ b/design/standard/stylesheets/setup2.css
@@ -157,6 +157,13 @@ fieldset {
     margin-top: 1em;
 }
 
+div.information {
+    background-color: #eeeeee;
+    border-radius: 5px;
+    padding: 1% 2%;
+    border: 1px solid #c6c6c6;
+}
+
 a, a:link, a:link.setup_final, div.setup_help a:link,
 a:visited, a:visited.setup_final, div.setup_help a:visited {
     color: #ff8c0f;

--- a/design/standard/templates/setup/init/site_types.tpl
+++ b/design/standard/templates/setup/init/site_types.tpl
@@ -116,6 +116,12 @@
 </table>
 
 {if not($message)}
+<h2>{'Additional packages'|i18n('design/standard/setup/init')}</h2>
+
+<div class="information">
+    <p>{'Looking for other packages? Full archive of all packages can be found <a href="%packages_url" target="_blank">here</a>.'|i18n('design/standard/setup/init', '', hash( '%packages_url', ezini( 'RepositorySettings', 'RemotePackagesIndexURLBase', 'package.ini' ) ) )}</p>
+</div>
+
 <fieldset>
   <legend>{'Upload package'|i18n( 'design/standard/setup/init' )}:</legend>
   <input class="file" name="PackageBinaryFile" type="file" />


### PR DESCRIPTION
Issue link: https://jira.ez.no/browse/EZP-21323

Screenshoot:
![screen shot 2013-08-08 at 19 30 19](https://f.cloud.github.com/assets/289757/933140/86c9fd54-0050-11e3-9242-9f05ba4c7edf.png)

Link goes to http://packages.ez.no/ezpublish/ (template gets url from ini setting)
