### PR TITLE
Fixed: EZP-21411: eZOracle: Link management doesn't show Objects using URL (part 2)

### DIFF
--- a/kernel/classes/ezpersistentobject.php
+++ b/kernel/classes/ezpersistentobject.php
@@ -79,14 +79,14 @@ class eZPersistentObject
         {
             foreach ( $def["fields"] as $key => $item )
             {
-                if ( isset( $item['name'] ) )
-                {
-                    $item = $item['name'];
-                }
-
                 if ( isset( $item['short_name'] ) && $item['short_name'] )
                 {
                     $key = $item['short_name'];
+                }
+
+                if ( isset( $item['name'] ) )
+                {
+                    $item = $item['name'];
                 }
 
                 $this->$item = isset( $row[$key] ) ? $row[$key] : null;


### PR DESCRIPTION
Fix in https://github.com/ezsystems/ezpublish-legacy/pull/728 is incorrect, the `short_name` index should be checked prior the `name` one, otherwise, the `$item` gets replaced and inspecting the `short_name` always fails.
