### PR TITLE
Fix ezjscore CSS packer not recognizing paths to files containing GET parameters with values

### DIFF
--- a/extension/ezjscore/classes/ezjscpacker.php
+++ b/extension/ezjscore/classes/ezjscpacker.php
@@ -493,7 +493,7 @@ class ezjscPacker
      */
     static function fixImgPaths( $fileContent, $file )
     {
-        if ( preg_match_all( "/url\(\s*[\'|\"]?([A-Za-z0-9_\-\/\.\\%?&#]+)[\'|\"]?\s*\)/ix", $fileContent, $urlMatches ) )
+        if ( preg_match_all( "/url\(\s*[\'|\"]?([A-Za-z0-9_\-\/\.\\%?&#=]+)[\'|\"]?\s*\)/ix", $fileContent, $urlMatches ) )
         {
            $urlMatches = array_unique( $urlMatches[1] );
            $cssPathArray   = explode( '/', $file );


### PR DESCRIPTION
Consider the following CSS from [Font Awesome 3.2.1](https://github.com/FortAwesome/Font-Awesome/blob/master/css/font-awesome.css#L28):

``` css
@font-face {
  font-family: 'FontAwesome';
  src: url('../font/fontawesome-webfont.eot?v=3.2.1');
  src: url('../font/fontawesome-webfont.eot?#iefix&v=3.2.1') format('embedded-opentype'), url('../font/fontawesome-webfont.woff?v=3.2.1') format('woff'), url('../font/fontawesome-webfont.ttf?v=3.2.1') format('truetype'), url('../font/fontawesome-webfont.svg#fontawesomeregular?v=3.2.1') format('svg');
  font-weight: normal;
  font-style: normal;
}
```

When packing the CSS with `ezcss_load`/`ezcss_require` template operators, none of these 5 paths to fonts will not be converted to their absolute paths because the regex is missing the equal sign (`=`), thus not recognizing GET parameters with values (`v=3.2.1`).

This is not intensively tested, but we didn't have any problems on two of our sites using Font Awesome with eZ JS Core CSS packer.
