### PR TITLE
Fix EZP-21465: Cleanup extra lines in the ezurl_object_link table added fix

### DIFF
--- a/update/database/mysql/5.2/dbupdate-5.1.0-to-5.2.0.sql
+++ b/update/database/mysql/5.2/dbupdate-5.1.0-to-5.2.0.sql
@@ -55,7 +55,7 @@ CREATE TEMPORARY TABLE ezurl_object_link_temp (
    KEY ezurl_ol_coa_version (contentobject_attribute_version),
    KEY ezurl_ol_url_id (url_id),
    UNIQUE KEY unique_key (contentobject_attribute_id, contentobject_attribute_version)
-) IGNORE SELECT * FROM ezurl_object_link;
+) IGNORE SELECT * FROM ezurl_object_link ORDER BY url_id DESC;
 
 TRUNCATE TABLE ezurl_object_link;
 


### PR DESCRIPTION
See previous PR: https://github.com/ezsystems/ezpublish-legacy/pull/748

Fixed the request for mysql to ensure that we erase the right line.
