### PR TITLE
Fixed EZP-21324: Images for original object lost when editing copies

### DIFF
--- a/kernel/classes/datatypes/ezimage/ezimagealiashandler.php
+++ b/kernel/classes/datatypes/ezimage/ezimagealiashandler.php
@@ -653,10 +653,10 @@ class eZImageAliasHandler
             return;
         }
         $attributeData = $handler->originalAttributeData();
-        $files = eZImageFile::fetchForContentObjectAttribute( $attributeData['attribute_id'], false );
+
         $dirs = array();
 
-        foreach ( $files as $filepath )
+        foreach ( eZImageFile::fetchRemovableImagesFromObjectAttribute( $attributeData['attribute_id'] ) as $filepath )
         {
             $file = eZClusterFileHandler::instance( $filepath );
             if ( $file->exists() )

--- a/update/database/mysql/5.2/dbupdate-5.1.0-to-5.2.0.sql
+++ b/update/database/mysql/5.2/dbupdate-5.1.0-to-5.2.0.sql
@@ -80,3 +80,17 @@ INNER JOIN
 SET
     o.language_mask = (o.language_mask & 1) | (v.language_mask & ~1);
 -- End EZP-21469
+
+-- Start EZP-21324:
+-- Cleanup extra lines in the ezimagefile table in order to create the unique key:
+DELETE i1
+FROM
+    ezimagefile i1
+INNER JOIN
+    ezimagefile i2 ON i1.contentobject_attribute_id = i2.contentobject_attribute_id AND i1.filepath = i2.filepath
+WHERE
+    i1.id > i2.id;
+
+-- Create the unique key:
+CREATE UNIQUE INDEX ezimagefile_co_attr_id_filepath ON ezimagefile (contentobject_attribute_id, filepath(255));
+-- End EZP-21324

--- a/update/database/postgresql/5.2/dbupdate-5.1.0-to-5.2.0.sql
+++ b/update/database/postgresql/5.2/dbupdate-5.1.0-to-5.2.0.sql
@@ -67,3 +67,16 @@ FROM
 WHERE
     o.id = v.contentobject_id AND o.current_version = v.version;
 -- End EZP-21469
+
+-- Start EZP-21324:
+-- Cleanup extra lines in the ezimagefile table in order to create the unique key:
+DELETE FROM
+    ezimagefile i1
+USING
+    ezimagefile i2
+WHERE
+    i1.contentobject_attribute_id = i2.contentobject_attribute_id AND i1.filepath = i2.filepath AND i1.id > i2.id;
+
+-- Create the unique key:
+CREATE UNIQUE INDEX ezimagefile_co_attr_id_filepath ON ezimagefile USING btree (contentobject_attribute_id, filepath);
+-- End EZP-21324


### PR DESCRIPTION
Issue: https://jira.ez.no/browse/EZP-21324
## Problem 1 (the initially reported one)

When an object (containing a non empty ezimage attribute) and all its versions are removed, the ezimage attribute files are removed without any checks whether those files are still referenced in another copy of that object.
## Problem 2

When a copy of an object (containing a non empty ezimage attribute) is made with all the versions, the `ezimagefile` table only gets the record of the published version, missing the entries for the previous versions.
## Solution

Only files used once are retrieved (thanks to an SQL self-join) and removed.
