### PR TITLE
Fix EZP-21397: Anchor tag removed if anchor text is only content in line...

### DIFF
--- a/extension/ezoe/design/standard/templates/ezoe/tag_anchor.tpl
+++ b/extension/ezoe/design/standard/templates/ezoe/tag_anchor.tpl
@@ -28,7 +28,7 @@ tinyMCEPopup.onInit.add( eZOEPopupUtils.BIND( eZOEPopupUtils.init, window, {ldel
     },
     tagCreator: function( ed, tag, customTag, selectedHtml )
     {
-        return eZOEPopupUtils.insertHTMLCleanly( ed, '<a id="__mce_tmp" class="mceItemAnchor"><\/a>', '__mce_tmp' );
+        return eZOEPopupUtils.insertHTMLCleanly( ed, '<a id="__mce_tmp" class="mceItemAnchor">\uFEFF<\/a>', '__mce_tmp' );
     }
 {/literal}
 {rdelim} ) );


### PR DESCRIPTION
..., or immediately adjacent lines

If there is no content next to the tag, it gets stripped from the XmlBlock content.

By appending a `&nbsp;` to the content to be inserted, this problem is avoided
