### PR TITLE
Fix EZP-21477: URL wildcards with leading slash are not matched

### DIFF
--- a/kernel/content/urlalias_wildcard.php
+++ b/kernel/content/urlalias_wildcard.php
@@ -6,6 +6,7 @@
  * @package kernel
  */
 
+/** @var eZModule $Module */
 $Module =& $Params['Module'];
 $http = eZHTTPTool::instance();
 
@@ -48,6 +49,7 @@ else if ( $Module->isCurrentAction( 'RemoveWildcard' ) )
 else if ( $Module->isCurrentAction( 'NewWildcard' ) )
 {
     $wildcardSrcText = trim( $Module->actionParameter( 'WildcardSourceText' ) );
+    $wildcardSrcText = ltrim( $wildcardSrcText, '/' );
     $wildcardDstText = trim( $Module->actionParameter( 'WildcardDestinationText' ) );
     $wildcardType = $http->hasPostVariable( 'WildcardType' ) && strlen( trim( $http->postVariable( 'WildcardType' ) ) ) > 0;
 
@@ -103,6 +105,7 @@ $limitList = array( array( 'id'    => 1,
                     array( 'id'    => 4,
                            'value' => 100 ) );
 $limitID = eZPreferences::value( 'admin_urlwildcard_list_limit' );
+$limitValues = array();
 foreach ( $limitList as $limitEntry )
 {
     $limitIDs[]                     = $limitEntry['id'];


### PR DESCRIPTION
At /content/urlwildcards, when the user creates an URL wildcard alias starting with a slash, it will not get matched.

I think the easiest solution would be to trim leading slashes from the wildcard when the user enters it, so here it is.

While at it, I also added a `/** @var eZModule $Module */` at the top of the file to satisfy IDEs and fixed a possible E_NOTICE for a possibly undefined `$limitValues` variable and a missing index. PHPStorm code inspection rules :).

https://jira.ez.no/browse/EZP-21477

Cheers
:octocat: Jérôme