### PR TITLE
Fix EZP-20880: Cache not cleared on role edits

### DIFF
--- a/kernel/classes/ezcontentcachemanager.php
+++ b/kernel/classes/ezcontentcachemanager.php
@@ -1110,6 +1110,8 @@ class eZContentCacheManager
             // view cache and/or ordinary template block cache
             eZContentObject::expireAllCache();
 
+            ezpEvent::getInstance()->notify( 'content/cache/all' );
+
             // subtree template block caches
             if ( $templateCacheEnabled )
             {

--- a/kernel/classes/ezcontentobject.php
+++ b/kernel/classes/ezcontentobject.php
@@ -5827,6 +5827,8 @@ class eZContentObject extends eZPersistentObject
      *
      * Transaction unsafe. If you call several transaction unsafe methods you must enclose
      * the calls within a db transaction; thus within db->begin and db->commit.
+     *
+     * Note: This is considered a internal function, instead use {@see eZContentCacheManager::clearAllContentCache}
      */
     static function expireAllCache()
     {


### PR DESCRIPTION
Several parts of kernel, including views in role module uses eZContentCacheManager::clearAllContentCache(); to really wipe out all content (view) cache when close to all cache is considered stale. This patch adds an content/cache/all event in this function to make sure 5.x-kernel's persistence and  http cache gets notification about this.
