### PR TITLE
Fixed EZP-21563: fatal error w/ approval wf + ezoe upload

### DIFF
--- a/extension/ezjscore/classes/ezjscajaxcontent.php
+++ b/extension/ezjscore/classes/ezjscajaxcontent.php
@@ -242,7 +242,7 @@ class ezjscAjaxContent
         $ret['owner_id']                	= (int) $contentObject->attribute( 'owner_id' );
         $ret['class_id']                	= (int) $contentObject->attribute( 'contentclass_id' );
         $ret['class_name']              	= $contentObject->attribute( 'class_name' );
-        $ret['path_identification_string'] 	= $node->attribute( 'path_identification_string' );
+        $ret['path_identification_string'] 	= $node ? $node->attribute( 'path_identification_string' ) : '';
         $ret['translations']            	= eZContentLanguage::decodeLanguageMask($contentObject->attribute( 'language_mask' ), true);
         $ret['can_edit']                	= $contentObject->attribute( 'can_edit' );
 

--- a/kernel/classes/ezcontentupload.php
+++ b/kernel/classes/ezcontentupload.php
@@ -696,10 +696,22 @@ class eZContentUpload
         if ( $storeResult['require_storage'] )
             $dataMap[$nameAttribute]->store();
 
+        // Getting the current transaction counter to check if all transactions are committed during content/publish operation (see below)
+        $transactionCounter = $db->transactionCounter();
         $tmpresult = $this->publishObject( $result, $result['errors'], $result['notices'],
                                            $object, $publishVersion, $class, $parentNodes, $parentMainNode );
 
+        // If publication was halted/cancelled (workflow, for instance), the transaction counter may not have reached 0.
+        // If not, operation is probably in STATUS_CANCELLED, STATUS_HALTED, STATUS_REPEAT or STATUS_QUEUED
+        // and final commit was not done as it's part of the operation body (see commit-transaction action in content/publish operation definition).
+        // Important note: Will only be committed transactions that weren't closed during the content/publish operation
+        for ( $i = 0, $transactionDiff = $db->transactionCounter() - $transactionCounter; $i < $transactionDiff; ++$i )
+        {
+            $db->commit();
+        }
+
         $db->commit();
+
         return $tmpresult;
     }
 


### PR DESCRIPTION
Fix for https://jira.ez.no/browse/EZP-21563.

When an approval workflow is in place that affects the media section, a fatal error will occur if an editor tries to upload an image/file from eZOE.

This is a regression from https://jira.ez.no/browse/EZP-19660, where a transaction was added to the publish operation; since publishing doesn't end, the transaction stack is invalid, and this is what causes the fatal error.

With this PR, the unapproved embed can be used during edition. If the embedding object is published, the unapproved embed(s) won't appear in content/view, and will start appearing as soon as the embed content is approved.
