### PR TITLE
Implement EZP-21731: Some parts of eZ Publish use a loose test for checking for SSL

### DIFF
--- a/extension/ezoe/ezxmltext/handlers/input/ezoexmlinput.php
+++ b/extension/ezoe/ezxmltext/handlers/input/ezoexmlinput.php
@@ -1806,13 +1806,7 @@ class eZOEXMLInput extends eZXMLInputHandler
                 $protocol = 'http';
 
                 // Default to https if SSL is enabled
-                // Check if SSL port is defined in site.ini
-                $sslPort = 443;
-                $ini = eZINI::instance();
-                if ( $ini->hasVariable( 'SiteSettings', 'SSLPort' ) )
-                    $sslPort = $ini->variable( 'SiteSettings', 'SSLPort' );
-
-                if ( eZSys::serverPort() == $sslPort )
+                if ( eZSys::isSSLNow() )
                     $protocol = 'https';
 
                 self::$serverURL = $protocol . '://' . $domain . eZSys::wwwDir();

--- a/kernel/url/view.php
+++ b/kernel/url/view.php
@@ -47,15 +47,7 @@ else
     $domain = getenv( 'HTTP_HOST' );
     $protocol = 'http';
 
-    // Check if SSL port is defined in site.ini
-    $ini = eZINI::instance();
-    $sslPort = 443;
-    if ( $ini->hasVariable( 'SiteSettings', 'SSLPort' ) )
-    {
-        $sslPort = $ini->variable( 'SiteSettings', 'SSLPort' );
-    }
-
-    if ( eZSys::serverPort() == $sslPort )
+    if ( eZSys::isSSLNow() )
     {
         $protocol = 'https';
     }

--- a/lib/ezutils/classes/ezhttptool.php
+++ b/lib/ezutils/classes/ezhttptool.php
@@ -544,17 +544,9 @@ class eZHTTPTool
         if ( !is_string( $protocol ) )
         {
             $protocol = 'http';
+
             // Default to https if SSL is enabled
-
-            // Check if SSL port is defined in site.ini
-            $ini = eZINI::instance();
-            $sslPort = 443;
-            if ( $ini->hasVariable( 'SiteSettings', 'SSLPort' ) )
-            {
-                $sslPort = $ini->variable( 'SiteSettings', 'SSLPort' );
-            }
-
-            if ( eZSys::serverPort() == $sslPort )
+            if ( eZSys::isSSLNow() )
             {
                 $protocol = 'https';
                 $port = false;


### PR DESCRIPTION
Instead of using a crafted test on port, use the more complete eZSys::isSSLNow() function, that also take into account configurations with an SSL reverse proxy.
