### PR TITLE
Fix EZP-20601: Permission checking when using object states

### DIFF
--- a/kernel/classes/ezcontentobjecttreenode.php
+++ b/kernel/classes/ezcontentobjecttreenode.php
@@ -1739,10 +1739,14 @@ class eZContentObjectTreeNode extends eZPersistentObject
                                     $stateGroupTable = "ezcobj_state_grp_{$stateIndex}_perm";
                                     $stateAliasTables[$stateIdentifier] = $stateTable;
 
-                                    $sqlPermissionCheckingFrom .=
-                                        " INNER JOIN ezcobj_state_link $stateLinkTable ON ($stateLinkTable.contentobject_id = ezcontentobject.id) " .
-                                        " INNER JOIN ezcobj_state_group $stateGroupTable ON ($stateGroupTable.identifier = '" . $db->escapeString( $stateIdentifier ) . "') " .
-                                        " INNER JOIN ezcobj_state $stateTable ON ($stateTable.id = $stateLinkTable.contentobject_state_id AND $stateTable.group_id = $stateGroupTable.id) ";
+                                    $sqlPermissionCheckingFrom .= ", ezcobj_state_link $stateLinkTable ";
+                                    $sqlPermissionCheckingFrom .= ", ezcobj_state_group $stateGroupTable ";
+                                    $sqlPermissionCheckingFrom .= ", ezcobj_state $stateTable ";
+                                    
+                                    $sqlPermissionCheckingWhere .= "AND $stateLinkTable.contentobject_id = ezcontentobject.id " .
+                                      							                "AND $stateTable.id = $stateLinkTable.contentobject_state_id " .
+                                                                    "AND $stateTable.group_id = $stateGroupTable.id " .
+                                                                    "AND $stateGroupTable.identifier='" . $db->escapeString( $stateIdentifier ) . "' ";
                                 }
 
                                 if ( count( $limitationArray[$ident] ) > 1 )


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-20601

Using object states caused a fatal error in the sql query.
Used the previous query from the 4.6 : http://pubsvn.ez.no/doxygen/4.6.0/html/ezcontentobjecttreenode_8php_source.html#l01633

This is update to PR #477
