### PR TITLE
Fixed EZP-20813: dfscleanup may delete too much data

### DIFF
--- a/kernel/private/classes/exceptions/cluster/noconnection.php
+++ b/kernel/private/classes/exceptions/cluster/noconnection.php
@@ -25,10 +25,13 @@ class eZClusterHandlerDBNoConnectionException extends eZDBException
      * @param string $pass The password (will be displayed as *)
      * @return void
      */
-    function __construct( $host, $user, $password )
+    function __construct( $host, $user, $password, $message = null )
     {
         $password = str_repeat( "*", strlen( $password ) );
-        parent::__construct( "Unable to connect to the database server '{$host}' using username '{$user}' and password '{$password}'" );
+        parent::__construct(
+            "Unable to connect to the database server '{$host}' using username '{$user}' and password '{$password}'" .
+            $message ? "\n$message" : ''
+        );
     }
 }
 ?>


### PR DESCRIPTION
Fixes http://jira.ez.no/browse/EZP-20813
### Situation

The `dfscleanup.php` script could, if either NFS or DB became unavailable, delete the whole database or the whole NFS folder. 
### Changes

This PR adds checks availability of both:
- We check that `<NfsMountPath>/<VarDir>` exists when a file was reported as missing
- Database error induced by `eZDFSFileHandler::exists()` and `eZDFSFileHandler::getFileList()`will now throw an Exception if a database error, instead of returning a meaningless false
### Testing done

Added interrupts ( `fgets( STDIN )` ) before critical operations, and:
- made NFS unavailable, simulating a mount error
- stopped the database server
  The script now aborts, explaining why, when one of those occur.
### Todo
- [ ] Move the CS only changes to a distinct commit
