### PR TITLE
Fix EZP-21627: ImageMagick "Unknown destination file" when php system function is disabled

### DIFF
--- a/lib/ezimage/classes/ezimageshellhandler.php
+++ b/lib/ezimage/classes/ezimageshellhandler.php
@@ -115,6 +115,11 @@ class eZImageShellHandler extends eZImageHandler
         {
             if ( !file_exists( $destinationMimeData['url'] ) )
             {
+                if ( !function_exists( 'system' ) ) 
+                {
+                    eZDebug::writeError( "PHP Warning: system() function has been disabled, you need to re-enable it" );
+                    return false;
+                }
                 eZDebug::writeError( 'Unknown destination file: ' . $destinationMimeData['url'] . " when executing '$systemString'", 'eZImageShellHandler(' . $this->HandlerName . ')' );
                 return false;
             }


### PR DESCRIPTION
If you have system function disabled in php.ini file, for a mather of security you'll get the message Unknown destination file: when you show be informed that the problem is related with the fact that the function has been disabled
