### PR TITLE
Fix EZP-20988: Stale links using non-translatable attribute

### DIFF
--- a/kernel/classes/datatypes/ezurl/ezurlobjectlink.php
+++ b/kernel/classes/datatypes/ezurl/ezurlobjectlink.php
@@ -167,15 +167,9 @@ class eZURLObjectLink extends eZPersistentObject
     static function fetchLinkList( $contentObjectAttributeID, $contentObjectAttributeVersion, $asObject = true )
     {
         $linkList = array();
-        $conditions = array( 'contentobject_attribute_id' => $contentObjectAttributeID );
-        if ( $contentObjectAttributeVersion !== false )
-            $conditions['contentobject_attribute_version'] = $contentObjectAttributeVersion;
-        $urlObjectLinkList = eZPersistentObject::fetchObjectList( eZURLObjectLink::definition(),
-                                                                   null,
-                                                                   $conditions,
-                                                                   null,
-                                                                   null,
-                                                                   $asObject );
+
+        $urlObjectLinkList = self::fetchLinkObjectList( $contentObjectAttributeID, $contentObjectAttributeVersion, $asObject );
+
         foreach ( $urlObjectLinkList as $urlObjectLink )
         {
             if ( $asObject )
@@ -190,6 +184,34 @@ class eZURLObjectLink extends eZPersistentObject
             }
         }
         return $linkList;
+    }
+
+    /**
+     * Fetches an array of eZURLObjectLink
+     *
+     * @param $contentObjectAttributeID
+     * @param $contentObjectAttributeVersion : if all links object for all versions are returned
+     * @param bool $asObject
+     *
+     * @return array|eZURLObjectLink[]|null
+     */
+    static public function fetchLinkObjectList( $contentObjectAttributeID, $contentObjectAttributeVersion, $asObject = true )
+    {
+        $conditions = array( 'contentobject_attribute_id' => $contentObjectAttributeID );
+
+        if ( $contentObjectAttributeVersion !== false )
+        {
+            $conditions['contentobject_attribute_version'] = $contentObjectAttributeVersion;
+        }
+
+        return eZPersistentObject::fetchObjectList(
+            eZURLObjectLink::definition(),
+            null,
+            $conditions,
+            null,
+            null,
+            $asObject
+        );
     }
 
     /*!


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-20988
# Description

During the version creation process the poststore method is called several times. We need to make sure only the last record is present to avoid duplicate (and stale) elements. Since we can't update the record (no primary key in this table), we clear it and write a new one.
# Test

Manual test creating content and then checking records in database.
