### PR TITLE
EZP-21728: Put extension test classes into correct autoload file

### DIFF
--- a/kernel/private/classes/ezautoloadgenerator.php
+++ b/kernel/private/classes/ezautoloadgenerator.php
@@ -330,20 +330,26 @@ class eZAutoloadGenerator
                     $extraExcludeKernelDirs = $extraExcludeDirs;
                     $extraExcludeKernelDirs[] = "@^{$sanitisedBasePath}{$dirSep}extension@";
                     $extraExcludeKernelDirs[] = "@^{$sanitisedBasePath}{$dirSep}tests@";
-                    $retFiles[self::MODE_KERNEL] = $this->buildFileList( $sanitisedBasePath, $extraExcludeKernelDirs );
+                    $retFiles[$modusOperandi] = $this->buildFileList( $sanitisedBasePath, $extraExcludeKernelDirs );
                     break;
 
                 case self::MODE_EXTENSION:
                 case self::MODE_KERNEL_OVERRIDE:
-                    $retFiles[$modusOperandi] = $this->buildFileList( "$sanitisedBasePath/extension", $extraExcludeDirs );
+                    $extraExcludeExtensionDirs = $extraExcludeDirs;
+                    $extraExcludeExtensionDirs[] = "@^{$sanitisedBasePath}{$dirSep}extension{$dirSep}[^{$dirSep}]+{$dirSep}tests@";
+                    $retFiles[$modusOperandi] = $this->buildFileList( "$sanitisedBasePath/extension", $extraExcludeExtensionDirs );
                     break;
 
                 case self::MODE_TESTS:
-                    $retFiles[self::MODE_TESTS] = $this->buildFileList( "$sanitisedBasePath/tests", $extraExcludeDirs );
+                    $retFiles[$modusOperandi] = $this->buildFileList( "$sanitisedBasePath/tests", $extraExcludeDirs );
+                    $extraExcludeExtensionDirs = $extraExcludeDirs;
+                    $extraExcludeExtensionDirs[] = "@^{$sanitisedBasePath}{$dirSep}extension{$dirSep}[^{$dirSep}]+{$dirSep}(?!tests)@";
+                    $extensionTestFiles = $this->buildFileList("$sanitisedBasePath/extension", $extraExcludeExtensionDirs );
+                    $retFiles[$modusOperandi] = array_merge( $retFiles[$modusOperandi], $extensionTestFiles );
                     break;
 
                 case self::MODE_SINGLE_EXTENSION:
-                    $retFiles = array( self::MODE_SINGLE_EXTENSION => $this->buildFileList( "$sanitisedBasePath", $extraExcludeDirs ) );
+                    $retFiles = array( $modusOperandi => $this->buildFileList( "$sanitisedBasePath", $extraExcludeDirs ) );
                     break;
             }
         }
@@ -377,6 +383,7 @@ class eZAutoloadGenerator
     {
         $dirSep = preg_quote( DIRECTORY_SEPARATOR );
         $exclusionFilter = array( "@^{$path}{$dirSep}(var|settings|benchmarks|bin|autoload|port_info|update|templates|tmp|UnitTest|lib{$dirSep}ezc)@" );
+
         if ( !empty( $extraFilter ) and is_array( $extraFilter ) )
         {
             foreach( $extraFilter as $filter )


### PR DESCRIPTION
When generating the autoloads with

``` bash
$ php bin/php/ezpgenerateautoloads.php -e
$ php bin/php/ezpgenerateautoloads.php -s
```

the test suites and test cases from extensions are written into the ezp_extension.php autoloads file instead of the ezp_tests.php autoloads file.

This has the effect that the test cases and suites are not added to the white list when generating code coverage reports and that the autoload array in ezp_extension.php might be larger than needed.

This patch prevents all PHP files from within a `tests` dir in extension directories of being written to `ezp_extension.php` and writes them into `ezp_tests.php` instead.

https://jira.ez.no/browse/EZP-21728

Cheers
:octocat: Jérôme
