### PR TITLE
Fixed EZP-21400: Discard draft, removes image file

### DIFF
--- a/kernel/classes/datatypes/ezimage/ezimagefile.php
+++ b/kernel/classes/datatypes/ezimage/ezimagefile.php
@@ -119,9 +119,13 @@ class eZImageFile extends eZPersistentObject
         $filepath = addcslashes( $filepath, "_" );
         $query = "SELECT id, version
                   FROM   ezcontentobject_attribute
-                  WHERE  contentobject_id = $contentObjectID and
-                         contentclassattribute_id = $contentClassAttributeID and
-                         data_text like '%url=\"$filepath\"%'";
+                  WHERE  contentobject_id = $contentObjectID AND
+                         contentclassattribute_id = $contentClassAttributeID AND
+                         data_text LIKE '%url=\"$filepath\"%'";
+        if ( $db->databaseName() == 'oracle' )
+        {
+            $query .= " ESCAPE '\'";
+        }
         $rows = $db->arrayQuery( $query );
         return $rows;
     }


### PR DESCRIPTION
Fixes https://jira.ez.no/browse/EZP-21400.

Oracle has no default escape character, when a character is escaped, it is required that the escape character is explicitly defined by appending:

``` sql
ESCAPE '\'
```
