### PR TITLE
Fix eZURLWildcard: wildcardsIndex is never cached

### DIFF
--- a/kernel/classes/ezurlwildcard.php
+++ b/kernel/classes/ezurlwildcard.php
@@ -429,8 +429,6 @@ class eZURLWildcard extends eZPersistentObject
      * Assign function names to input variables. Generates the wildcard cache if
      * expired.
      *
-     * @param $regexpArrayCallback function to get an array of regexps
-     *
      * @return array The wildcards index, as an array of regexps
      */
     protected static function wildcardsIndex()
@@ -440,16 +438,16 @@ class eZURLWildcard extends eZPersistentObject
             $cacheIndexFile = self::loadCacheFile();
 
             // if NULL is returned, the cache doesn't exist or isn't valid
-            $wildcardsIndex = $cacheIndexFile->processFile( array( __CLASS__, 'fetchCacheFile' ), self::expiryTimestamp() );
-            if ( $wildcardsIndex === null )
+            self::$wildcardsIndex = $cacheIndexFile->processFile( array( __CLASS__, 'fetchCacheFile' ), self::expiryTimestamp() );
+            if ( self::$wildcardsIndex === null )
             {
                 // This will generate and return the index, and store the cache
                 // files for the different wildcards for later use
-                $wildcardsIndex = self::createWildcardsIndex();
+                self::$wildcardsIndex = self::createWildcardsIndex();
             }
         }
 
-        return $wildcardsIndex;
+        return self::$wildcardsIndex;
     }
 
     /**
@@ -462,7 +460,8 @@ class eZURLWildcard extends eZPersistentObject
      *   ...
      *   'wildcard_<md5>_N.php': contains cached wildcards.
      * Each file has info about eZURLWildcard::WILDCARDS_PER_CACHE_FILE wildcards.
-     * @return void
+     *
+     * @return array
      */
     protected static function createWildcardsIndex()
     {


### PR DESCRIPTION
At the moment, the eZUrlWildcards Index is never cached in the class and so fetched from the cache file or recreated on each call.

This patch ensures that the wildcards index is cached in class on first call and stored until `expireCache()` is called. In addition, the PHPDocs of the `wildcardsIndex()` and `createWildcardsIndex()` are matching the method's params and return values.

Cheers
:octocat: Jérôme
