### PR TITLE
Fix EZP-21738 - Warning: fopen & chmod

### DIFF
--- a/kernel/classes/clusterfilehandlers/ezfsfilehandler.php
+++ b/kernel/classes/clusterfilehandlers/ezfsfilehandler.php
@@ -186,7 +186,8 @@ class eZFSFileHandler
         eZFile::create( basename( $filePath ), dirname( $filePath ), $contents, true );
 
         $perm = eZINI::instance()->variable( 'FileSettings', 'StorageFilePermissions' );
-        chmod( $filePath, octdec( $perm ) );
+        if ( file_exists( $filePath ) )
+            chmod( $filePath, octdec( $perm ) );
 
         eZDebug::accumulatorStop( 'dbfile' );
     }
@@ -211,7 +212,8 @@ class eZFSFileHandler
 
         eZFile::create( basename( $filePath ), dirname( $filePath ), $contents, true );
         $perm = eZINI::instance()->variable( 'FileSettings', 'StorageFilePermissions' );
-        chmod( $filePath, octdec( $perm ) );
+        if ( file_exists( $filePath ) )
+            chmod( $filePath, octdec( $perm ) );
 
         eZDebug::accumulatorStop( 'dbfile' );
     }

--- a/lib/ezfile/classes/ezfile.php
+++ b/lib/ezfile/classes/ezfile.php
@@ -60,21 +60,23 @@ class eZFile
                 $dirname .= "/";
             $filepath = $dirname . "ezfile-tmp." . md5( $filepath . getmypid() . mt_rand() );
         }
-
-        $file = fopen( $filepath, 'wb' );
-        if ( $file )
+        if ( file_exists( $filepath ) )
         {
-//             eZDebugSetting::writeNotice( 'ezfile-create', "Created file $filepath", 'eZFile::create' );
-            if ( $data )
-                fwrite( $file, $data );
-            fclose( $file );
-
-            if ( $atomic )
+            $file = fopen( $filepath, 'wb' );
+            if ( $file )
             {
-                // If the renaming process fails, delete the temporary file
-                eZFile::rename( $filepath, $realpath, false, eZFile::CLEAN_ON_FAILURE );
+//             eZDebugSetting::writeNotice( 'ezfile-create', "Created file $filepath", 'eZFile::create' );
+                if ( $data )
+                    fwrite( $file, $data );
+                fclose( $file );
+
+                if ( $atomic )
+                {
+                    // If the renaming process fails, delete the temporary file
+                    eZFile::rename( $filepath, $realpath, false, eZFile::CLEAN_ON_FAILURE );
+                }
+                return true;
             }
-            return true;
         }
 //         eZDebugSetting::writeNotice( 'ezfile-create', "Failed creating file $filepath", 'eZFile::create' );
         return false;

--- a/lib/ezfile/classes/ezfile.php
+++ b/lib/ezfile/classes/ezfile.php
@@ -151,7 +151,14 @@ class eZFile
             eZDir::mkdir( dirname( $destFile ), false, true );
         }
 
-        $status = rename( $srcFile, $destFile );
+        if ( file_exists( $srcFile ) )
+        {
+            $status = rename( $srcFile, $destFile );
+        }
+        else
+        {
+            $status = false;
+        }
         // Rename operation failed, check $flags to know what to do then
         if ( $status === false )
         {


### PR DESCRIPTION
This addresses the issue http://jira.ez.no/browse/EZP-21738 in legacy appears the following warnings if xdebug is enabled

Warning: fopen(var/ezdemo_site/cache/ezfile-tmp.c19d06360486837d05e3623a1f206cc3) [function.fopen]: failed to open stream: No such file or directory in /var/www/ezp/ezpublish_legacy/lib/ezfile/classes/ezfile.php on line 64

and

Warning: chmod() [function.chmod]: No such file or directory in /var/www/ezp/ezpublish_legacy/kernel/classes/clusterfilehandlers/ezfsfilehandler.php on line 214
