### PR TITLE
Fix EZP-21467: PHP Notice in ezurlaliasquery.php

### DIFF
--- a/kernel/classes/ezurlaliasquery.php
+++ b/kernel/classes/ezurlaliasquery.php
@@ -101,9 +101,7 @@ class eZURLAliasQuery
 
     function hasAttribute( $name )
     {
-        return in_array( $name,
-                         array_diff( get_object_vars( $this ),
-                                     array( 'query' ) ) );
+        return $name !== "query" && array_key_exists( $name, get_object_vars( $this ) );
     }
 
     function attribute( $name )


### PR DESCRIPTION
`array_diff()` in `eZURLAliasQuery::hasAttribute()` throws an E_NOTICE when used on a nested array. 

`array_diff_assoc()` fixes this.

Cheers
:octocat: Jérôme
