### PR TITLE
EZP-21614 : avoid twice tpl compilation

### DIFF
--- a/bin/php/eztc.php
+++ b/bin/php/eztc.php
@@ -114,6 +114,7 @@ else
     $additionalSiteDesignList = $ini->variable( "DesignSettings", "AdditionalSiteDesignList" );
 
     $designList = array_merge( array( $standardDesign ), $additionalSiteDesignList, array( $siteDesign ) );
+    $designList = array_unique( $designList );
 
     $tpl = eZTemplate::factory();
 

--- a/bin/php/eztemplatecheck.php
+++ b/bin/php/eztemplatecheck.php
@@ -91,6 +91,7 @@ else
     $additionalSiteDesignList = $ini->variable( "DesignSettings", "AdditionalSiteDesignList" );
 
     $designList = array_merge( array( $standardDesign ), $additionalSiteDesignList, array( $siteDesign ) );
+    $designList = array_unique( $designList );
 
     $tpl = eZTemplate::factory();
 


### PR DESCRIPTION
In case the site.ini[DesignSettings]StandardDesign is duplicated in site.ini[DesignSettings]AdditionalSiteDesignList, the template in standard design folder are compiled/checked twice.

This PR intends to solve the problem by doing the same thing that the code in eztemplatedesignresource.php
