### PR TITLE
Updated Travis CI status image to point to the correct project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-eZ Publish 4 [![Build Status](https://secure.travis-ci.org/ezsystems/ezpublish.png)](http://travis-ci.org/ezsystems/ezpublish)
+eZ Publish 4 [![Build Status](https://secure.travis-ci.org/ezsystems/ezpublish-legacy.png)](http://travis-ci.org/ezsystems/ezpublish-legacy)
 ============
 
 What is eZ Publish?


### PR DESCRIPTION
The travis CI status image in the README currently points to `ezsystems/ezpublish` instead of `ezsystems/ezpublish-legacy`. That's why we see "build error" instead of "build passed".

This PR changes the URLs so that we see a little more green :).

Cheers
:octocat: Jérôme
