### PR TITLE
Fix for EZP-21605: Version history Status column is missing data

### DIFF
--- a/design/admin/templates/content/history.tpl
+++ b/design/admin/templates/content/history.tpl
@@ -90,7 +90,7 @@
     <td><a href={concat( '/content/versionview/', $object.id, '/', $version.version, '/', $initial_language.locale )|ezurl} title="{'View the contents of version #%version_number. Translation: %translation.'|i18n( 'design/admin/content/history',, hash( '%version_number', $version.version, '%translation', $initial_language.name ) )}">{$version.version}</a></td>
 
     {* Status. *}
-    <td>{$version.status|choose( 'Draft'|i18n( 'design/admin/content/history' ), 'Published'|i18n( 'design/admin/content/history' ), 'Pending'|i18n( 'design/admin/content/history' ), 'Archived'|i18n( 'design/admin/content/history' ), 'Rejected'|i18n( 'design/admin/content/history' ), 'Untouched draft'|i18n( 'design/admin/content/history' ) )}</td>
+    <td>{$version.status|choose( 'Draft'|i18n( 'design/admin/content/history' ), 'Published'|i18n( 'design/admin/content/history' ), 'Pending'|i18n( 'design/admin/content/history' ), 'Archived'|i18n( 'design/admin/content/history' ), 'Rejected'|i18n( 'design/admin/content/history' ), 'Untouched draft'|i18n( 'design/admin/content/history' ), 'Repeat'|i18n( 'design/standard/content/history' ), 'Queued'|i18n( 'design/standard/content/history' ) )}</td>
 
     {* Modified translation. *}
     <td>

--- a/design/standard/templates/content/history.tpl
+++ b/design/standard/templates/content/history.tpl
@@ -83,7 +83,7 @@
 	<td><a href={concat( '/content/versionview/', $object.id, '/', $version.version, '/', $initial_language.locale )|ezurl} title="{'View the contents of version #%version_number. Translation: %translation.'|i18n( 'design/standard/content/history',, hash( '%version_number', $version.version, '%translation', $initial_language.name ) )}">{$version.version}</a></td>
 
     {* Status. *}
-	<td>{$version.status|choose( 'Draft'|i18n( 'design/standard/content/history' ), 'Published'|i18n( 'design/standard/content/history' ), 'Pending'|i18n( 'design/standard/content/history' ), 'Archived'|i18n( 'design/standard/content/history' ), 'Rejected'|i18n( 'design/standard/content/history' ), 'Untouched draft'|i18n( 'design/standard/content/history' ) )}</td>
+	<td>{$version.status|choose( 'Draft'|i18n( 'design/standard/content/history' ), 'Published'|i18n( 'design/standard/content/history' ), 'Pending'|i18n( 'design/standard/content/history' ), 'Archived'|i18n( 'design/standard/content/history' ), 'Rejected'|i18n( 'design/standard/content/history' ), 'Untouched draft'|i18n( 'design/standard/content/history' ), 'Repeat'|i18n( 'design/standard/content/history' ), 'Queued'|i18n( 'design/standard/content/history' ) )}</td>
 
     {* Modified translation. *}
 	<td>


### PR DESCRIPTION
Since we have 2 newer object version statuses, the Manage Versions interface should show information about these new statuses.

Link: https://jira.ez.no/browse/EZP-21605