### PR TITLE
EZP-21713: Added extension/*/tests/settings to override dirs for Unit Tests

### DIFF
--- a/tests/toolkit/ezpextensionhelper.php
+++ b/tests/toolkit/ezpextensionhelper.php
@@ -59,7 +59,9 @@ class ezpExtensionHelper
         $activeExtensions[] = $extension;
         $ini->setVariable( 'ExtensionSettings', 'ActiveExtensions', $activeExtensions );
         $extensionDirectory = eZExtension::baseDirectory();
+        $ini->prependOverrideDir( $extensionDirectory . '/' . $extension . '/tests/settings', true, 'extension-tests:' . $extension, 'extension' );
         $ini->prependOverrideDir( $extensionDirectory . '/' . $extension . '/settings', true, 'extension:' . $extension, 'extension' );
+        $ini->resetAllInstances(false);
         eZExtension::clearActiveExtensionsMemoryCache();
         return true;
     }


### PR DESCRIPTION
When unit-testing extensions, it is currently not possible to override settings from within the extension only for the tests. This is currently only possible when we put the settings into `/ezpublish_root/tests/settings/`.

With this PR, it is possible to put settings into `extension/<my_extension>/tests/settings` which will then be used during Unit Tests (and only then).

Cheers
:octocat: Jérôme

https://jira.ez.no/browse/EZP-21713
