### PR TITLE
Change constants to strings in array keys

### DIFF
--- a/kernel/class/ezclassfunctioncollection.php
+++ b/kernel/class/ezclassfunctioncollection.php
@@ -35,13 +35,13 @@ class eZClassFunctionCollection
             $classNameFilter = eZContentClassName::sqlFilter( 'cc' );
             $version = eZContentClass::VERSION_STATUS_DEFINED;
 
-            $sql = "SELECT DISTINCT cc.*, $classNameFilter[nameField] " .
-                   "FROM ezcontentclass cc, ezcontentclass_classgroup ccg, $classNameFilter[from] " .
-                   "WHERE cc.version = $version" .
+            $sql = "SELECT DISTINCT cc.*, {$classNameFilter['nameField']} " .
+                   "FROM ezcontentclass cc, ezcontentclass_classgroup ccg, {$classNameFilter['from']} " .
+                   "WHERE cc.version = {$version}" .
                    "      AND cc.id = ccg.contentclass_id" .
-                   "      AND $groupFilter" .
-                   "      AND $classNameFilter[where] " .
-                   "ORDER BY $classNameFilter[nameField] ASC";
+                   "      AND {$groupFilter}" .
+                   "      AND {$classNameFilter['where']} " .
+                   "ORDER BY {$classNameFilter['nameField']} ASC";
 
             $rows = $db->arrayQuery( $sql );
             $classes = eZPersistentObject::handleRows( $rows, 'eZContentClass', true );

--- a/kernel/classes/ezcache.php
+++ b/kernel/classes/ezcache.php
@@ -492,13 +492,13 @@ class eZCache
             if ( is_callable( $function ) )
                 call_user_func_array( $function, array( $cacheItem ) );
             else
-                eZDebug::writeError("Could not call cache item $functionName for id '$cacheItem[id]', is it a static public function?", __METHOD__ );
+                eZDebug::writeError("Could not call cache item {$functionName} for id '{$cacheItem['id']}', is it a static public function?", __METHOD__ );
         }
         else
         {
             if ( !isset( $cacheItem['path'] ) || strlen( $cacheItem['path'] ) < 1 )
             {
-                eZDebug::writeError( "No path specified for cache item '$cacheItem[name]', can not clear cache.", __METHOD__ );
+                eZDebug::writeError( "No path specified for cache item '{$cacheItem['name']}', can not clear cache.", __METHOD__ );
                 return;
             }
 

--- a/kernel/classes/ezcontentclass.php
+++ b/kernel/classes/ezcontentclass.php
@@ -518,11 +518,11 @@ class eZContentClass extends eZPersistentObject
         if ( $fetchAll )
         {
             // If $asObject is true we fetch all fields in class
-            $fields = $asObject ? "cc.*, $classNameFilter[nameField]" : "cc.id, $classNameFilter[nameField]";
-            $rows = $db->arrayQuery( "SELECT DISTINCT $fields " .
-                                     "FROM ezcontentclass cc$filterTableSQL, $classNameFilter[from] " .
+            $fields = $asObject ? "cc.*, {$classNameFilter['nameField']}" : "cc.id, {$classNameFilter['nameField']}";
+            $rows = $db->arrayQuery( "SELECT DISTINCT {$fields} " .
+                                     "FROM ezcontentclass cc{$filterTableSQL}, {$classNameFilter['from']} " .
                                      "WHERE cc.version = " . eZContentClass::VERSION_STATUS_DEFINED . " $filterSQL " .
-                                     "ORDER BY $classNameFilter[nameField] ASC" );
+                                     "ORDER BY {$classNameFilter['nameField']} ASC" );
             $classList = eZPersistentObject::handleRows( $rows, 'eZContentClass', $asObject );
         }
         else
@@ -535,12 +535,12 @@ class eZContentClass extends eZPersistentObject
 
             $classIDCondition = $db->generateSQLINStatement( $classIDArray, 'cc.id' );
             // If $asObject is true we fetch all fields in class
-            $fields = $asObject ? "cc.*, $classNameFilter[nameField]" : "cc.id, $classNameFilter[nameField]";
-            $rows = $db->arrayQuery( "SELECT DISTINCT $fields " .
-                                     "FROM ezcontentclass cc$filterTableSQL, $classNameFilter[from] " .
+            $fields = $asObject ? "cc.*, {$classNameFilter['nameField']}" : "cc.id, {$classNameFilter['nameField']}";
+            $rows = $db->arrayQuery( "SELECT DISTINCT {$fields} " .
+                                     "FROM ezcontentclass cc{$filterTableSQL}, {$classNameFilter['from']} " .
                                      "WHERE $classIDCondition AND" .
-                                     "      cc.version = " . eZContentClass::VERSION_STATUS_DEFINED . " $filterSQL " .
-                                     "ORDER BY $classNameFilter[nameField] ASC" );
+                                     "      cc.version = " . eZContentClass::VERSION_STATUS_DEFINED . " {$filterSQL} " .
+                                     "ORDER BY {$classNameFilter['nameField']} ASC" );
             $classList = eZPersistentObject::handleRows( $rows, 'eZContentClass', $asObject );
         }
 
@@ -680,11 +680,11 @@ class eZContentClass extends eZPersistentObject
         $classList = array();
         $db = eZDB::instance();
         // If $asObject is true we fetch all fields in class
-        $fields = $asObject ? "cc.*" : "cc.id, $classNameFilter[nameField]";
-        $rows = $db->arrayQuery( "SELECT DISTINCT $fields " .
-                                 "FROM ezcontentclass cc$filterTableSQL, $classNameFilter[from] " .
-                                 "WHERE cc.version = " . eZContentClass::VERSION_STATUS_DEFINED . "$filterSQL AND $classNameFilter[where]" .
-                                 "ORDER BY $classNameFilter[nameField] ASC" );
+        $fields = $asObject ? "cc.*" : "cc.id, {$classNameFilter['nameField']}";
+        $rows = $db->arrayQuery( "SELECT DISTINCT {$fields} " .
+                                 "FROM ezcontentclass cc{$filterTableSQL}, {$classNameFilter['from']} " .
+                                 "WHERE cc.version = " . eZContentClass::VERSION_STATUS_DEFINED . "{$filterSQL} AND {$classNameFilter['where']}" .
+                                 "ORDER BY {$classNameFilter['nameField']} ASC" );
 
         $classList = eZPersistentObject::handleRows( $rows, 'eZContentClass', $asObject );
         return $classList;

--- a/kernel/classes/ezcontentclassclassgroup.php
+++ b/kernel/classes/ezcontentclassclassgroup.php
@@ -160,12 +160,12 @@ class eZContentClassClassGroup extends eZPersistentObject
         }
 
         $db = eZDB::instance();
-        $sql = "SELECT contentclass.* $classNameSqlFilter[nameField]
-                FROM ezcontentclass  contentclass, ezcontentclass_classgroup class_group $classNameSqlFilter[from]
+        $sql = "SELECT contentclass.* {$classNameSqlFilter['nameField']}
+                FROM ezcontentclass  contentclass, ezcontentclass_classgroup class_group {$classNameSqlFilter['from']}
                 WHERE contentclass.id=class_group.contentclass_id
-                $versionCond
-                AND class_group.group_id='$group_id' $classNameSqlFilter[where]
-                $orderByClause";
+                {$versionCond}
+                AND class_group.group_id='$group_id' {$classNameSqlFilter['where']}
+                {$orderByClause}";
         $rows = $db->arrayQuery( $sql );
         return eZPersistentObject::handleRows( $rows, "eZContentClass", $asObject );
     }

--- a/kernel/classes/ezcontentobject.php
+++ b/kernel/classes/ezcontentobject.php
@@ -3228,26 +3228,26 @@ class eZContentObject extends eZPersistentObject
                         ezcontentclass.identifier as contentclass_identifier,
                         ezcontentclass.is_container as is_container,
                         ezcontentobject.*, ezcontentobject_name.name as name, ezcontentobject_name.real_translation
-                        $sortingInfo[attributeTargetSQL]
+                        {$sortingInfo['attributeTargetSQL']}
                      FROM
                         ezcontentclass,
                         ezcontentobject,
                         ezcontentobject_link,
                         ezcontentobject_name
-                        $sortingInfo[attributeFromSQL]
+                        {$sortingInfo['attributeFromSQL']}
                      WHERE
                         ezcontentclass.id=ezcontentobject.contentclass_id AND
                         ezcontentclass.version=0 AND
                         ezcontentobject.status=" . eZContentObject::STATUS_PUBLISHED . " AND
-                        $sortingInfo[attributeWhereSQL]
-                        $relatedClassIdentifiersSQL
-                        $relationTypeMasking
-                        $fromOrToContentObjectID
-                        $showInvisibleNodesCond AND
+                        {$sortingInfo['attributeWhereSQL']}
+                        {$relatedClassIdentifiersSQL}
+                        {$relationTypeMasking}
+                        {$fromOrToContentObjectID}
+                        {$showInvisibleNodesCond} AND
                         ezcontentobject.id = ezcontentobject_name.contentobject_id AND
                         ezcontentobject.current_version = ezcontentobject_name.content_version AND
                         " . eZContentLanguage::sqlFilter( 'ezcontentobject_name', 'ezcontentobject' ) . "
-                        $sortingString";
+                        {$sortingString}";
         if ( !$offset && !$limit )
         {
             $relatedObjects = $db->arrayQuery( $query );
@@ -4873,11 +4873,11 @@ class eZContentObject extends eZPersistentObject
         if ( $fetchAll )
         {
             // If $asObject is true we fetch all fields in class
-            $fields = $asObject ? "cc.*, $classNameFilter[nameField]" : "cc.id, $classNameFilter[nameField]";
-            $rows = $db->arrayQuery( "SELECT DISTINCT $fields " .
-                                     "FROM ezcontentclass cc$filterTableSQL, $classNameFilter[from] " .
-                                     "WHERE cc.version = " . eZContentClass::VERSION_STATUS_DEFINED . " $filterSQL AND $classNameFilter[where] " .
-                                     "ORDER BY $classNameFilter[nameField] ASC" );
+            $fields = $asObject ? "cc.*, {$classNameFilter['nameField']}" : "cc.id, {$classNameFilter['nameField']}";
+            $rows = $db->arrayQuery( "SELECT DISTINCT {$fields} " .
+                                     "FROM ezcontentclass cc{$filterTableSQL}, {$classNameFilter['from']} " .
+                                     "WHERE cc.version = " . eZContentClass::VERSION_STATUS_DEFINED . " {$filterSQL} AND {$classNameFilter['where']} " .
+                                     "ORDER BY {$classNameFilter['nameField']} ASC" );
             $classList = eZPersistentObject::handleRows( $rows, 'eZContentClass', $asObject );
         }
         else
@@ -4890,12 +4890,12 @@ class eZContentObject extends eZPersistentObject
 
             $classIDCondition = $db->generateSQLINStatement( $classIDArray, 'cc.id' );
             // If $asObject is true we fetch all fields in class
-            $fields = $asObject ? "cc.*, $classNameFilter[nameField]" : "cc.id, $classNameFilter[nameField]";
-            $rows = $db->arrayQuery( "SELECT DISTINCT $fields " .
-                                     "FROM ezcontentclass cc$filterTableSQL, $classNameFilter[from] " .
-                                     "WHERE $classIDCondition AND" .
-                                     "      cc.version = " . eZContentClass::VERSION_STATUS_DEFINED . " $filterSQL AND $classNameFilter[where] " .
-                                     "ORDER BY $classNameFilter[nameField] ASC" );
+            $fields = $asObject ? "cc.*, {$classNameFilter['nameField']}" : "cc.id, {$classNameFilter['nameField']}";
+            $rows = $db->arrayQuery( "SELECT DISTINCT {$fields} " .
+                                     "FROM ezcontentclass cc{$filterTableSQL}, {$classNameFilter['from']} " .
+                                     "WHERE {$classIDCondition} AND" .
+                                     "      cc.version = " . eZContentClass::VERSION_STATUS_DEFINED . " {$filterSQL} AND {$classNameFilter['where']} " .
+                                     "ORDER BY {$classNameFilter['nameField']} ASC" );
             $classList = eZPersistentObject::handleRows( $rows, 'eZContentClass', $asObject );
         }
 

--- a/kernel/classes/ezcontentobjecttrashnode.php
+++ b/kernel/classes/ezcontentobjecttrashnode.php
@@ -264,7 +264,7 @@ class eZContentObjectTrashNode extends eZContentObjectTreeNode
                         ezcontentclass.identifier as class_identifier,
                         ezcontentobject_name.name as name,
                         ezcontentobject_name.real_translation
-                        $sortingInfo[attributeTargetSQL] ";
+                        {$sortingInfo['attributeTargetSQL']} ";
         }
         $query .= "FROM
                         ezcontentobject_trash ezcot
@@ -274,19 +274,19 @@ class eZContentObjectTrashNode extends eZContentObjectTreeNode
                             ezcot.contentobject_id = ezcontentobject_name.contentobject_id AND
                             ezcot.contentobject_version = ezcontentobject_name.content_version
                         )
-                        $sortingInfo[attributeFromSQL]
-                        $attributeFilter[from]
-                        $sqlPermissionChecking[from]
+                        {$sortingInfo['attributeFromSQL']}
+                        {$attributeFilter['from']}
+                        {$sqlPermissionChecking['from']}
                    WHERE
-                        $sortingInfo[attributeWhereSQL]
-                        $attributeFilter[where]
+                        {$sortingInfo['attributeWhereSQL']}
+                        {$attributeFilter['where']}
                         " . eZContentLanguage::sqlFilter( 'ezcontentobject_name', 'ezcontentobject' ) . "
-                        $sqlPermissionChecking[where]
-                        $objectNameFilterSQL
+                        {$sqlPermissionChecking['where']}
+                        {$objectNameFilterSQL}
                         AND " . eZContentLanguage::languagesSQLFilter( 'ezcontentobject' );
 
         if ( !$asCount && $sortingInfo['sortingFields'] && strlen( $sortingInfo['sortingFields'] ) > 5  )
-            $query .= " ORDER BY $sortingInfo[sortingFields]";
+            $query .= " ORDER BY {$sortingInfo['sortingFields']}";
 
         $db = eZDB::instance();
         if ( !$offset && !$limit )

--- a/kernel/classes/ezcontentobjecttreenode.php
+++ b/kernel/classes/ezcontentobjecttreenode.php
@@ -637,8 +637,8 @@ class eZContentObjectTreeNode extends eZPersistentObject
                         {
                             $classNameFilter = eZContentClassName::sqlFilter();
                             $sortingFields .= 'contentclass_name';
-                            $datatypeSortingTargetSQL .= ", $classNameFilter[nameField] AS contentclass_name";
-                            $attributeFromSQL .= " INNER JOIN $classNameFilter[from] ON ($classNameFilter[where])";
+                            $datatypeSortingTargetSQL .= ", {$classNameFilter['nameField']} AS contentclass_name";
+                            $attributeFromSQL .= " INNER JOIN {$classNameFilter['from']} ON ({$classNameFilter['where']})";
                         } break;
                         case 'priority':
                         {
@@ -677,7 +677,7 @@ class eZContentObjectTreeNode extends eZPersistentObject
 
                                 $sql = $dataType->customSortingSQL( $params );
 
-                                $datatypeFromSQL .= " INNER JOIN $sql[from] ON ($sql[where])";
+                                $datatypeFromSQL .= " INNER JOIN {$sql['from']} ON ({$sql['where']})";
                                 $datatypeSortingFieldSQL = $sql['sorting_field'];
                                 $datatypeSortingTargetSQL .= ', ' . $sql['sorting_field'];
                             }
@@ -1112,7 +1112,7 @@ class eZContentObjectTreeNode extends eZPersistentObject
                             $classNameFilter = eZContentClassName::sqlFilter();
                             $filterField = $classNameFilter['nameField'];
                             $filterFieldType = 'string';
-                            $filterSQL['from'] .= " INNER JOIN $classNameFilter[from] ON ($classNameFilter[where])";
+                            $filterSQL['from'] .= " INNER JOIN {$classNameFilter['from']} ON ({$classNameFilter['where']})";
                         } break;
                         case 'priority':
                         {
@@ -2051,24 +2051,24 @@ class eZContentObjectTreeNode extends eZPersistentObject
             "    ezcontentobject_tree.contentobject_id = ezcontentobject_name.contentobject_id AND " .
             "    ezcontentobject_tree.contentobject_version = ezcontentobject_name.content_version " .
             ") " .
-            "$sortingInfo[attributeFromSQL] $attributeFilter[from] $extendedAttributeFilter[tables] $sqlPermissionChecking[from] " .
+            "{$sortingInfo['attributeFromSQL']} {$attributeFilter['from']} {$extendedAttributeFilter['tables']} {$sqlPermissionChecking['from']} " .
             "WHERE " .
             "$pathStringCond " .
-            "$extendedAttributeFilter[joins] " .
-            "$sortingInfo[attributeWhereSQL] " .
-            "$attributeFilter[where] " .
+            "{$extendedAttributeFilter['joins']} " .
+            "{$sortingInfo['attributeWhereSQL']} " .
+            "{$attributeFilter['where']} " .
             "$notEqParentString " .
             "$mainNodeOnlyCond " .
             "$classCondition " .
             "$objectNameLanguageFilter " .
             "$showInvisibleNodesCond " .
-            "$sqlPermissionChecking[where] " .
+            "{$sqlPermissionChecking['where']} " .
             "$objectNameFilterSQL AND " .
             "$languageFilter " .
             $groupBySQL;
 
         if ( $sortingInfo['sortingFields'] )
-            $query .= " ORDER BY $sortingInfo[sortingFields]";
+            $query .= " ORDER BY {$sortingInfo['sortingFields']}";
 
         $db = eZDB::instance();
 
@@ -2244,16 +2244,16 @@ class eZContentObjectTreeNode extends eZPersistentObject
 
             $queryNodes .= " (
                           $pathStringCond
-                          $extendedAttributeFilter[joins]
-                          $sortingInfo[attributeWhereSQL]
-                          $attributeFilter[where]
+                          {$extendedAttributeFilter['joins']}
+                          {$sortingInfo['attributeWhereSQL']}
+                          {$attributeFilter['where']}
                           ezcontentclass.version=0 AND
                           $notEqParentString
                           $mainNodeOnlyCond
                           $classCondition
                           " . eZContentLanguage::sqlFilter( 'ezcontentobject_name', 'ezcontentobject' ) . "
                           $showInvisibleNodesCond
-                          $sqlPermissionChecking[where]
+                          {$sqlPermissionChecking['where']}
                           $languageFilter
                       )
                       OR";
@@ -2278,7 +2278,7 @@ class eZContentObjectTreeNode extends eZPersistentObject
             "ezcontentobject_tree.node_id, ezcontentobject_tree.parent_node_id, ezcontentobject_tree.path_identification_string, ezcontentobject_tree.path_string, " .
             "ezcontentobject_tree.priority, ezcontentobject_tree.remote_id, ezcontentobject_tree.sort_field, ezcontentobject_tree.sort_order, ezcontentclass.serialized_name_list as class_serialized_name_list, " .
             "ezcontentclass.identifier as class_identifier, ezcontentclass.is_container $groupBySelectText, ezcontentobject_name.name, ezcontentobject_name.real_translation " .
-            "$sortingInfo[attributeTargetSQL], $nodeParams[ResultID] AS resultid " .
+            "{$sortingInfo['attributeTargetSQL']}, {$nodeParams['ResultID']} AS resultid " .
             "FROM ezcontentobject_tree " .
             "INNER JOIN ezcontentobject ON (ezcontentobject.id = ezcontentobject_tree.contentobject_id) " .
             "INNER JOIN ezcontentclass ON (ezcontentclass.id = ezcontentobject.contentclass_id) " .
@@ -2286,17 +2286,17 @@ class eZContentObjectTreeNode extends eZPersistentObject
             "    ezcontentobject_name.contentobject_id = ezcontentobject_tree.contentobject_id AND " .
             "    ezcontentobject_name.content_version = ezcontentobject_tree.contentobject_version " .
             ") " .
-            "$sortingInfo[attributeFromSQL] " .
-            "$attributeFilter[from] " .
-            "$extendedAttributeFilter[tables] " .
-            "$sqlPermissionChecking[from] " .
+            "{$sortingInfo['attributeFromSQL']} " .
+            "{$attributeFilter['from']} " .
+            "{$extendedAttributeFilter['tables']} " .
+            "{$sqlPermissionChecking['from']} " .
             "WHERE " .
             substr( $queryNodes, 0, -2 ) . " " .
             $groupBySQL;
 
         if ( $sortingInfo['sortingFields'] )
         {
-            $query .= " ORDER BY $sortingInfo[sortingFields]";
+            $query .= " ORDER BY {$sortingInfo['sortingFields']}";
         }
 
         $db = eZDB::instance();
@@ -2494,19 +2494,19 @@ class eZContentObjectTreeNode extends eZPersistentObject
                            ezcontentobject_name.contentobject_id = ezcontentobject_tree.contentobject_id AND
                            ezcontentobject_name.content_version = ezcontentobject_tree.contentobject_version
                        )
-                       $attributeFilter[from]
-                       $extendedAttributeFilter[tables]
-                       $sqlPermissionChecking[from]
+                       {$attributeFilter['from']}
+                       {$extendedAttributeFilter['tables']}
+                       {$sqlPermissionChecking['from']}
                   WHERE $pathStringCond
-                        $extendedAttributeFilter[joins]
+                        {$extendedAttributeFilter['joins']}
                         $mainNodeOnlyCond
                         $classCondition
-                        $attributeFilter[where]
+                        {$attributeFilter['where']}
                         ezcontentclass.version=0 AND
                         $notEqParentString
                         $objectNameLanguageFilter
                         $showInvisibleNodesCond
-                        $sqlPermissionChecking[where]
+                        {$sqlPermissionChecking['where']}
                         $objectNameFilterSQL
                         $languageFilter ";
 
@@ -2601,20 +2601,20 @@ class eZContentObjectTreeNode extends eZPersistentObject
                           ezcontentobject_name.content_version = ezcontentobject_tree.contentobject_version
                       )
 
-                      $attributeFilter[from]
-                      $extendedAttributeFilter[tables]
-                      $sqlPermissionChecking[from]
+                      {$attributeFilter['from']}
+                      {$extendedAttributeFilter['tables']}
+                      {$sqlPermissionChecking['from']}
                    WHERE
                       $pathStringCond
-                      $extendedAttributeFilter[joins]
-                      $attributeFilter[where]
+                      {$extendedAttributeFilter['joins']}
+                      {$attributeFilter['where']}
                       ezcontentclass.version = 0 AND
                       $notEqParentString
                       $mainNodeOnlyCond
                       $classCondition
                       " . eZContentLanguage::sqlFilter( 'ezcontentobject_name', 'ezcontentobject' ) . "
                       $showInvisibleNodesCond
-                      $sqlPermissionChecking[where]
+                      {$sqlPermissionChecking['where']}
                 $groupBySQL";
 
 
@@ -5171,11 +5171,11 @@ class eZContentObjectTreeNode extends eZPersistentObject
         if ( $fetchAll )
         {
             // If $asObject is true we fetch all fields in class
-            $fields = $asObject ? "cc.*, $classNameFilter[nameField]" : "cc.id, $classNameFilter[nameField]";
+            $fields = $asObject ? "cc.*, {$classNameFilter['nameField']}" : "cc.id, {$classNameFilter['nameField']}";
             $rows = $db->arrayQuery( "SELECT DISTINCT $fields " .
-                                     "FROM ezcontentclass cc$filterTableSQL, $classNameFilter[from] " .
-                                     "WHERE cc.version = " . eZContentClass::VERSION_STATUS_DEFINED . " $filterSQL AND $classNameFilter[where] " .
-                                     "ORDER BY $classNameFilter[nameField] ASC" );
+                                     "FROM ezcontentclass cc$filterTableSQL, {$classNameFilter['from']} " .
+                                     "WHERE cc.version = " . eZContentClass::VERSION_STATUS_DEFINED . " $filterSQL AND {$classNameFilter['where']} " .
+                                     "ORDER BY {$classNameFilter['nameField']} ASC" );
             $classList = eZPersistentObject::handleRows( $rows, 'eZContentClass', $asObject );
         }
         else
@@ -5188,12 +5188,12 @@ class eZContentObjectTreeNode extends eZPersistentObject
 
             $classIDCondition = $db->generateSQLINStatement( $classIDArray, 'cc.id' );
             // If $asObject is true we fetch all fields in class
-            $fields = $asObject ? "cc.*, $classNameFilter[nameField]" : "cc.id, $classNameFilter[nameField]";
+            $fields = $asObject ? "cc.*, {$classNameFilter['nameField']}" : "cc.id, {$classNameFilter['nameField']}";
             $rows = $db->arrayQuery( "SELECT DISTINCT $fields " .
-                                     "FROM ezcontentclass cc$filterTableSQL, $classNameFilter[from] " .
+                                     "FROM ezcontentclass cc$filterTableSQL, {$classNameFilter['from']} " .
                                      "WHERE $classIDCondition AND" .
-                                     "      cc.version = " . eZContentClass::VERSION_STATUS_DEFINED . " $filterSQL AND $classNameFilter[where] " .
-                                     "ORDER BY $classNameFilter[nameField] ASC" );
+                                     "      cc.version = " . eZContentClass::VERSION_STATUS_DEFINED . " $filterSQL AND {$classNameFilter['where']} " .
+                                     "ORDER BY {$classNameFilter['nameField']} ASC" );
             $classList = eZPersistentObject::handleRows( $rows, 'eZContentClass', $asObject );
         }
 

--- a/kernel/common/ezcontentstructuretreeoperator.php
+++ b/kernel/common/ezcontentstructuretreeoperator.php
@@ -144,13 +144,13 @@ class eZContentStructureTreeOperator
                                    ezcontentobject_name.contentobject_id = ezcontentobject_tree.contentobject_id AND
                                    ezcontentobject_name.content_version = ezcontentobject_tree.contentobject_version
                                )
-                               $permissionChecking[from]
+                               {$permissionChecking['from']}
                           WHERE $pathStringCond
                                 $classCondition
                                 ezcontentclass.version=0 AND
                                 $notEqParentString
                                 " . eZContentLanguage::sqlFilter( 'ezcontentobject_name', 'ezcontentobject' ) . "
-                                $permissionChecking[where] ";
+                                {$permissionChecking['where']} ";
         }
         else
         {
@@ -169,19 +169,19 @@ class eZContentStructureTreeOperator
                                  ezcontentobject_name.contentobject_id = ezcontentobject_tree.contentobject_id AND
                                  ezcontentobject_name.content_version = ezcontentobject_tree.contentobject_version
                              )
-                             $sortingInfo[attributeFromSQL]
-                             $permissionChecking[from]
+                             {$sortingInfo['attributeFromSQL']}
+                             {$permissionChecking['from']}
                       WHERE
                              $pathStringCond
-                             $sortingInfo[attributeWhereSQL]
+                             {$sortingInfo['attributeWhereSQL']}
                              ezcontentclass.version=0 AND
                              $notEqParentString
                              $classCondition
                              ezcontentobject_tree.contentobject_is_published = 1 AND
                              " . eZContentLanguage::sqlFilter( 'ezcontentobject_name', 'ezcontentobject' ) . "
                              $showInvisibleNodesCond
-                             $permissionChecking[where]
-                      ORDER BY $sortingInfo[sortingFields]";
+                             {$permissionChecking['where']}
+                      ORDER BY {$sortingInfo['sortingFields']}";
 
         }
 

--- a/kernel/content/ezcontentfunctioncollection.php
+++ b/kernel/content/ezcontentfunctioncollection.php
@@ -844,12 +844,12 @@ class eZContentFunctionCollection
                       INNER JOIN ezcontentobject ON (ezcontentobject.id = ezcontentobject_attribute.contentobject_id AND ezcontentobject.current_version = ezcontentobject_attribute.version)
                       INNER JOIN ezcontentobject_tree ON (ezcontentobject_tree.contentobject_id = ezcontentobject.id)
                       INNER JOIN ezcontentclass ON (ezcontentclass.id = ezcontentobject.contentclass_id)
-                       $sqlPermissionChecking[from]
-                  WHERE 
+                       {$sqlPermissionChecking['from']}
+                  WHERE
                   $parentNodeIDString
                   $sqlMatching
                   $showInvisibleNodesCond
-                  $sqlPermissionChecking[where]
+                  {$sqlPermissionChecking['where']}
                   $sqlClassIDs
                   $sqlOwnerString
                   AND ezcontentclass.version = 0
@@ -1016,13 +1016,13 @@ class eZContentFunctionCollection
                        INNER JOIN ezcontentobject ON (ezcontentobject_attribute.version = ezcontentobject.current_version AND ezcontentobject_attribute.contentobject_id = ezcontentobject.id)
                        INNER JOIN ezcontentobject_tree ON (ezcontentobject_tree.contentobject_id = ezcontentobject.id)
                        INNER JOIN ezcontentclass ON (ezcontentclass.id = ezcontentobject.contentclass_id)
-                       $sortingInfo[attributeFromSQL]
-                       $sqlPermissionChecking[from]
+                       {$sortingInfo['attributeFromSQL']}
+                       {$sqlPermissionChecking['from']}
                   WHERE
                   $parentNodeIDString
                   $sqlMatching
                   $showInvisibleNodesCond
-                  $sqlPermissionChecking[where]
+                  {$sqlPermissionChecking['where']}
                   $sqlClassIDString
                   $sqlOwnerString
                   AND ezcontentclass.version = 0

--- a/kernel/private/modules/oauth/authorize.php
+++ b/kernel/private/modules/oauth/authorize.php
@@ -2,11 +2,11 @@
 /**
  * File containing the oauth/authorize view definition
  *
- * @param string $_GET[client_id] the client application identifier, as in ezpRestClient
- * @param string $_GET[redirect_uri] the URI the view should redirect to in case of success
- * @param string $_GET[response_type] the requested response type. Can be code_and_token, code, or token
- * @param string $_GET[scope] the permissions scope the client requests (optional)
- * @param string $_GET[state] Not implemented yet (optional)
+ * @param string $_GET['client_id'] the client application identifier, as in ezpRestClient
+ * @param string $_GET['redirect_uri'] the URI the view should redirect to in case of success
+ * @param string $_GET['response_type'] the requested response type. Can be code_and_token, code, or token
+ * @param string $_GET['scope'] the permissions scope the client requests (optional)
+ * @param string $_GET['state'] Not implemented yet (optional)
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.

--- a/kernel/search/plugins/ezsearchengine/ezsearchengine.php
+++ b/kernel/search/plugins/ezsearchengine/ezsearchengine.php
@@ -879,7 +879,7 @@ class eZSearchEngine implements ezpSearchEngine
                                               $subTreeTable
                                               INNER JOIN ezcontentclass ON (ezcontentclass.id = ezcontentobject.contentclass_id)
                                               INNER JOIN ezcontentobject_tree ON (ezcontentobject_tree.contentobject_id = ezcontentobject.id)
-                                              $sqlPermissionChecking[from]
+                                              {$sqlPermissionChecking['from']}
                                          WHERE
                                                $searchDateQuery
                                                $sectionQuery
@@ -890,7 +890,7 @@ class eZSearchEngine implements ezpSearchEngine
                                          ezcontentclass.version = '0' AND
                                          ezcontentobject_tree.node_id = ezcontentobject_tree.main_node_id
                                          $showInvisibleNodesCond
-                                         $sqlPermissionChecking[where]",
+                                         {$sqlPermissionChecking['where']}",
                                     eZDBInterface::SERVER_SLAVE );
                     }
                     else
@@ -908,7 +908,7 @@ class eZSearchEngine implements ezpSearchEngine
                                              INNER JOIN ezcontentclass ON (ezcontentclass.id = ezcontentobject.contentclass_id)
                                              INNER JOIN ezcontentobject_tree ON (ezcontentobject_tree.contentobject_id = ezcontentobject.id)
                                              INNER JOIN $tmpTable0 ON ($tmpTable0.contentobject_id = ezsearch_object_word_link.contentobject_id)
-                                             $sqlPermissionChecking[from]
+                                             {$sqlPermissionChecking['from']}
                                           WHERE
                                           $searchDateQuery
                                           $sectionQuery
@@ -919,7 +919,7 @@ class eZSearchEngine implements ezpSearchEngine
                                           ezcontentclass.version = '0' AND
                                           ezcontentobject_tree.node_id = ezcontentobject_tree.main_node_id
                                           $showInvisibleNodesCond
-                                          $sqlPermissionChecking[where]",
+                                          {$sqlPermissionChecking['where']}",
                                     eZDBInterface::SERVER_SLAVE );
                     }
                     $i++;
@@ -941,7 +941,7 @@ class eZSearchEngine implements ezpSearchEngine
                                           $subTreeTable
                                           INNER JOIN ezcontentclass ON (ezcontentclass.id = ezcontentobject.contentclass_id)
                                           INNER JOIN ezcontentobject_tree ON (ezcontentobject_tree.contentobject_id = ezcontentobject.id)
-                                          $sqlPermissionChecking[from]
+                                          {$sqlPermissionChecking['from']}
                                      WHERE
                                           $searchDateQuery
                                           $sectionQuery
@@ -951,7 +951,7 @@ class eZSearchEngine implements ezpSearchEngine
                                           ezcontentclass.version = '0' AND
                                           ezcontentobject_tree.node_id = ezcontentobject_tree.main_node_id
                                           $showInvisibleNodesCond
-                                          $sqlPermissionChecking[where]",
+                                          {$sqlPermissionChecking['where']}",
                              eZDBInterface::SERVER_SLAVE );
                  $this->TempTablesCount = 1;
                  $i = $this->TempTablesCount;
@@ -1163,7 +1163,7 @@ class eZSearchEngine implements ezpSearchEngine
                             $classNameFilter = eZContentClassName::sqlFilter();
                             $selectSQL .= ", " . $classNameFilter['nameField'] . " AS class_name";
                             $sortingFields .= "class_name";
-                            $attributeFromSQL .= " INNER JOIN $classNameFilter[from] ON ($classNameFilter[where])";
+                            $attributeFromSQL .= " INNER JOIN {$classNameFilter['from']} ON ({$classNameFilter['where']})";
                         } break;
                         case 'priority':
                         {
@@ -1666,7 +1666,7 @@ class eZSearchEngine implements ezpSearchEngine
                        $subTreeTable
                        INNER JOIN ezcontentclass ON (ezcontentclass.id = ezcontentobject.contentclass_id)
                        INNER JOIN ezcontentobject_tree ON (ezcontentobject_tree.contentobject_id = ezcontentobject.id)
-                       $sqlPermissionChecking[from]
+                       {$sqlPermissionChecking['from']}
                     WHERE
                     $searchDateQuery
                     $sectionQuery
@@ -1676,7 +1676,7 @@ class eZSearchEngine implements ezpSearchEngine
                     $subTreeSQL
                     ezcontentclass.version = '0' AND
                     ezcontentobject_tree.node_id = ezcontentobject_tree.main_node_id
-                    $sqlPermissionChecking[where]",
+                    {$sqlPermissionChecking['where']}",
                     eZDBInterface::SERVER_SLAVE );
         }
         else
@@ -1693,7 +1693,7 @@ class eZSearchEngine implements ezpSearchEngine
                        INNER JOIN ezcontentclass ON (ezcontentclass.id = ezcontentobject.contentclass_id)
                        INNER JOIN ezcontentobject_tree ON (ezcontentobject_tree.contentobject_id = ezcontentobject.id)
                        INNER JOIN $tmpTable0 ON ($tmpTable0.contentobject_id = ezsearch_object_word_link.contentobject_id)
-                       $sqlPermissionChecking[from]
+                       {$sqlPermissionChecking['from']}
                     WHERE
                     $searchDateQuery
                     $sectionQuery
@@ -1703,7 +1703,7 @@ class eZSearchEngine implements ezpSearchEngine
                     $subTreeSQL
                     ezcontentclass.version = '0' AND
                     ezcontentobject_tree.node_id = ezcontentobject_tree.main_node_id
-                    $sqlPermissionChecking[where]",
+                    {$sqlPermissionChecking['where']}",
                     eZDBInterface::SERVER_SLAVE );
         }
 
@@ -1805,7 +1805,7 @@ class eZSearchEngine implements ezpSearchEngine
                        $subTreeTable
                        INNER JOIN ezcontentclass ON (ezcontentclass.id = ezcontentobject.contentclass_id)
                        INNER JOIN ezcontentobject_tree ON (ezcontentobject_tree.contentobject_id = ezcontentobject.id)
-                       $sqlPermissionChecking[from]
+                       {$sqlPermissionChecking['from']}
                     WHERE
                     $searchDateQuery
                     $sectionQuery
@@ -1815,7 +1815,7 @@ class eZSearchEngine implements ezpSearchEngine
                     $subTreeSQL
                     ezcontentclass.version = '0' AND
                     ezcontentobject_tree.node_id = ezcontentobject_tree.main_node_id
-                    $sqlPermissionChecking[where]",
+                    {$sqlPermissionChecking['where']}",
                     eZDBInterface::SERVER_SLAVE );
                 }
                 else
@@ -1832,7 +1832,7 @@ class eZSearchEngine implements ezpSearchEngine
                        INNER JOIN ezcontentclass ON (ezcontentclass.id = ezcontentobject.contentclass_id)
                        INNER JOIN ezcontentobject_tree ON (ezcontentobject_tree.contentobject_id = ezcontentobject.id)
                        INNER JOIN $tmpTable0 ON ($tmpTable0.contentobject_id = ezsearch_object_word_link.contentobject_id)
-                       $sqlPermissionChecking[from]
+                       {$sqlPermissionChecking['from']}
                     WHERE
                     $searchDateQuery
                     $sectionQuery
@@ -1842,7 +1842,7 @@ class eZSearchEngine implements ezpSearchEngine
                     $subTreeSQL
                     ezcontentclass.version = '0' AND
                     ezcontentobject_tree.node_id = ezcontentobject_tree.main_node_id
-                    $sqlPermissionChecking[where]",
+                    {$sqlPermissionChecking['where']}",
                     eZDBInterface::SERVER_SLAVE );
                 }
                 $i++;


### PR DESCRIPTION
At many locations in the code, constants are used as array keys instead of strings, e.g. `$array[key]` instead of `$array['key']`. This doesn't seem to cause errors, but **if** one day a constant with the same name as a used key was defined somewhere, things could break.

Quoting the [PHP Manual on Arrays](http://de.php.net/manual/en/language.types.array.php#language.types.array.foo-bar):

> **Why is $foo[bar] wrong?**
> 
> Always use quotes around a string literal array index. For example, `$foo['bar']` is correct, while `$foo[bar]` is not. But why? It is common to encounter this kind of syntax in old scripts:
> 
> ``` php
> <?php
> $foo[bar] = 'enemy';
> echo $foo[bar];
> // etc
> ?>
> ```
> 
> This is wrong, but it works. The reason is that this code has an undefined constant (bar) rather than a string ('bar' - notice the quotes). PHP may in the future define constants which, unfortunately for such code, have the same name. It works because PHP automatically converts a bare string (an unquoted string which does not correspond to any known symbol) into a string which contains the bare string. For instance, if there is no defined constant named bar, then PHP will substitute in the string 'bar' and use that.

If I would continue to replace these occurrences everywhere I find them, would this be getting merged back into master? What would be the requirements? 
- One commit per file (what would then be the best commit message for each one?)
- One squashed commit that includes everything?

I appreciate your feedback!
:octocat: Jérôme

PS: Travis currently fails, but I believe that this is not connected to this PR.
