### PR TITLE
Fix EZP-21685: Selection attribute fail in ContentStaging with value Zero

### DIFF
--- a/kernel/classes/datatypes/ezselection/ezselectiontype.php
+++ b/kernel/classes/datatypes/ezselection/ezselectiontype.php
@@ -375,7 +375,7 @@ class eZSelectionType extends eZDataType
     function hasObjectAttributeContent( $contentObjectAttribute )
     {
         $selected = $this->objectAttributeContent( $contentObjectAttribute );
-        return !empty( $selected[0] );
+        return isset( $selected[0] ) && $selected[0] != ''; 
     }
 
     function sortKey( $contentObjectAttribute )


### PR DESCRIPTION
Recovering https://github.com/ezsystems/ezpublish-legacy/pull/496 which fixes this issue
`empty( "0" )` (the first option's value) returns true, meaning that has_content will return false
