### PR TITLE
Fix EZP-21444 - Fatal error: mysqli_query(): Query error (1054): Unknown column 'ezcontentobject_name.content_version' in 'on clause' while browsing blogs by tag

### DIFF
--- a/kernel/classes/ezcontentobjecttreenode.php
+++ b/kernel/classes/ezcontentobjecttreenode.php
@@ -659,7 +659,7 @@ class eZContentObjectTreeNode extends eZPersistentObject
                             $datatypeWhereSQL = "
                                    $contentAttributeTableAlias.contentobject_id = ezcontentobject.id AND
                                    $contentAttributeTableAlias.contentclassattribute_id = $classAttributeID AND
-                                   $contentAttributeTableAlias.version = ezcontentobject_name.content_version AND";
+                                   $contentAttributeTableAlias.version = ezcontentobject.current_version AND";
                             $datatypeWhereSQL .= eZContentLanguage::sqlFilter( $contentAttributeTableAlias, 'ezcontentobject' );
 
                             $dataType = eZDataType::create( eZContentObjectTreeNode::dataTypeByClassAttributeID( $classAttributeID ) );


### PR DESCRIPTION
When using eZ Demo Blog, if you click on a tag from a Blog Post you'll get a fatal error

```
Fatal error: mysqli_query(): Query error (1054): Unknown column 'ezcontentobject_name.content_version' in 'on clause'. Query: SELECT DISTINCT ezcontentobject_tree.node_id, ezkeyword.keyword, a0.sort_key_int FROM ezkeyword INNER JOIN ezkeyword_attribute_link ON (ezkeyword_attribute_link.keyword_id = ezkeyword.id) INNER JOIN ezcontentobject_attribute ON (ezcontentobject_attribute.id = ezkeyword_attribute_link.objectattribute_id) INNER JOIN ezcontentobject ON (ezcontentobject_attribute.version = ezcontentobject.current_version AND ezcontentobject_attribute.contentobject_id = ezcontentobject.id) INNER JOIN ezcontentobject_tree ON (ezcontentobject_tree.contentobject_id = ezcontentobject.id) INNER JOIN ezcontentclass ON (ezcontentclass.id = ezcontentobject.contentclass_id) INNER JOIN ezcontentobject_attribute a0 ON ( a0.contentobject_id = in /var/www/blog_resende_biz/ezpublish_legacy/lib/ezdb/classes/ezmysqlidb.php on line 419
```

https://jira.ez.no/browse/EZP-21444
