### PR TITLE
Fixed EZP-21469: [API] language mask on ezcontentobject incorreclty set

### DIFF
--- a/update/database/mysql/5.2/dbupdate-5.1.0-to-5.2.0.sql
+++ b/update/database/mysql/5.2/dbupdate-5.1.0-to-5.2.0.sql
@@ -61,3 +61,14 @@ TRUNCATE TABLE ezurl_object_link;
 
 INSERT INTO ezurl_object_link SELECT * FROM ezurl_object_link_temp;
 -- End ezp-21465
+
+-- Start EZP-21469
+-- While using the public API, ezcontentobject.language_mask was not updated correctly,
+-- the UPDATE statement below fixes that based on the language_mask of the current version.
+UPDATE
+    ezcontentobject AS o
+INNER JOIN
+    ezcontentobject_version AS v ON o.id = v.contentobject_id AND o.current_version = v.version
+SET
+    o.language_mask = (o.language_mask & 1) | (v.language_mask & ~1);
+-- End EZP-21469

--- a/update/database/postgresql/5.2/dbupdate-5.1.0-to-5.2.0.sql
+++ b/update/database/postgresql/5.2/dbupdate-5.1.0-to-5.2.0.sql
@@ -52,3 +52,16 @@ WHERE T1.url_id < ANY (SELECT url_id
       AND T1.contentobject_attribute_id = T2.contentobject_attribute_id
       AND T1.contentobject_attribute_version = T2.contentobject_attribute_version);
 -- End ezp-21465
+
+-- Start EZP-21469
+-- While using the public API, ezcontentobject.language_mask was not updated correctly,
+-- the UPDATE statement below fixes that based on the language_mask of the current version.
+UPDATE
+    ezcontentobject AS o
+SET
+    language_mask = (o.language_mask & 1) | (v.language_mask & ~1)
+FROM
+    ezcontentobject_version AS v
+WHERE
+    o.id = v.contentobject_id AND o.current_version = v.version;
+-- End EZP-21469


### PR DESCRIPTION
The `ezcontentobject.language_mask` was not updated correctly when creating content in a new language. This has been solved in https://jira.ez.no/browse/EZP-20018 but fixing the data was not part of it.

This PR proposes to fix that while upgrading to 5.2, as part of the SQL upgrade script.

It works by aggregating all ezcontentobject_version.language_mask by contentobject_id, thanks to the `BIT_OR()` SQL aggregate function, which is then combined (OR) with the "always available flag" which is stored in the 1st bit of ezcontentobject.language_mask.
- [x] Testing what `ezcontentobject.language_mask` looks like with a draft from a new language not yet published. We might want to take into account the status (published).
