### PR TITLE
Fix EZP-21410: object name limit does not support multibyte charset

### DIFF
--- a/kernel/classes/eznamepatternresolver.php
+++ b/kernel/classes/eznamepatternresolver.php
@@ -112,7 +112,7 @@ class eZNamePatternResolver
         $this->version = $contentVersion;
         $this->translation = $contentTranslation;
 
-        $this->namePattern = $this->filterNamePattern( $namePattern);
+        $this->namePattern = $this->filterNamePattern( $namePattern );
     }
 
     /**
@@ -131,13 +131,13 @@ class eZNamePatternResolver
         $objectName = $this->translatePattern();
 
         // Make sure length is not longer then $limit unless it's 0
-        if ( !$limit || strlen( $objectName ) <= $limit )
+        if ( !$limit || mb_strlen( $objectName, "utf-8" ) <= $limit )
         {
             return $objectName;
         }
         else
         {
-            return rtrim( substr( $objectName, 0, $limit - strlen( $sequence ) +1 ) ) . $sequence;
+            return preg_replace( "/[\pZ\pC]+$/u", '', mb_substr( $objectName, 0, $limit - mb_strlen( $sequence, "utf-8" ) +1, "utf-8" ) ) . $sequence;
         }
     }
 

--- a/tests/tests/kernel/classes/eznamepatternresolver_regression.php
+++ b/tests/tests/kernel/classes/eznamepatternresolver_regression.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * File containing the eZNamePatternResolverRegression class
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ * @package tests
+ */
+
+class eZNamePatternResolverRegression extends ezpTestCase
+{
+    /**
+     * @return array
+     */
+    public function providerForTestNamePatternResolver()
+    {
+        return array(
+            array(// test ASCII string split, no trimming
+                "This is a Very Long Name isn't it?",
+                20,
+                "..",
+                "<name>",
+                "name",
+                "This is a Very Long.."
+            ),
+            array(// test ASCII string split, whitespace trimming
+                "This is a Very Long \n\t\r\0Name isn't it?",
+                25,
+                "..",
+                "<name>",
+                "name",
+                "This is a Very Long.."
+            ),
+            array(// test ASCII string split, comma and dot trimming
+                "This is a Very Long,.Name isn't it?",
+                22,
+                "..",
+                "<name>",
+                "name",
+                "This is a Very Long,..."
+            ),
+            array(// test uft-8 string split, no trimming
+                "私は簡単にパブリッシュの記事で使用することができるようなもの、何でも、記述する必要が、それはそう、私はただ何を書き留めて、何を参照してくださいますね、あなたが実際にTIに考えている心の中で何かが出てくるのが難しいのようなものだ登場。ポイントは、私が百五文字が必要だということです。これで十分です。くそー、もっと2",
+                31,
+                "..",
+                "<name>",
+                "name",
+                "私は簡単にパブリッシュの記事で使用することができるようなもの.."
+            ),
+            array(// test uft-8 string split, with ideographic comma trimming
+                "私は簡単にパブリッシュの記事で使用することができるようなもの、何でも、記述する必要が、それはそう、私はただ何を書き留めて、何を参照してくださいますね、あなたが実際にTIに考えている心の中で何かが出てくるのが難しいのようなものだ登場。ポイントは、私が百五文字が必要だということです。これで十分です。くそー、もっと2",
+                32,
+                "..",
+                "<name>",
+                "name",
+                "私は簡単にパブリッシュの記事で使用することができるようなもの、.."
+            ),
+        );
+    }
+
+    /**
+     * Test to check fix for "object name limit does not support multibyte charset"
+     *
+     * @link https://jira.ez.no/browse/EZP-21410
+     * @dataProvider providerForTestNamePatternResolver
+     */
+    public function testNamePatternResolver( $name, $limit, $sequence, $namePattern, $identifier, $expects )
+    {
+        $contentObjectMock = $this->getMock( "eZContentObject", array(), array(), '', false, false );
+        $contentObjectAttributeMock = $this->getMock( "eZContentObjectAttribute", array(), array(), '', false, false );
+
+
+        $contentObjectMock
+            ->expects( $this->once() )
+            ->method( "fetchAttributesByIdentifier" )
+            ->with( array( $identifier ), false, array( false ) )
+            ->will( $this->returnValue( array( $contentObjectAttributeMock ) ) );
+
+        $contentObjectAttributeMock
+            ->expects( $this->once() )
+            ->method( "contentClassAttributeIdentifier" )
+            ->will( $this->returnValue( $identifier ) );
+
+        $contentObjectAttributeMock
+            ->expects( $this->once() )
+            ->method( 'title' )
+            ->will( $this->returnValue( $name ) );
+
+
+        $resolver = new eZNamePatternResolver( $namePattern, $contentObjectMock );
+        $result = $resolver->resolveNamePattern( $limit, $sequence );
+
+        $this->assertEquals( $expects, $result );
+    }
+}

--- a/tests/tests/kernel/suite.php
+++ b/tests/tests/kernel/suite.php
@@ -51,6 +51,7 @@ class eZKernelTestSuite extends ezpDatabaseTestSuite
         $this->addTestSuite( 'eZBinaryFileTypeRegression' );
         $this->addTestSuite( 'eZContentClassRegression' );
         $this->addTestSuite( 'eZURLOperatorTest' );
+        $this->addTestSuite( 'eZNamePatternResolverRegression' );
 
         $this->addTestSuite( 'ezpTopologicalSortTest' );
         $this->addTestSuite( 'eZExtensionWithOrderingTest' );


### PR DESCRIPTION
<del>BC: This change also introduces support for trimming away misc comma and dot symbols</del> -> moved to new [Story](https://jira.ez.no/browse/EZP-21418)
