### PR TITLE
Fix EZP-21588: error in copy with split dfs tables

### DIFF
--- a/kernel/private/classes/clusterfilehandlers/dfsbackends/mysqli.php
+++ b/kernel/private/classes/clusterfilehandlers/dfsbackends/mysqli.php
@@ -248,7 +248,7 @@ class eZDFSFileHandlerMySQLiBackend implements eZClusterEventNotifier
         $nameTrunk       = self::nameTrunk( $dstFilePath, $scope );
 
         // Copy file metadata.
-        if ( $this->_insertUpdate( $this->dbTable( $srcFilePath ),
+        if ( $this->_insertUpdate( $this->dbTable( $dstFilePath ),
                                    array( 'datatype'=> $datatype,
                                           'name' => $dstFilePath,
                                           'name_trunk' => $nameTrunk,


### PR DESCRIPTION
http://jira.ez.no/browse/EZP-21588

The `eZDFSFileHandlerMySQLBackend::copyInner()` method was using the source file path to get the table for the destination file.

Tested with eZ Image Editor, with DFS + split tables enabled: editing a file just doesn't work without the patch.
