### PR TITLE
Fix EZP-21547: headers not sent for cached errors

### DIFF
--- a/kernel/content/view.php
+++ b/kernel/content/view.php
@@ -174,7 +174,7 @@ else
             false
         );
 
-        return eZClusterFileHandler::instance( $cacheFileArray['cache_path'] )
+        $result = eZClusterFileHandler::instance( $cacheFileArray['cache_path'] )
             ->processCache(
                 array( 'eZNodeviewfunctions', 'contentViewRetrieve' ),
                 array( 'eZNodeviewfunctions', 'contentViewGenerate' ),
@@ -182,6 +182,16 @@ else
                 null,
                 $args
             );
+
+        if ( isset( $result['responseHeaders'] ) )
+        {
+            foreach ( $result['responseHeaders'] as $header )
+            {
+                header( $header );
+            }
+        }
+
+        return $result;
     }
 
     $data = eZNodeviewfunctions::contentViewGenerate( false, $args ); // the false parameter will disable generation of the 'binarydata' entry

--- a/kernel/error/view.php
+++ b/kernel/error/view.php
@@ -75,8 +75,10 @@ $GLOBALS["eZRequestError"] = true;
                     }
                     else
                     {
-                        header( eZSys::serverVariable( 'SERVER_PROTOCOL' ) . " $httpErrorString" );
-                        header( "Status: $httpErrorString" );
+                        $responseHeaders = array(
+                            eZSys::serverVariable( 'SERVER_PROTOCOL' ) . " $httpErrorString",
+                            "Status: $httpErrorString"
+                        );
                     }
                 }
             }
@@ -183,4 +185,5 @@ $Result['path'] = array( array( 'text' => ezpI18n::tr( 'kernel/error', 'Error' )
 $Result['errorCode'] = $httpErrorCode;
 $Result['errorMessage'] = $httpErrorName;
 
-?>
+if ( isset( $responseHeaders ) )
+    $Result['responseHeaders'] = $responseHeaders;


### PR DESCRIPTION
Fixes https://jira.ez.no/browse/EZP-21547.

Maybe not the right way to do it, but it at least highlights what needs to be fixed.
1. Makes sure error headers are stored in cache data (in addition to the error code & message)
2. Sends those headers again when using the cached version
## Testing

Without the patch, if you go to http://ez/Media/ as anonymous user, you get a 401. If you reload, you will get a 200 OK.
With the patch, you will consistently get a 401.
