### PR TITLE
Fix EZP-21471: JS error on versionview of unpublished object.

### DIFF
--- a/design/admin/templates/content/view/versionview.tpl
+++ b/design/admin/templates/content/view/versionview.tpl
@@ -147,7 +147,8 @@
 
 {* DESIGN: Header START *}<div class="box-header"><div class="box-ml">
 
-<h1 class="context-title"><a href={concat( '/class/view/', $object.contentclass_id )|ezurl} onclick="ezpopmenu_showTopLevel( event, 'ClassMenu', ez_createAArray( new Array( '%classID%', {$object.contentclass_id},'%objectID%',{$object.id},'%nodeID%',{$node.node_id},'%currentURL%','{$node.url|wash( javascript )}')), '{$object.content_class.name|wash(javascript)}', ['class-createnodefeed', 'class-removenodefeed'] ); return false;">{$object.content_class.identifier|class_icon( normal, $node.class_name )}</a>&nbsp;{$object.name|wash}&nbsp;[{$object.content_class.name|wash}]</h1>
+<h1 class="context-title"><a href={concat( '/class/view/', $object.contentclass_id )|ezurl} onclick="ezpopmenu_showTopLevel( event, 'ClassMenu', ez_createAArray( new Array( '%classID%', {$object.contentclass_id},'%objectID%',{$object.id}, '%nodeID%', {if $node.node_id}{$node.node_id}{else}null{/if}, '%currentURL%','{$node.url|wash( javascript )}')), '{$object.content_class.name|wash(javascript)}', ['class-createnodefeed', 'class-removenodefeed' {if $node.node_id|is_null()}, 'class-history', 'url-alias'{/if}] ); return false;">{$object.content_class.identifier|class_icon( normal, $node.class_name )}</a>&nbsp;{$object.name|wash}&nbsp;[{$object.content_class.name|wash}]</h1>
+
 
 {* DESIGN: Mainline *}<div class="header-mainline"></div>
 

--- a/design/admin/templates/popupmenu/popup_class_menu.tpl
+++ b/design/admin/templates/popupmenu/popup_class_menu.tpl
@@ -13,7 +13,11 @@ menuArray['ClassMenu']['elements']['class-removenodefeed'] = {ldelim} 'url': {"/
 menuArray['ClassMenu']['elements']['class-removenodefeed']['disabled_class'] = 'menu-item-disabled';
 menuArray['ClassMenu']['elements']['class-removenodefeed']['disabled_for'] = {ldelim} 'class-removenodefeed': 'yes' {rdelim};
 menuArray['ClassMenu']['elements']['class-history'] = {ldelim} 'url': {"content/history/%objectID%"|ezurl} {rdelim};
+menuArray['ClassMenu']['elements']['class-history']['disabled_class'] = 'menu-item-disabled';
+menuArray['ClassMenu']['elements']['class-history']['disabled_for'] = {ldelim} 'class-history': 'yes' {rdelim};
 menuArray['ClassMenu']['elements']['url-alias'] = {ldelim} 'url': {"content/urlalias/%nodeID%"|ezurl} {rdelim};
+menuArray['ClassMenu']['elements']['url-alias']['disabled_class'] = 'menu-item-disabled';
+menuArray['ClassMenu']['elements']['url-alias']['disabled_for'] = {ldelim} 'url-alias': 'yes' {rdelim};
 </script>
 
 <div class="popupmenu" id="ClassMenu">


### PR DESCRIPTION
JIRA Issue: https://jira.ez.no/browse/EZP-21471

When previewing an unpublished object, a NodeID does not yet exist, which caused the parameter array for the  'class' popup menu to be incorrectly created, resulting in a JavaScript error.

This fixes the issue by making sure a valid parameters array is used, using a `null` value if there is no NodeID yet.
In this case, it also disables the menu options 'Manage Versions' and 'Manage URL Aliases', as they are not applicable to the object being created.
