### PR TITLE
EZP-21408: Add composer autoloads in ezpgenerateautoloads.php in pure legacy context

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ before_script:
  - if [ $DB == "mysql" ]; then mysql -e "CREATE DATABASE IF NOT EXISTS $DB_NAME;" -u$DB_USER ; fi
  - if [ $DB == "postgresql" ]; then psql -c "CREATE DATABASE $DB_NAME;" -U $DB_USER ; psql -c "CREATE EXTENSION pgcrypto;" -U $DB_USER $DB_NAME ; fi
  - php bin/php/ezpgenerateautoloads.php -s -e
- - cp config.php-TRAVIS config.php
  - composer install --prefer-source
 
 script:

--- a/autoload.php
+++ b/autoload.php
@@ -23,6 +23,7 @@ if ( !defined( 'EZCBASE_ENABLED' ) )
 {
     $appName = defined( 'EZP_APP_FOLDER_NAME' ) ? EZP_APP_FOLDER_NAME : 'ezpublish';
     $appFolder = __DIR__ . "/../$appName";
+    $legacyVendorDir = __DIR__ . "/vendor";
 
     // Bundled
     if ( defined( 'EZP_USE_BUNDLED_COMPONENTS' ) ? EZP_USE_BUNDLED_COMPONENTS === true : file_exists( __DIR__ . "/lib/ezc" ) )
@@ -41,6 +42,12 @@ if ( !defined( 'EZCBASE_ENABLED' ) )
     else if ( strpos( $appFolder, "{$appName}/../{$appName}" ) === false && file_exists( "{$appFolder}/autoload.php" ) )
     {
         require_once "{$appFolder}/autoload.php";
+        $baseEnabled = false;
+    }
+    // Composer if in eZ Publish legacy context
+    else if ( file_exists( "{$legacyVendorDir}/autoload.php" ) )
+    {
+        require_once "{$legacyVendorDir}/autoload.php";
         $baseEnabled = false;
     }
     // PEAR install

--- a/bin/php/ezpgenerateautoloads.php
+++ b/bin/php/ezpgenerateautoloads.php
@@ -18,6 +18,7 @@ if ( file_exists( "config.php" ) )
 //{
 $appName = defined( 'EZP_APP_FOLDER_NAME' ) ? EZP_APP_FOLDER_NAME : 'ezpublish';
 $appFolder = getcwd() . "/../$appName";
+$legacyVendorDir = getcwd() . "/vendor";
 
 $baseEnabled = true;
 // Bundled
@@ -35,6 +36,12 @@ else if ( defined( 'EZC_BASE_PATH' ) )
 else if ( strpos( $appFolder, "{$appName}/../{$appName}" ) === false && file_exists( "{$appFolder}/autoload.php" ) )
 {
     require_once "{$appFolder}/autoload.php";
+    $baseEnabled = false;
+}
+// Composer if in eZ Publish legacy context
+else if ( file_exists( "{$legacyVendorDir}/autoload.php" ) )
+{
+    require_once "{$legacyVendorDir}/autoload.php";
     $baseEnabled = false;
 }
 // PEAR

--- a/config.php-TRAVIS
+++ b/config.php-TRAVIS
@@ -1,8 +1,0 @@
-<?php
-// config.php for Travis tests.
-// https://travis-ci.org/ezsystems/ezpublish-legacy
-
-// Explicitly don't use ezcBase autoloader, in favor of Composer's.
-define( 'EZCBASE_ENABLED', false );
-// Registering Composer autoloader.
-$loader = require __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
This patch adds the ability to use the Zeta Components installed through composer in a pure eZ Publish legacy install without the need to download the eZ Components into `lib/ezc` or to install them through PEAR.

Without this patch, the call of `php bin/php/ezpgenerateautoloads.php -e` would stop with the following error:

``` bash
Warning: require(Base/src/base.php): failed to open stream: No such file or directory in .../ezpublish-legacy/bin/php/ezpgenerateautoloads.php on line 45
```

https://jira.ez.no/browse/EZP-21408
