### PR TITLE
Implement EZP-21493: content fetch keyword filtered by subtree

### DIFF
--- a/kernel/content/ezcontentfunctioncollection.php
+++ b/kernel/content/ezcontentfunctioncollection.php
@@ -782,7 +782,8 @@ class eZContentFunctionCollection
                                 $owner = false,
                                 $parentNodeID = false,
                                 $includeDuplicates = true,
-                                $strictMatching = false )
+                                $strictMatching = false,
+                                $depth = 1 )
     {
         $classIDArray = array();
         if ( is_numeric( $classid ) )
@@ -804,7 +805,16 @@ class eZContentFunctionCollection
         $alphabet = $db->escapeString( $alphabet );
 
         $sqlOwnerString = is_numeric( $owner ) ? "AND ezcontentobject.owner_id = '$owner'" : '';
-        $parentNodeIDString = is_numeric( $parentNodeID ) ? "AND ezcontentobject_tree.parent_node_id = '$parentNodeID'" : '';
+        $parentNodeIDString = '';
+        if ( is_numeric( $parentNodeID ) )
+        {
+            $notEqParentString  = '';
+            // If the node(s) doesn't exist we return null.
+            if ( !eZContentObjectTreeNode::createPathConditionAndNotEqParentSQLStrings( $parentNodeIDString, $notEqParentString, $parentNodeID, $depth ) )
+            {
+                return null;
+            }
+        }
 
         $sqlClassIDs = '';
         if ( $classIDArray != null )
@@ -835,12 +845,13 @@ class eZContentFunctionCollection
                       INNER JOIN ezcontentobject_tree ON (ezcontentobject_tree.contentobject_id = ezcontentobject.id)
                       INNER JOIN ezcontentclass ON (ezcontentclass.id = ezcontentobject.contentclass_id)
                        $sqlPermissionChecking[from]
-                  WHERE $sqlMatching
+                  WHERE 
+                  $parentNodeIDString
+                  $sqlMatching
                   $showInvisibleNodesCond
                   $sqlPermissionChecking[where]
                   $sqlClassIDs
                   $sqlOwnerString
-                  $parentNodeIDString
                   AND ezcontentclass.version = 0
                   AND ezcontentobject.status = " . eZContentObject::STATUS_PUBLISHED . "
                   AND ezcontentobject_tree.main_node_id = ezcontentobject_tree.node_id";
@@ -870,7 +881,8 @@ class eZContentFunctionCollection
                            $sortBy = array(),
                            $parentNodeID = false,
                            $includeDuplicates = true,
-                           $strictMatching = false )
+                           $strictMatching = false,
+                           $depth = 1 )
     {
         $classIDArray = array();
         if ( is_numeric( $classid ) )
@@ -974,7 +986,16 @@ class eZContentFunctionCollection
         }
 
         $sqlOwnerString = is_numeric( $owner ) ? "AND ezcontentobject.owner_id = '$owner'" : '';
-        $parentNodeIDString = is_numeric( $parentNodeID ) ? "AND ezcontentobject_tree.parent_node_id = '$parentNodeID'" : '';
+        $parentNodeIDString = '';
+        if ( is_numeric( $parentNodeID ) )
+        {
+            $notEqParentString  = '';
+            // If the node(s) doesn't exist we return null.
+            if ( !eZContentObjectTreeNode::createPathConditionAndNotEqParentSQLStrings( $parentNodeIDString, $notEqParentString, $parentNodeID, $depth ) )
+            {
+                return null;
+            }
+        }
 
         $sqlClassIDString = '';
         if ( is_array( $classIDArray ) and count( $classIDArray ) )
@@ -1000,12 +1021,12 @@ class eZContentFunctionCollection
                        $sortingInfo[attributeFromSQL]
                        $sqlPermissionChecking[from]
                   WHERE
+                  $parentNodeIDString
                   $sqlMatching
                   $showInvisibleNodesCond
                   $sqlPermissionChecking[where]
                   $sqlClassIDString
                   $sqlOwnerString
-                  $parentNodeIDString
                   AND ezcontentclass.version = 0
                   AND ezcontentobject.status = ".eZContentObject::STATUS_PUBLISHED."
                   AND ezcontentobject_tree.main_node_id = ezcontentobject_tree.node_id

--- a/kernel/content/function_definition.php
+++ b/kernel/content/function_definition.php
@@ -942,14 +942,18 @@ $FunctionList['keyword'] = array( 'name' => 'keyword',
                                                                 'type' => 'integer',
                                                                 'required' => false,
                                                                 'default' => false ),
-                                                        array( 'name' => 'include_duplicates',
+                                                         array( 'name' => 'include_duplicates',
                                                                 'type' => 'bool',
                                                                 'required' => false,
                                                                 'default' => true ),
                                                          array( 'name' => 'strict_matching',
-                                                                 'type' => 'bool',
-                                                                 'required' => false,
-                                                                 'default' => false ) ) );
+                                                                'type' => 'bool',
+                                                                'required' => false,
+                                                                'default' => false ),
+                                                         array( 'name' => 'depth',
+                                                                'type' => 'integer',
+                                                                'required' => false,
+                                                                'default' => 1 ) ) );
 
 
 $FunctionList['keyword_count'] = array( 'name' => 'keyword_count',
@@ -979,7 +983,11 @@ $FunctionList['keyword_count'] = array( 'name' => 'keyword_count',
                                                                array( 'name' => 'strict_matching',
                                                                       'type' => 'bool',
                                                                       'required' => false,
-                                                                      'default' => false ) ) );
+                                                                      'default' => false ),
+                                                               array( 'name' => 'depth',
+                                                                      'type' => 'integer',
+                                                                      'required' => false,
+                                                                      'default' => 1 ) ) );
 
 $FunctionList['access'] = array( 'name' => 'access',
                                  'operation_types' => array( 'read' ),

--- a/tests/tests/kernel/classes/ezcontentfunctioncollection_test.php
+++ b/tests/tests/kernel/classes/ezcontentfunctioncollection_test.php
@@ -6,6 +6,7 @@
  * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
  * @version //autogentag//
  * @package tests
+ * @group ezpDatabaseTestCase
  */
 
 class eZContentFunctionCollectionTest extends ezpDatabaseTestCase
@@ -140,7 +141,7 @@ class eZContentFunctionCollectionTest extends ezpDatabaseTestCase
         $object->publish();
 
         // fetch count for prefix 'k' on class 1
-        foreach( array( $class1ID, $class2ID ) as $contentClassID )
+        foreach ( array( $class1ID, $class2ID ) as $contentClassID )
         {
             $count = eZContentFunctionCollection::fetchKeywordCount( 'k', $contentClassID );
             $this->assertInternalType( 'array', $count );
@@ -153,6 +154,85 @@ class eZContentFunctionCollectionTest extends ezpDatabaseTestCase
         $this->assertInternalType( 'array', $count );
         $this->assertArrayHasKey( 'result', $count );
         $this->assertEquals( 6, $count['result'] );
+
+        
+     
+        // Create placeholder folders for objects
+        $folder1 = new ezpObject( 'folder', 2 );
+        $folder1->title = __FUNCTION__ . ' A';
+        $folder1->publish();
+
+        $folder2 = new ezpObject( 'folder', 2 );
+        $folder2->title = __FUNCTION__ . ' B';
+        $folder2->publish();
+
+        $folder3 = new ezpObject( 'folder', $folder1->mainNode->node_id );
+        $folder3->title = __FUNCTION__ . ' A';
+        $folder3->publish();
+
+        
+        // Create an objects to test function
+        $object0 = new ezpObject( $class1Identifier, 2 );
+        $object0->title = __FUNCTION__ . ' A ';
+        $object0->keywords = "keyword7";
+        $object0->publish();
+        
+        $object1 = new ezpObject( $class1Identifier, $folder1->mainNode->node_id );
+        $object1->title = __FUNCTION__ . ' A ';
+        $object1->keywords = "keyword7";
+        $object1->publish();
+        
+        $object2 = new ezpObject( $class1Identifier, $folder2->mainNode->node_id );
+        $object2->title = __FUNCTION__ . ' C ';
+        $object2->keywords = "keyword7";
+        $object2->publish();
+        
+        $object3 = new ezpObject( $class1Identifier, $folder3->mainNode->node_id );
+        $object3->title = __FUNCTION__ . ' D ';
+        $object3->keywords = "keyword7";
+        $object3->publish();
+        
+        // Fetch keyword count for class 1, not specifying parent node
+        $count = eZContentFunctionCollection::fetchKeywordCount( 'keyword7', $class1ID );
+        $this->assertInternalType( 'array', $count );
+        $this->assertArrayHasKey( 'result', $count );
+        $this->assertEquals( 4, $count['result'] );
+        
+        // Fetch keyword count for class 1, directly below parentNodeId (rootNode)
+        $count = eZContentFunctionCollection::fetchKeywordCount( 'keyword7', $class1ID, false, 2 );
+        $this->assertInternalType( 'array', $count );
+        $this->assertArrayHasKey( 'result', $count );
+        $this->assertEquals( 1, $count['result'] );
+        
+        // Fetch keyword count for class 1, directly below parentNodeId (specific folder)
+        $count = eZContentFunctionCollection::fetchKeywordCount( 'keyword7', $class1ID, false, $folder1->mainNode->node_id );
+        $this->assertInternalType( 'array', $count );
+        $this->assertArrayHasKey( 'result', $count );
+        $this->assertEquals( 1, $count['result'] );
+        
+        // Fetch keyword count for class 1, from root folder, with depth equal to 2
+        $count = eZContentFunctionCollection::fetchKeywordCount( 'keyword7', $class1ID, false, 2, true, false, 2 );
+        $this->assertInternalType( 'array', $count );
+        $this->assertArrayHasKey( 'result', $count );
+        $this->assertEquals( 3, $count['result'] );
+        
+        // Fetch keyword count for class 1, from sepecific node, with depth equal to 2
+        $count = eZContentFunctionCollection::fetchKeywordCount( 'keyword7', $class1ID, false, $folder1->mainNode->node_id, true, false, 2 );
+        $this->assertInternalType( 'array', $count );
+        $this->assertArrayHasKey( 'result', $count );
+        $this->assertEquals( 2, $count['result'] );
+        
+        // Fetch keyword count for class 1, from root folder, with depth equal to 0 (unlimited)
+        $count = eZContentFunctionCollection::fetchKeywordCount( 'keyword7', $class1ID, false, 2, true, false, 0 );
+        $this->assertInternalType( 'array', $count );
+        $this->assertArrayHasKey( 'result', $count );
+        $this->assertEquals( 4, $count['result'] );
+        
+        // Fetch keyword count for class 1, from specific folder, with depth equal to 0 (unlimited)
+        $count = eZContentFunctionCollection::fetchKeywordCount( 'keyword7', $class1ID, false, $folder1->mainNode->node_id, true, false, 0 );
+        $this->assertInternalType( 'array', $count );
+        $this->assertArrayHasKey( 'result', $count );
+        $this->assertEquals( 2, $count['result'] );
     }
 
     /**
@@ -169,20 +249,153 @@ class eZContentFunctionCollectionTest extends ezpDatabaseTestCase
         $class1->store();
         $class1ID = $class1->class->attribute( 'id' );
 
-        // Create an instance of each of these classes with attributes
-        $object = new ezpObject( $class1Identifier, 2 );
-        $object->title = __FUNCTION__;
-        $object->keywords = "keyword1, keyword2, keyword3";
-        $object->publish();
+        // Create placeholder folders for objects
+        $folder1 = new ezpObject( 'folder', 2 );
+        $folder1->title = __FUNCTION__ . ' A';
+        $folder1->publish();
 
-        // Fetch keywords for class 1
+        $folder2 = new ezpObject( 'folder', 2 );
+        $folder2->title = __FUNCTION__ . ' B';
+        $folder2->publish();
+
+        $folder3 = new ezpObject( 'folder', $folder1->mainNode->node_id );
+        $folder3->title = __FUNCTION__ . ' A';
+        $folder3->publish();
+
+        // Create an objects to test function
+        $object0 = new ezpObject( $class1Identifier, 2 );
+        $object0->title = __FUNCTION__ . ' A ';
+        $object0->keywords = "keyword1, keyword2, keyword3";
+        $object0->publish();
+        
+        $object1 = new ezpObject( $class1Identifier, $folder1->mainNode->node_id );
+        $object1->title = __FUNCTION__ . ' A ';
+        $object1->keywords = "keyword1, keyword2, keyword3";
+        $object1->publish();
+        
+        $object2 = new ezpObject( $class1Identifier, $folder2->mainNode->node_id );
+        $object2->title = __FUNCTION__ . ' C ';
+        $object2->keywords = "keyword1, keyword2, keyword3";
+        $object2->publish();
+        
+        $object3 = new ezpObject( $class1Identifier, $folder3->mainNode->node_id );
+        $object3->title = __FUNCTION__ . ' D ';
+        $object3->keywords = "keyword1, keyword2, keyword3";
+        $object3->publish();
+        
+        // Fetch keywords for class 1, on all scope
         $keywords = eZContentFunctionCollection::fetchKeyword(
             'k', $class1ID, 0, 20 );
         $this->assertInternalType( 'array', $keywords );
         $this->assertArrayHasKey( 'result', $keywords );
         $this->assertInternalType( 'array', $keywords['result'] );
+        $this->assertEquals( 12, count( $keywords['result'] ) );
+        foreach ( $keywords['result'] as $result )
+        {
+            $this->assertInternalType( 'array', $result );
+            $this->assertArrayHasKey( 'keyword', $result );
+            $this->assertArrayHasKey( 'link_object', $result );
+            $this->assertInstanceOf( 'eZContentObjectTreeNode', $result['link_object'] );
+        }
+        
+        // Fetch keyword1 for class 1, not specifying parent node
+        $keywords = eZContentFunctionCollection::fetchKeyword(
+            'keyword1', $class1ID, 0, 20 );
+        $this->assertInternalType( 'array', $keywords );
+        $this->assertArrayHasKey( 'result', $keywords );
+        $this->assertInternalType( 'array', $keywords['result'] );
+        $this->assertEquals( 4, count( $keywords['result'] ) );
+        foreach ( $keywords['result'] as $result )
+        {
+            $this->assertInternalType( 'array', $result );
+            $this->assertArrayHasKey( 'keyword', $result );
+            $this->assertArrayHasKey( 'link_object', $result );
+            $this->assertInstanceOf( 'eZContentObjectTreeNode', $result['link_object'] );
+        }
+        
+        // Fetch keyword1 for class 1, directly below parentNodeId (rootNode)
+        $keywords = eZContentFunctionCollection::fetchKeyword(
+            'keyword1', $class1ID, 0, 20, false, array(), 2 );
+        $this->assertInternalType( 'array', $keywords );
+        $this->assertArrayHasKey( 'result', $keywords );
+        $this->assertInternalType( 'array', $keywords['result'] );
+        $this->assertEquals( 1, count( $keywords['result'] ) );
+        foreach ( $keywords['result'] as $result )
+        {
+            $this->assertInternalType( 'array', $result );
+            $this->assertArrayHasKey( 'keyword', $result );
+            $this->assertArrayHasKey( 'link_object', $result );
+            $this->assertInstanceOf( 'eZContentObjectTreeNode', $result['link_object'] );
+        }
+        
+        // Fetch keywords for class 1, directly below parentNodeId (specific folder)
+        $keywords = eZContentFunctionCollection::fetchKeyword(
+            'keyword1', $class1ID, 0, 20, false, array(), $folder1->mainNode->node_id );
+        $this->assertInternalType( 'array', $keywords );
+        $this->assertArrayHasKey( 'result', $keywords );
+        $this->assertInternalType( 'array', $keywords['result'] );
+        $this->assertEquals( 1, count( $keywords['result'] ) );
+        foreach ( $keywords['result'] as $result )
+        {
+            $this->assertInternalType( 'array', $result );
+            $this->assertArrayHasKey( 'keyword', $result );
+            $this->assertArrayHasKey( 'link_object', $result );
+            $this->assertInstanceOf( 'eZContentObjectTreeNode', $result['link_object'] );
+        }
+        
+        // Fetch keywords for class 1, from root folder, with depth equal to 2
+        $keywords = eZContentFunctionCollection::fetchKeyword(
+            'keyword1', $class1ID, 0, 20, false, array(), 2, true, false, 2 );
+        $this->assertInternalType( 'array', $keywords );
+        $this->assertArrayHasKey( 'result', $keywords );
+        $this->assertInternalType( 'array', $keywords['result'] );
         $this->assertEquals( 3, count( $keywords['result'] ) );
-        foreach( $keywords['result'] as $result )
+        foreach ( $keywords['result'] as $result )
+        {
+            $this->assertInternalType( 'array', $result );
+            $this->assertArrayHasKey( 'keyword', $result );
+            $this->assertArrayHasKey( 'link_object', $result );
+            $this->assertInstanceOf( 'eZContentObjectTreeNode', $result['link_object'] );
+        }
+
+        // Fetch keywords for class 1, from sepecific node, with depth equal to 2
+        $keywords = eZContentFunctionCollection::fetchKeyword(
+            'keyword1', $class1ID, 0, 20, false, array(), $folder1->mainNode->node_id, true, false, 2 );
+        $this->assertInternalType( 'array', $keywords );
+        $this->assertArrayHasKey( 'result', $keywords );
+        $this->assertInternalType( 'array', $keywords['result'] );
+        $this->assertEquals( 2, count( $keywords['result'] ) );
+        foreach ( $keywords['result'] as $result )
+        {
+            $this->assertInternalType( 'array', $result );
+            $this->assertArrayHasKey( 'keyword', $result );
+            $this->assertArrayHasKey( 'link_object', $result );
+            $this->assertInstanceOf( 'eZContentObjectTreeNode', $result['link_object'] );
+        }
+        
+        // Fetch keywords for class 1, from root folder, with depth equal to 0 (unlimited)
+        $keywords = eZContentFunctionCollection::fetchKeyword(
+            'keyword1', $class1ID, 0, 20, false, array(), 2, true, false, 0 );
+        $this->assertInternalType( 'array', $keywords );
+        $this->assertArrayHasKey( 'result', $keywords );
+        $this->assertInternalType( 'array', $keywords['result'] );
+        $this->assertEquals( 4, count( $keywords['result'] ) );
+        foreach ( $keywords['result'] as $result )
+        {
+            $this->assertInternalType( 'array', $result );
+            $this->assertArrayHasKey( 'keyword', $result );
+            $this->assertArrayHasKey( 'link_object', $result );
+            $this->assertInstanceOf( 'eZContentObjectTreeNode', $result['link_object'] );
+        }
+
+        // Fetch keywords for class 1, from specific folder, with depth equal to 0 (unlimited)
+        $keywords = eZContentFunctionCollection::fetchKeyword(
+            'keyword1', $class1ID, 0, 20, false, array(), $folder1->mainNode->node_id, true, false, 0 );
+        $this->assertInternalType( 'array', $keywords );
+        $this->assertArrayHasKey( 'result', $keywords );
+        $this->assertInternalType( 'array', $keywords['result'] );
+        $this->assertEquals( 2, count( $keywords['result'] ) );
+        foreach ( $keywords['result'] as $result )
         {
             $this->assertInternalType( 'array', $result );
             $this->assertArrayHasKey( 'keyword', $result );


### PR DESCRIPTION
As a developer, I would like to be able to fetch **keyword** and **keyword_count**, using the parent_node_id / depth parameter combination to limit the results.

Right now, the only limitation implemented is parent_node_id, which behaves as it does in a content/list function, with depth=1. (If parent_node_id is specified, only it's direct children will be considered, not it's children' children)

The goal is be to be able to use parent_node_id, with depth=0, to retrieve keywords and keyword_count from an whole subtree.
