### PR TITLE
Fix EZP-21420: Added zetacomponents/event-log to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "zetacomponents/console-tools": "@dev",
         "zetacomponents/database": "@dev",
         "zetacomponents/debug": "@dev",
+        "zetacomponents/event-log": "@dev",
         "zetacomponents/feed": "@dev",
         "zetacomponents/image-conversion": "@dev",
         "zetacomponents/mail": "@dev",


### PR DESCRIPTION
When the Zeta Components are used (installed through composer, not available in lib/ezc or through PEAR), running the PHPUnit tests with an activated extension (e.g. ezcomments) fails with the message 

```
Fatal error: Class 'ezcLog' not found in /../vendor/zetacomponents/debug/src/debug.php on line 145
```

Adding `zetacomponents/event-log` to the composer.json file fixes this.

https://jira.ez.no/browse/EZP-21408
