### PR TITLE
Fixed: EZP-21457: eZSys::escapeShellArgument() escapes "\" while the shell escape character is the simple quote

### DIFF
--- a/lib/ezutils/classes/ezsys.php
+++ b/lib/ezutils/classes/ezsys.php
@@ -286,17 +286,15 @@ class eZSys
     public static function escapeShellArgument( $argument )
     {
         $escapeChar = self::instance()->ShellEscapeCharacter;
-        $argument = str_replace( "\\", "\\\\", $argument );
         if ( $escapeChar == "'" )
         {
-            $argument = str_replace( $escapeChar, $escapeChar . "\\" . $escapeChar . $escapeChar, $argument );
+            $argument = str_replace( "'", "'\\''", $argument );
         }
         else
         {
-            $argument = str_replace( $escapeChar, "\\" . $escapeChar, $argument );
+            $argument = str_replace( $escapeChar, "\\" . $escapeChar, addcslashes( $argument, '\\' ) );
         }
-        $argument = $escapeChar . $argument . $escapeChar;
-        return $argument;
+        return $escapeChar . $argument . $escapeChar;
     }
 
     /**


### PR DESCRIPTION
Fixes: https://jira.ez.no/browse/EZP-21457

When single quotes are used, backslashes MUST NOT be escaped:

```
$ echo '\'
\
$ echo '\\'
\\
```
