### PR TITLE
Add "cluster/storeFile" cluster event

### DIFF
--- a/doc/features/4.7/cluster_events.md
+++ b/doc/features/4.7/cluster_events.md
@@ -98,6 +98,9 @@ Try to use constants instead or configuration objects passed to your custom gate
 - `cluster/storeMetadata` - **Notification**.
   The metadata array is passed as argument.
 
+- `cluster/storeFile` - **Notification**.
+  The file path, datatype and scope are passed as arguments.
+
 - `cluster/loadMetadata` - **Filter**.
   File path we need metadata from is passed as argument.
   Must return an the metadata array or false.

--- a/kernel/private/classes/clusterfilehandlers/dfsbackends/mysqli.php
+++ b/kernel/private/classes/clusterfilehandlers/dfsbackends/mysqli.php
@@ -898,7 +898,7 @@ class eZDFSFileHandlerMySQLiBackend implements eZClusterEventNotifier
         $return = $this->_protect( array( $this, '_storeInner' ), $fname,
                          $filePath, $datatype, $scope, $fname );
 
-        $this->eventHandler->notify( 'cluster/deleteFile', array( $filePath ) );
+        $this->eventHandler->notify( 'cluster/storeFile', array( $filePath, $datatype, $scope ) );
 
         return $return;
     }
@@ -1874,6 +1874,7 @@ class eZDFSFileHandlerMySQLiBackend implements eZClusterEventNotifier
             'cluster/storeMetadata',
             'cluster/loadMetadata',
             'cluster/fileExists',
+            'cluster/storeFile',
             'cluster/deleteFile',
             'cluster/deleteByLike',
             'cluster/deleteByDirList',

--- a/kernel/private/classes/clusterfilehandlers/interfaces/ezclustereventlistener.php
+++ b/kernel/private/classes/clusterfilehandlers/interfaces/ezclustereventlistener.php
@@ -104,4 +104,14 @@ interface eZClusterEventListener
      * @return void
      */
     public function deleteByNametrunk( $nametrunk );
+
+    /**
+     * Notifies of a storeFile operation
+     *
+     * @param string $filePath
+     * @param string $datatype
+     * @param string $scope
+     * @return void
+     */
+    public function storeFile( $filePath, $datatype, $scope );
 }


### PR DESCRIPTION
I saw that `cluster/deleteFile` is called in `eZDFSFileHandlerMySQLiBackend::_store()` and thought this couldn't be the intended use.

Then I thought it could be a good idea to introduce a new cluster event that notifies listeners on file creation, as a complement to `cluster/deleteFile`.

So here it is :).

Cheers
:octocat: Jérôme
