### PR TITLE
Fix EZP-19077: ezjscore fatal error encoding object w/out a node

### DIFF
--- a/extension/ezjscore/classes/ezjscajaxcontent.php
+++ b/extension/ezjscore/classes/ezjscajaxcontent.php
@@ -242,7 +242,7 @@ class ezjscAjaxContent
         $ret['owner_id']                	= (int) $contentObject->attribute( 'owner_id' );
         $ret['class_id']                	= (int) $contentObject->attribute( 'contentclass_id' );
         $ret['class_name']              	= $contentObject->attribute( 'class_name' );
-        $ret['path_identification_string'] 	= $node->attribute( 'path_identification_string' );
+        $ret['path_identification_string'] 	= $node ? $node->attribute( 'path_identification_string' ) : '';
         $ret['translations']            	= eZContentLanguage::decodeLanguageMask($contentObject->attribute( 'language_mask' ), true);
         $ret['can_edit']                	= $contentObject->attribute( 'can_edit' );
 


### PR DESCRIPTION
Fixes https://jira.ez.no/browse/EZP-19077.

Happens when an object is encoded through ezjscore while it doesn't have a node yet (interrupted publishing, etc).
