### PR TITLE
Fix EZP-21443: Debug log displayed when using long japaneese strings in name

### DIFF
--- a/kernel/classes/ezpersistentobject.php
+++ b/kernel/classes/ezpersistentobject.php
@@ -370,14 +370,14 @@ class eZPersistentObject
                  $field_def['datatype'] === 'string'            &&
                  array_key_exists( 'max_length', $field_def )   &&
                  $field_def['max_length'] > 0                   &&
-                 strlen( $value ) > $field_def['max_length'] )
+                 mb_strlen( $value, "utf-8" ) > $field_def['max_length'] )
             {
-                $obj->setAttribute( $field_name, substr( $value, 0, $field_def['max_length'] ) );
+                $obj->setAttribute( $field_name, mb_substr( $value, 0, $field_def['max_length'], "utf-8" ) );
                 eZDebug::writeDebug( $value, "truncation of $field_name to max_length=". $field_def['max_length'] );
             }
             $bindDataTypes = array( 'text' );
             if ( $db->bindingType() != eZDBInterface::BINDING_NO &&
-                 strlen( $value ) > 2000 &&
+                 mb_strlen( $value, "utf-8" ) > 2000 &&
                  is_array( $field_def ) &&
                  in_array( $field_def['datatype'], $bindDataTypes  )
                  )
@@ -1180,7 +1180,7 @@ class eZPersistentObject
 
             $bindDataTypes = array( 'text' );
             if ( $db->bindingType() != eZDBInterface::BINDING_NO &&
-                 strlen( $value ) > 2000 &&
+                 mb_strlen( $value, "utf-8" ) > 2000 &&
                  is_array( $fieldDef ) &&
                  in_array( $fieldDef['datatype'], $bindDataTypes  )
                  )


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-21443
# Description

When using a long object name the test (and the trimming) was using a method that is not compatible with unicode.
The calls have been replaced with a unicode compliant method everywhere it was relevant in the file.
# Tests

Manual tests on Firefox.
