### PR TITLE
Fix EZP-21038: Treemenu breaks with non latin char

### DIFF
--- a/kernel/content/treemenu.php
+++ b/kernel/content/treemenu.php
@@ -171,6 +171,8 @@ else
     $response['children_count'] = count( $children );
     $response['children'] = array();
 
+    $httpCharset = eZTextCodec::httpCharset();
+
     foreach ( $children as $child )
     {
         $childObject = $child->object();
@@ -180,7 +182,7 @@ else
         $object = $child->object();
         $childResponse['class_id'] = (int)$object->ClassID;
         $childResponse['has_children'] = $child->subTreeCount( $conditions ) > 0;
-        $childResponse['name'] = htmlentities( $child->getName() );
+        $childResponse['name'] = htmlentities( $child->getName(), ENT_COMPAT, $httpCharset );
         $childResponse['url'] = $child->url();
         // force system url on empty urls (root node)
         if ( $childResponse['url'] === '' )
@@ -203,8 +205,6 @@ else
         unset( $object );
         eZContentObject::clearCache();
     }
-
-    $httpCharset = eZTextCodec::httpCharset();
 
     $jsonText= json_encode( $response );
 
@@ -229,8 +229,8 @@ else
         header( 'Cache-Control: cache, max-age=' . MAX_AGE . ', post-check=' . MAX_AGE . ', pre-check=' . MAX_AGE );
         header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s', $node->ModifiedSubNode ) . ' GMT' );
         header( 'Pragma: cache' );
-        header( 'Content-Type: application/json' );
-        header( 'Content-Length: '.strlen( $jsonText ) );
+        header( 'Content-Type: application/json; charset=' . $httpCharset );
+        header( 'Content-Length: '. mb_strlen( $jsonText ) );
     }
 
     $Result['lastModified'] = new DateTime( "@$node->ModifiedSubNode" );


### PR DESCRIPTION
Issue: https://jira.ez.no/browse/EZP-21038

Since b768d2f22bae527eaa659d16fba84c3e63507e5c, treemenu is broken
because htmlentities() needs to know the charset used, especially when
it is not UTF-8 (PHP 5.4) or ISO-8859-1 (PHP 5.3).
Also use mb_strlen() instead of strlen(), and specify the charset in the
Content-Type HTTP header.
