### PR TITLE
Implemented EZP-15040: Support for more than 30 languages

### DIFF
--- a/doc/bc/5.2/changes-5.2.txt
+++ b/doc/bc/5.2/changes-5.2.txt
@@ -56,6 +56,11 @@ Removed features
 Removed constants
 -----------------
 
+- eZContentLanguage::MAX_COUNT
+
+  The number of languages supported cannot be hold in a constant anymore, the
+  method eZContentLanguage::maxCount() should be used instead.
+
 
 Removed globals
 ---------------

--- a/kernel/classes/ezcontentlanguage.php
+++ b/kernel/classes/ezcontentlanguage.php
@@ -10,8 +10,6 @@
 
 class eZContentLanguage extends eZPersistentObject
 {
-    const MAX_COUNT = 30;
-
     /**
      * Constructor.
      *
@@ -58,7 +56,7 @@ class eZContentLanguage extends eZPersistentObject
      * \param name Optional. Name of the language. If not specified, the international language name for the $locale locale
      *             will be used.
      * \return eZContentLanguage object of the added language (or the existing one if specified language has been already used)
-     *         or false in case of any error (invalid locale code or already reached eZContentLanguage::MAX_COUNT languages).
+     *         or false in case of any error (invalid locale code or already reached eZContentLanguage::maxCount() languages).
      * \static
      */
     static function addLanguage( $locale, $name = null )
@@ -85,7 +83,7 @@ class eZContentLanguage extends eZPersistentObject
             return $existingLanguage;
         }
 
-        if ( count( $languages ) >= eZContentLanguage::MAX_COUNT )
+        if ( count( $languages ) >= self::maxCount() )
         {
             eZDebug::writeError( 'Too many languages, cannot add more!', __METHOD__ );
             return false;
@@ -599,7 +597,7 @@ class eZContentLanguage extends eZPersistentObject
      */
     public static function decodeLanguageMask( $langMask, $returnLanguageLocale = false )
     {
-        $maxNumberOfLanguges = eZContentLanguage::MAX_COUNT;
+        $maxNumberOfLanguges = self::maxCount();
         $maxInteger = pow( 2, $maxNumberOfLanguges );
 
         $list = array();
@@ -936,6 +934,17 @@ class eZContentLanguage extends eZPersistentObject
         $cachePath = eZSys::cacheDirectory() . '/ezcontentlanguage_cache.php';
         eZClusterFileHandler::instance()->fileDelete( $cachePath );
     }
-}
 
-?>
+    /**
+     * Returns the maximum number of languages supported.
+     *
+     * On 64-bit platforms we support more languages. PHP uses signed integers,
+     * and the first bit is reserved for the "always available" flag,
+     * so we can use 62 bits on 64 bits hardware, or 30 on 32-bit. The database
+     * uses a 64-bit integer on all platforms.
+     */
+    static public function maxCount()
+    {
+        return ( 8 * PHP_INT_SIZE ) - 2;
+    }
+}

--- a/kernel/classes/ezurlaliasquery.php
+++ b/kernel/classes/ezurlaliasquery.php
@@ -317,11 +317,12 @@ class eZURLAliasQuery
         if ( !is_array( $rows ) || count( $rows ) == 0 )
             return array();
         $list = array();
+        $maxNumberOfLanguages = eZContentLanguage::maxCount();
         foreach ( $rows as $row )
         {
             $row['always_available'] = $row['lang_mask'] % 2;
             $mask = $row['lang_mask'] & ~1;
-            for ( $i = 1; $i < 30; ++$i )
+            for ( $i = 1; $i < $maxNumberOfLanguages; ++$i )
             {
                 $newMask = (1 << $i);
                 if ( ($newMask & $mask) > 0 )

--- a/kernel/sql/mysql/kernel_schema.sql
+++ b/kernel/sql/mysql/kernel_schema.sql
@@ -37,11 +37,11 @@ CREATE TABLE ezbinaryfile (
 
 
 CREATE TABLE ezcobj_state (
-  default_language_id int(11) NOT NULL default '0',
+  default_language_id bigint(20) NOT NULL default '0',
   group_id int(11) NOT NULL default '0',
   id int(11) NOT NULL auto_increment,
   identifier varchar(45) NOT NULL default '',
-  language_mask int(11) NOT NULL default '0',
+  language_mask bigint(20) NOT NULL default '0',
   priority int(11) NOT NULL default '0',
   PRIMARY KEY  (id),
   UNIQUE KEY ezcobj_state_identifier (group_id,identifier),
@@ -54,10 +54,10 @@ CREATE TABLE ezcobj_state (
 
 
 CREATE TABLE ezcobj_state_group (
-  default_language_id int(11) NOT NULL default '0',
+  default_language_id bigint(20) NOT NULL default '0',
   id int(11) NOT NULL auto_increment,
   identifier varchar(45) NOT NULL default '',
-  language_mask int(11) NOT NULL default '0',
+  language_mask bigint(20) NOT NULL default '0',
   PRIMARY KEY  (id),
   UNIQUE KEY ezcobj_state_group_identifier (identifier),
   KEY ezcobj_state_group_lmask (language_mask)
@@ -70,8 +70,8 @@ CREATE TABLE ezcobj_state_group (
 CREATE TABLE ezcobj_state_group_language (
   contentobject_state_group_id int(11) NOT NULL default '0',
   description longtext NOT NULL,
-  language_id int(11) NOT NULL default '0',
-  real_language_id int(11) NOT NULL default '0',
+  language_id bigint(20) NOT NULL default '0',
+  real_language_id bigint(20) NOT NULL default '0',
   name varchar(45) NOT NULL default '',
   PRIMARY KEY  (contentobject_state_group_id,real_language_id)
 ) ENGINE=InnoDB;
@@ -83,7 +83,7 @@ CREATE TABLE ezcobj_state_group_language (
 CREATE TABLE ezcobj_state_language (
   contentobject_state_id int(11) NOT NULL default '0',
   description longtext NOT NULL,
-  language_id int(11) NOT NULL default '0',
+  language_id bigint(20) NOT NULL default '0',
   name varchar(45) NOT NULL default '',
   PRIMARY KEY  (contentobject_state_id,language_id)
 ) ENGINE=InnoDB;
@@ -255,7 +255,7 @@ CREATE TABLE ezcollab_simple_message (
 
 CREATE TABLE ezcontent_language (
   disabled int(11) NOT NULL default '0',
-  id int(11) NOT NULL default '0',
+  id bigint(20) NOT NULL default '0',
   locale varchar(20) NOT NULL default '',
   name varchar(255) NOT NULL default '',
   PRIMARY KEY  (id),
@@ -300,9 +300,9 @@ CREATE TABLE ezcontentclass (
   creator_id int(11) NOT NULL default '0',
   id int(11) NOT NULL auto_increment,
   identifier varchar(50) NOT NULL default '',
-  initial_language_id int(11) NOT NULL default '0',
+  initial_language_id bigint(20) NOT NULL default '0',
   is_container int(11) NOT NULL default '0',
-  language_mask int(11) NOT NULL default '0',
+  language_mask bigint(20) NOT NULL default '0',
   modified int(11) NOT NULL default '0',
   modifier_id int(11) NOT NULL default '0',
   remote_id varchar(100) NOT NULL default '',
@@ -371,7 +371,7 @@ CREATE TABLE ezcontentclass_classgroup (
 CREATE TABLE ezcontentclass_name (
   contentclass_id int(11) NOT NULL default '0',
   contentclass_version int(11) NOT NULL default '0',
-  language_id int(11) NOT NULL default '0',
+  language_id bigint(20) NOT NULL default '0',
   language_locale varchar(20) NOT NULL default '',
   name varchar(255) NOT NULL default '',
   PRIMARY KEY  (contentclass_id,contentclass_version,language_id)
@@ -399,8 +399,8 @@ CREATE TABLE ezcontentobject (
   contentclass_id int(11) NOT NULL default '0',
   current_version int(11) default NULL,
   id int(11) NOT NULL auto_increment,
-  initial_language_id int(11) NOT NULL default '0',
-  language_mask int(11) NOT NULL default '0',
+  initial_language_id bigint(20) NOT NULL default '0',
+  language_mask bigint(20) NOT NULL default '0',
   modified int(11) NOT NULL default '0',
   name varchar(255) default NULL,
   owner_id int(11) NOT NULL default '0',
@@ -432,7 +432,7 @@ CREATE TABLE ezcontentobject_attribute (
   data_type_string varchar(50) default '',
   id int(11) NOT NULL auto_increment,
   language_code varchar(20) NOT NULL default '',
-  language_id int(11) NOT NULL default '0',
+  language_id bigint(20) NOT NULL default '0',
   sort_key_int int(11) NOT NULL default '0',
   sort_key_string varchar(255) NOT NULL default '',
   version int(11) NOT NULL default '0',
@@ -467,7 +467,7 @@ CREATE TABLE ezcontentobject_name (
   content_translation varchar(20) NOT NULL default '',
   content_version int(11) NOT NULL default '0',
   contentobject_id int(11) NOT NULL default '0',
-  language_id int(11) NOT NULL default '0',
+  language_id bigint(20) NOT NULL default '0',
   name varchar(255) default NULL,
   real_translation varchar(20) default NULL,
   PRIMARY KEY  (contentobject_id,content_version,content_translation),
@@ -544,8 +544,8 @@ CREATE TABLE ezcontentobject_version (
   created int(11) NOT NULL default '0',
   creator_id int(11) NOT NULL default '0',
   id int(11) NOT NULL auto_increment,
-  initial_language_id int(11) NOT NULL default '0',
-  language_mask int(11) NOT NULL default '0',
+  initial_language_id bigint(20) NOT NULL default '0',
+  language_mask bigint(20) NOT NULL default '0',
   modified int(11) NOT NULL default '0',
   status int(11) NOT NULL default '0',
   user_id int(11) NOT NULL default '0',
@@ -1570,7 +1570,7 @@ CREATE TABLE ezurlalias_ml (
   id int(11) NOT NULL default '0',
   is_alias int(11) NOT NULL default '0',
   is_original int(11) NOT NULL default '0',
-  lang_mask int(11) NOT NULL default '0',
+  lang_mask bigint(20) NOT NULL default '0',
   link int(11) NOT NULL default '0',
   parent int(11) NOT NULL default '0',
   text longtext NOT NULL,

--- a/share/db_schema.dba
+++ b/share/db_schema.dba
@@ -158,8 +158,8 @@ $schema = array (
     array (
       'default_language_id' => 
       array (
-        'length' => 11,
-        'type' => 'int',
+        'length' => 20,
+        'type' => 'bigint',
         'not_null' => '1',
         'default' => 0,
       ),
@@ -184,8 +184,8 @@ $schema = array (
       ),
       'language_mask' => 
       array (
-        'length' => 11,
-        'type' => 'int',
+        'length' => 20,
+        'type' => 'bigint',
         'not_null' => '1',
         'default' => 0,
       ),
@@ -241,8 +241,8 @@ $schema = array (
     array (
       'default_language_id' => 
       array (
-        'length' => 11,
-        'type' => 'int',
+        'length' => 20,
+        'type' => 'bigint',
         'not_null' => '1',
         'default' => 0,
       ),
@@ -260,8 +260,8 @@ $schema = array (
       ),
       'language_mask' => 
       array (
-        'length' => 11,
-        'type' => 'int',
+        'length' => 20,
+        'type' => 'bigint',
         'not_null' => '1',
         'default' => 0,
       ),
@@ -314,8 +314,8 @@ $schema = array (
       ),
       'language_id' => 
       array (
-        'length' => 11,
-        'type' => 'int',
+        'length' => 20,
+        'type' => 'bigint',
         'not_null' => '1',
         'default' => 0,
       ),
@@ -328,8 +328,8 @@ $schema = array (
       ),
       'real_language_id' => 
       array (
-        'length' => 11,
-        'type' => 'int',
+        'length' => 20,
+        'type' => 'bigint',
         'not_null' => '1',
         'default' => 0,
       ),
@@ -367,8 +367,8 @@ $schema = array (
       ),
       'language_id' => 
       array (
-        'length' => 11,
-        'type' => 'int',
+        'length' => 20,
+        'type' => 'bigint',
         'not_null' => '1',
         'default' => 0,
       ),
@@ -1136,8 +1136,8 @@ $schema = array (
       ),
       'id' => 
       array (
-        'length' => 11,
-        'type' => 'int',
+        'length' => 20,
+        'type' => 'bigint',
         'not_null' => '1',
         'default' => 0,
       ),
@@ -1333,8 +1333,8 @@ $schema = array (
       ),
       'initial_language_id' => 
       array (
-        'length' => 11,
-        'type' => 'int',
+        'length' => 20,
+        'type' => 'bigint',
         'not_null' => '1',
         'default' => 0,
       ),
@@ -1347,8 +1347,8 @@ $schema = array (
       ),
       'language_mask' => 
       array (
-        'length' => 11,
-        'type' => 'int',
+        'length' => 20,
+        'type' => 'bigint',
         'not_null' => '1',
         'default' => 0,
       ),
@@ -1699,8 +1699,8 @@ $schema = array (
       ),
       'language_id' => 
       array (
-        'length' => 11,
-        'type' => 'int',
+        'length' => 20,
+        'type' => 'bigint',
         'not_null' => '1',
         'default' => 0,
       ),
@@ -1815,15 +1815,15 @@ $schema = array (
       ),
       'initial_language_id' => 
       array (
-        'length' => 11,
-        'type' => 'int',
+        'length' => 20,
+        'type' => 'bigint',
         'not_null' => '1',
         'default' => 0,
       ),
       'language_mask' => 
       array (
-        'length' => 11,
-        'type' => 'int',
+        'length' => 20,
+        'type' => 'bigint',
         'not_null' => '1',
         'default' => 0,
       ),
@@ -2003,8 +2003,8 @@ $schema = array (
       ),
       'language_id' => 
       array (
-        'length' => 11,
-        'type' => 'int',
+        'length' => 20,
+        'type' => 'bigint',
         'not_null' => '1',
         'default' => 0,
       ),
@@ -2181,8 +2181,8 @@ $schema = array (
       ),
       'language_id' => 
       array (
-        'length' => 11,
-        'type' => 'int',
+        'length' => 20,
+        'type' => 'bigint',
         'not_null' => '1',
         'default' => 0,
       ),
@@ -2607,15 +2607,15 @@ $schema = array (
       ),
       'initial_language_id' => 
       array (
-        'length' => 11,
-        'type' => 'int',
+        'length' => 20,
+        'type' => 'bigint',
         'not_null' => '1',
         'default' => 0,
       ),
       'language_mask' => 
       array (
-        'length' => 11,
-        'type' => 'int',
+        'length' => 20,
+        'type' => 'bigint',
         'not_null' => '1',
         'default' => 0,
       ),
@@ -7096,8 +7096,8 @@ $schema = array (
       ),
       'lang_mask' => 
       array (
-        'length' => 11,
-        'type' => 'int',
+        'length' => 20,
+        'type' => 'bigint',
         'not_null' => '1',
         'default' => 0,
       ),

--- a/update/database/mysql/5.2/dbupdate-5.1.0-to-5.2.0.sql
+++ b/update/database/mysql/5.2/dbupdate-5.1.0-to-5.2.0.sql
@@ -1,3 +1,45 @@
 SET storage_engine=InnoDB;
 UPDATE ezsite_data SET value='5.2.0alpha1' WHERE name='ezpublish-version';
 UPDATE ezsite_data SET value='1' WHERE name='ezpublish-release';
+
+ALTER TABLE ezcontent_language
+    MODIFY id BIGINT NOT NULL DEFAULT '0';
+
+ALTER TABLE ezcontentclass
+    MODIFY initial_language_id BIGINT NOT NULL DEFAULT '0',
+    MODIFY language_mask BIGINT NOT NULL DEFAULT '0';
+
+ALTER TABLE ezcontentclass_name
+    MODIFY language_id BIGINT NOT NULL DEFAULT '0';
+
+ALTER TABLE ezcontentobject
+    MODIFY initial_language_id BIGINT NOT NULL DEFAULT '0',
+    MODIFY language_mask BIGINT NOT NULL DEFAULT '0';
+
+ALTER TABLE ezcontentobject_name
+    MODIFY language_id BIGINT NOT NULL DEFAULT '0';
+
+ALTER TABLE ezcontentobject_attribute
+    MODIFY language_id BIGINT NOT NULL DEFAULT '0';
+
+ALTER TABLE ezcontentobject_version
+    MODIFY initial_language_id BIGINT NOT NULL DEFAULT '0',
+    MODIFY language_mask BIGINT NOT NULL DEFAULT '0';
+
+ALTER TABLE ezcobj_state
+    MODIFY default_language_id BIGINT NOT NULL DEFAULT '0',
+    MODIFY language_mask BIGINT NOT NULL DEFAULT '0';
+
+ALTER TABLE ezcobj_state_group
+    MODIFY default_language_id BIGINT NOT NULL DEFAULT '0',
+    MODIFY language_mask BIGINT NOT NULL DEFAULT '0';
+
+ALTER TABLE ezcobj_state_group_language
+    MODIFY language_id BIGINT NOT NULL DEFAULT '0',
+    MODIFY real_language_id BIGINT NOT NULL DEFAULT '0';
+
+ALTER TABLE ezcobj_state_language
+    MODIFY language_id BIGINT NOT NULL DEFAULT '0';
+
+ALTER TABLE ezurlalias_ml
+    MODIFY lang_mask BIGINT NOT NULL DEFAULT '0';

--- a/update/database/postgresql/5.2/dbupdate-5.1.0-to-5.2.0.sql
+++ b/update/database/postgresql/5.2/dbupdate-5.1.0-to-5.2.0.sql
@@ -1,2 +1,44 @@
 UPDATE ezsite_data SET value='5.2.0alpha1' WHERE name='ezpublish-version';
 UPDATE ezsite_data SET value='1' WHERE name='ezpublish-release';
+
+ALTER TABLE ezcontent_language
+    ALTER COLUMN id TYPE BIGINT;
+
+ALTER TABLE ezcontentclass
+    ALTER COLUMN initial_language_id TYPE BIGINT,
+    ALTER COLUMN language_mask TYPE BIGINT;
+
+ALTER TABLE ezcontentclass_name
+    ALTER COLUMN language_id TYPE BIGINT;
+
+ALTER TABLE ezcontentobject
+    ALTER COLUMN initial_language_id TYPE BIGINT,
+    ALTER COLUMN language_mask TYPE BIGINT;
+
+ALTER TABLE ezcontentobject_name
+    ALTER COLUMN language_id TYPE BIGINT;
+
+ALTER TABLE ezcontentobject_attribute
+    ALTER COLUMN language_id TYPE BIGINT;
+
+ALTER TABLE ezcontentobject_version
+    ALTER COLUMN initial_language_id TYPE BIGINT,
+    ALTER COLUMN language_mask TYPE BIGINT;
+
+ALTER TABLE ezcobj_state
+    ALTER COLUMN default_language_id TYPE BIGINT,
+    ALTER COLUMN language_mask TYPE BIGINT;
+
+ALTER TABLE ezcobj_state_group
+    ALTER COLUMN default_language_id TYPE BIGINT,
+    ALTER COLUMN language_mask TYPE BIGINT;
+
+ALTER TABLE ezcobj_state_group_language
+    ALTER COLUMN language_id TYPE BIGINT,
+    ALTER COLUMN real_language_id TYPE BIGINT;
+
+ALTER TABLE ezcobj_state_language
+    ALTER COLUMN language_id TYPE BIGINT;
+
+ALTER TABLE ezurlalias_ml
+    ALTER COLUMN lang_mask TYPE BIGINT;


### PR DESCRIPTION
Issue: https://jira.ez.no/browse/EZP-15040

Support for more than 30 (up to 62) languages thanks to the **bigint** SQL datatype.

To be reviewed together with: https://github.com/ezsystems/ezpublish-kernel/pull/493

Thank you @glye for the initial patch!
