### PR TITLE
EZP-21471: additional fix for IE 'invalid argument' reading href.

### DIFF
--- a/design/admin/javascript/popupmenu/ezpopupmenu.js
+++ b/design/admin/javascript/popupmenu/ezpopupmenu.js
@@ -323,7 +323,7 @@ function _doItemSubstitution( menuID, menuHeader )
         {
             CurrentDisabledMenusItems[hrefElement.id] = new Array();
             CurrentDisabledMenusItems[hrefElement.id]['className'] = hrefElement.className;
-            CurrentDisabledMenusItems[hrefElement.id]['href'] = hrefElement.href;
+            CurrentDisabledMenusItems[hrefElement.id]['href'] = hrefElement.getAttribute('href');
             CurrentDisabledMenusItems[hrefElement.id]['onmouseover'] = hrefElement.onmouseover;
             CurrentDisabledMenusItems[hrefElement.id]['onclick'] = hrefElement.onclick;
 


### PR DESCRIPTION
JIRA Issue: https://jira.ez.no/browse/EZP-21471

The previous commit https://github.com/ezsystems/ezpublish-legacy/commit/086cca2f6d90ac790ed75a9cac754e43dca21de9 fixed the menu building from the template, and disabled invalid menus for a new object.

However, versions of IE are subject to a bug/behavior that causes an error when reading invalid URIs (such as the ones before `%NodeID%` substitution) from the `href` property.

This fixes the issue by using the `getAttribute()` method instead.
