### PR TITLE
Fixed: EZP-21357: Wildcards '*' not escaped for shell commands when using 'urlalias_iri' transformation group

### DIFF
--- a/lib/ezimage/classes/ezimageshellhandler.php
+++ b/lib/ezimage/classes/ezimageshellhandler.php
@@ -65,7 +65,18 @@ class eZImageShellHandler extends eZImageHandler
             $sourceMimeData['url'] .= $frameRangeParameters[$sourceMimeData['name']];
         }
 
-        $argumentList[] = eZSys::escapeShellArgument( $sourceMimeData['url'] );
+        // Issue EZP-21357:
+        // ImageMagick has it's own meta-characters support, hence:
+        //     $ convert 'File*.jpg'' ...
+        // Still expand File*.jpg as the shell would do, however, this is only true for the file's basename part and not
+        // for the whole path.
+        $argumentList[] = eZSys::escapeShellArgument(
+            dirname( $sourceMimeData['url'] ) . DIRECTORY_SEPARATOR . addcslashes(
+                basename( $sourceMimeData['url'] ),
+                // ImageMagick meta-characters
+                '~*?[]{}<>'
+            )
+        );
 
         $qualityParameters = $this->QualityParameters;
         if ( $qualityParameters and


### PR DESCRIPTION
Fixes: https://jira.ez.no/browse/EZP-21357

Depends on #729.

Unfortunately, ImageMagick implements lot of... magic(k), doing:

``` bash
$ convert 'File*.jpg'' ...
```

**WILL** expand File*.jpg.

More info at: http://www.imagemagick.org/Usage/files/#read_meta
