### PR TITLE
Fix EZP-21465: Cleanup extra lines in the ezurl_object_link table

### DIFF
--- a/update/database/mysql/5.2/dbupdate-5.1.0-to-5.2.0.sql
+++ b/update/database/mysql/5.2/dbupdate-5.1.0-to-5.2.0.sql
@@ -1,3 +1,21 @@
 SET storage_engine=InnoDB;
 UPDATE ezsite_data SET value='5.2.0alpha1' WHERE name='ezpublish-version';
 UPDATE ezsite_data SET value='1' WHERE name='ezpublish-release';
+
+-- Start ezp-21465 : Cleanup extra lines in the ezurl_object_link table
+DROP TEMPORARY TABLE IF EXISTS ezurl_object_link_temp ;
+
+CREATE TEMPORARY TABLE ezurl_object_link_temp (
+   contentobject_attribute_id int(11) NOT NULL DEFAULT '0',
+   contentobject_attribute_version int(11) NOT NULL DEFAULT '0',
+   url_id int(11) NOT NULL DEFAULT '0',
+   KEY ezurl_ol_coa_id (contentobject_attribute_id),
+   KEY ezurl_ol_coa_version (contentobject_attribute_version),
+   KEY ezurl_ol_url_id (url_id),
+   UNIQUE KEY unique_key (contentobject_attribute_id, contentobject_attribute_version)
+) IGNORE SELECT * FROM ezurl_object_link;
+
+TRUNCATE TABLE ezurl_object_link;
+
+INSERT INTO ezurl_object_link SELECT * FROM ezurl_object_link_temp;
+-- End ezp-21465

--- a/update/database/postgresql/5.2/dbupdate-5.1.0-to-5.2.0.sql
+++ b/update/database/postgresql/5.2/dbupdate-5.1.0-to-5.2.0.sql
@@ -1,2 +1,13 @@
 UPDATE ezsite_data SET value='5.2.0alpha1' WHERE name='ezpublish-version';
 UPDATE ezsite_data SET value='1' WHERE name='ezpublish-release';
+
+-- Start ezp-21465 : Cleanup extra lines in the ezurl_object_link table
+DELETE
+FROM ezurl_object_link AS T1
+WHERE T1.url_id < ANY (SELECT url_id
+      FROM ezurl_object_link T2
+      WHERE T1.url_id <> T2.url_id
+      AND T1.contentobject_attribute_id = T2.contentobject_attribute_id
+      AND T1.contentobject_attribute_version = T2.contentobject_attribute_version);
+-- End ezp-21465
+


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-21465
# Description

Stale links were created when using non translatable URLs in ezurl_object_link
Example of corrupted data (first line needs to be deleted): 

| contentobject_attribute_id | contentobject_attribute_version | url_id |
| --- | --- | --- |
| 780 | 8 | 62 |
| 781 | 8 | 63 |
| 780 | 8 | 63 |
# Tests

Manual test on mysql et pgsql

Thanks to @patrickallaert for this version of the mysql script, mine was working but was not as pretty :)
