### PR TITLE
Fixed EZP-21444: SQL query error in fetch('content',  'keyword') with some 'sort_by' parameters

### DIFF
--- a/kernel/classes/ezcontentobjecttreenode.php
+++ b/kernel/classes/ezcontentobjecttreenode.php
@@ -659,7 +659,7 @@ class eZContentObjectTreeNode extends eZPersistentObject
                             $datatypeWhereSQL = "
                                    $contentAttributeTableAlias.contentobject_id = ezcontentobject.id AND
                                    $contentAttributeTableAlias.contentclassattribute_id = $classAttributeID AND
-                                   $contentAttributeTableAlias.version = ezcontentobject_name.content_version AND";
+                                   $contentAttributeTableAlias.version = ezcontentobject.current_version AND";
                             $datatypeWhereSQL .= eZContentLanguage::sqlFilter( $contentAttributeTableAlias, 'ezcontentobject' );
 
                             $dataType = eZDataType::create( eZContentObjectTreeNode::dataTypeByClassAttributeID( $classAttributeID ) );

--- a/kernel/content/ezcontentfunctioncollection.php
+++ b/kernel/content/ezcontentfunctioncollection.php
@@ -918,12 +918,10 @@ class eZContentFunctionCollection
             {
                 case 'keyword':
                 case 'name':
-                {
                     $sortingString = '';
                     if ( $sortBy[0] == 'name' )
                     {
                         $sortingString = 'ezcontentobject.name';
-                        $sortingInfo['attributeTargetSQL'] = ', ' . $sortingString;
                     }
                     elseif ( $sortBy[0] == 'keyword' )
                     {
@@ -931,7 +929,6 @@ class eZContentFunctionCollection
                             $sortingString = 'ezkeyword.keyword';
                         else
                             $sortingString = 'keyword';
-                        $sortingInfo['attributeTargetSQL'] = '';
                     }
 
                     $sortOrder = true; // true is ascending
@@ -939,24 +936,25 @@ class eZContentFunctionCollection
                         $sortOrder = $sortBy[1];
                     $sortingOrder = $sortOrder ? ' ASC' : ' DESC';
                     $sortingInfo['sortingFields'] = $sortingString . $sortingOrder;
-                } break;
+                    break;
                 default:
-                {
                     $sortingInfo = eZContentObjectTreeNode::createSortingSQLStrings( $sortBy );
+            }
 
-                    if ( $sortBy[0] == 'attribute' )
-                    {
-                        // if sort_by is 'attribute' we should add ezcontentobject_name to "FromSQL" and link to ezcontentobject
-                        $sortingInfo['attributeFromSQL']  .= ' INNER JOIN ezcontentobject_name ON (ezcontentobject_name.contentobject_id = ezcontentobject.id)';
-                        $sqlTarget = 'DISTINCT ezcontentobject_tree.node_id, '.$sqlKeyword;
-                    }
-                    else // for unique declaration
-                    {
-                        $sortByArray = explode( ' ', $sortingInfo['sortingFields'] );
-                        $sortingInfo['attributeTargetSQL'] .= ', ' . $sortByArray[0];
-                    }
-
-                } break;
+            // Fixing the attributeTargetSQL
+            switch ( $sortBy[0] )
+            {
+                case 'keyword':
+                    $sortingInfo['attributeTargetSQL'] = '';
+                    break;
+                case 'name':
+                    $sortingInfo['attributeTargetSQL'] = ', ezcontentobject.name';
+                    break;
+                case 'attribute':
+                case 'class_name':
+                    break;
+                default:
+                    $sortingInfo['attributeTargetSQL'] .= ', ' . strtok( $sortingInfo["sortingFields"], " " );
             }
 
             $sqlTarget .= $sortingInfo['attributeTargetSQL'];


### PR DESCRIPTION
Extends @pedroresende's PR: #726.

Issue: https://jira.ez.no/browse/EZP-21444

Pedro's patch is correct, there is no reason to join `$contentAttributeTableAlias.version` with `ezcontentobject_name.content_version` while `ezcontentobject.current_version` is always around.

The possible problem mentioned by @andrerom on @pedroresende's PR with _sort_by_ set to "name" does not exist. In that case, the `ezcontentobject.name` field is used.

This fix also improves the query a lot by not joining with `ezcontentobject_name` at all with a _sort_by_ based on attribute (as this is the case in default's ezdemo blog template). This join can potentially be very big, depending on the number of languages available.

Tests done:
Using the `fetch('content',  'keyword')` with all possible _sort_by_ parameters.
