### PR TITLE
Fix EZP-21411: eZOracle: Link management doesn't show Objects using URL

### DIFF
--- a/kernel/classes/datatypes/ezurl/ezurlobjectlink.php
+++ b/kernel/classes/datatypes/ezurl/ezurlobjectlink.php
@@ -50,6 +50,10 @@ class eZURLObjectLink extends eZPersistentObject
                       'sort' => array( 'url_id' => 'asc' ),
                       'class_name' => 'eZURLObjectLink',
                       'name' => 'ezurl_object_link' );
+        if ( eZDB::instance()->databaseName() == "oracle" )
+        {
+            $definition['fields']['contentobject_attr_version'] = $definition['fields']['contentobject_attribute_version'];
+        }
         return $definition;
     }
 


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-21411

In _oracle_, **ezcontentobject_attribute** column **contentobject_attribute_version** is named **contentobject_attr_version**.
eZURLObjectLink->definition updated accordingly

Manual text on any browser
