### PR TITLE
EZP-21435/21436: Ensure database connection for tests

### DIFF
--- a/tests/toolkit/ezpdatabasesuite.php
+++ b/tests/toolkit/ezpdatabasesuite.php
@@ -58,6 +58,11 @@ class ezpDatabaseTestSuite extends ezpTestSuite
             eZDB::setInstance( $this->sharedFixture );
             self::$isDatabaseSetup = true;
         }
+
+        if ( !( $this->sharedFixture instanceof eZDBInterface ) && eZDB::hasInstance() )
+        {
+            $this->sharedFixture = eZDB::instance();
+        }
     }
 }
 ?>

--- a/tests/toolkit/ezpdatabasetestcase.php
+++ b/tests/toolkit/ezpdatabasetestcase.php
@@ -55,6 +55,11 @@ class ezpDatabaseTestCase extends ezpTestCase
 
             eZDB::setInstance( $this->sharedFixture );
         }
+
+        if ( !( $this->sharedFixture instanceof eZDBInterface ) && eZDB::hasInstance() )
+        {
+            $this->sharedFixture = eZDB::instance();
+        }
     }
 
     protected function tearDown()


### PR DESCRIPTION
The tests for the ezcomments and ezfind extensions fail because `$this->sharedFixture` is not set.

eZ Comments: https://travis-ci.org/jeromegamez/ezpublish-legacy-tests/jobs/10397894#L331
eZ Find: https://travis-ci.org/jeromegamez/ezpublish-legacy-tests/jobs/10397894#L745

When running the eZ Publish tests, the shared fixture has already been set in `ezpDatabaseTestSuite`, so the sharedFixture can be retrieved from there.

https://jira.ez.no/browse/EZP-21435
https://jira.ez.no/browse/EZP-21436

Cheers
:octocat: Jérôme
