### PR TITLE
Fix EZP-21611: unpublish cronjob uses anonymous credentials

### DIFF
--- a/cronjobs/unpublish.php
+++ b/cronjobs/unpublish.php
@@ -19,8 +19,13 @@ foreach( $rootNodeIDList as $nodeID )
 {
     $rootNode = eZContentObjectTreeNode::fetch( $nodeID );
 
-    $articleNodeArray = $rootNode->subTree( array( 'ClassFilterType' => 'include',
-                                                    'ClassFilterArray' => $unpublishClasses ) );
+    $articleNodeArray = $rootNode->subTree( 
+        array( 
+            'ClassFilterType' => 'include',
+            'ClassFilterArray' => $unpublishClasses,
+            'Limitation' => array()
+        ) 
+    );
 
     foreach ( $articleNodeArray as $articleNode )
     {


### PR DESCRIPTION
Removed limitation from subTree selection

https://jira.ez.no/browse/EZP-21611
