### PR TITLE
Fix EZP-21509: error in clear view cache for subtree.

### DIFF
--- a/kernel/classes/ezcontentobjecttreenode.php
+++ b/kernel/classes/ezcontentobjecttreenode.php
@@ -6160,7 +6160,7 @@ class eZContentObjectTreeNode extends eZPersistentObject
 
             $objectIDList = array();
             foreach ( $subtreeChunk as $curNode )
-                $objectIDList[] = $curNode['contentobject_id'];
+                $objectIDList[] = $curNode['id'];
             unset( $subtreeChunk );
 
             eZContentCacheManager::clearContentCacheIfNeeded( array_unique( $objectIDList ) );

--- a/kernel/content/action.php
+++ b/kernel/content/action.php
@@ -1424,7 +1424,7 @@ else if ( $module->isCurrentAction( 'ClearViewCache' ) or
             $objectIDList = array();
             foreach ( $subtree as $subtreeNode )
             {
-                $objectIDList[] = $subtreeNode['contentobject_id'];
+                $objectIDList[] = $subtreeNode['id'];
             }
             $objectIDList = array_unique( $objectIDList );
             unset( $subtree );


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-21509

Since EZP-18195 (https://github.com/ezsystems/ezpublish-legacy/commit/4652d45ca637239b4aaa8242fef24d7b6e08b7a6), the `contentobject_id` node column has been removed in favor of just `id`.

This fixes an issue with content cache clearing, by updating the column name.
