### PR TITLE
EZP-21775: Make eZFSFileHandler implement eZClusterFileHandlerInterface

### DIFF
--- a/kernel/classes/clusterfilehandlers/ezfsfilehandler.php
+++ b/kernel/classes/clusterfilehandlers/ezfsfilehandler.php
@@ -8,7 +8,7 @@
  * @package kernel
  */
 
-class eZFSFileHandler
+class eZFSFileHandler implements eZClusterFileHandlerInterface
 {
     const EXPIRY_TIMESTAMP = 233366400;
 
@@ -927,7 +927,7 @@ class eZFSFileHandler
     /**
      * Ends the cache generation started by startCacheGeneration().
      */
-    public function endCacheGeneration()
+    public function endCacheGeneration( $rename = true )
     {
         return true;
     }
@@ -978,6 +978,21 @@ class eZFSFileHandler
     public function hasStaleCacheSupport()
     {
         return false;
+    }
+
+    public function getFileList($scopes = false, $excludeScopes = false)
+    {
+        return false;
+    }
+
+    public function isDBFileExpired($expiry, $curtime, $ttl)
+    {
+        return self::isFileExpired( $this->filePath, @filemtime( $this->filePath ), $expiry, $curtime, $ttl );
+    }
+
+    public function isLocalFileExpired($expiry, $curtime, $ttl)
+    {
+        return self::isFileExpired( $this->filePath, @filemtime( $this->filePath ), $expiry, $curtime, $ttl );
     }
 
     public $metaData = null;

--- a/kernel/private/classes/clusterfilehandlers/ezdfsfilehandler.php
+++ b/kernel/private/classes/clusterfilehandlers/ezdfsfilehandler.php
@@ -713,7 +713,7 @@ class eZDFSFileHandler implements eZClusterFileHandlerInterface, ezpDatabaseBase
      *                    disable TTL.
      * @return bool
      */
-    public function isFileExpired( $fname, $mtime, $expiry, $curtime, $ttl )
+    public static function isFileExpired( $fname, $mtime, $expiry, $curtime, $ttl )
     {
         if ( $mtime == false or $mtime < 0 )
         {

--- a/kernel/private/interfaces/ezclusterfilehandlerinterface.php
+++ b/kernel/private/interfaces/ezclusterfilehandlerinterface.php
@@ -140,7 +140,7 @@ interface eZClusterFileHandlerInterface
      *                    disable TTL.
      * @return bool
      */
-    public function isFileExpired( $fname, $mtime, $expiry, $curtime, $ttl );
+    public static function isFileExpired( $fname, $mtime, $expiry, $curtime, $ttl );
 
     /**
      * Calculates if the current file data is expired or not.
@@ -201,7 +201,8 @@ interface eZClusterFileHandlerInterface
 
     /**
      * Returns file contents.
-     * @return contents string, or false in case of an error.
+     * @param string $filePath
+     * @return string|bool string, or false in case of an error.
      */
     public function fileFetchContents( $filePath );
 

--- a/tests/tests/kernel/classes/clusterfilehandlers/ezclusterfilehandler_abstract_test.php
+++ b/tests/tests/kernel/classes/clusterfilehandlers/ezclusterfilehandler_abstract_test.php
@@ -382,7 +382,7 @@ abstract class eZClusterFileHandlerAbstractTest extends ezpDatabaseTestCase
         $expiry = -1;
         $curtime = time();
         $ttl = null;
-        $result = $ch->isFileExpired( $fname, $mtime, $expiry, $curtime, $ttl);
+        $result = $ch::isFileExpired( $fname, $mtime, $expiry, $curtime, $ttl);
         self::assertTrue( $result, "negative mtime: expired expected" );
 
         // FALSE mtime: expired
@@ -390,7 +390,7 @@ abstract class eZClusterFileHandlerAbstractTest extends ezpDatabaseTestCase
         $expiry = -1;
         $curtime = time();
         $ttl = null;
-        $result = $ch->isFileExpired( $fname, $mtime, $expiry, $curtime, $ttl);
+        $result = $ch::isFileExpired( $fname, $mtime, $expiry, $curtime, $ttl);
         self::assertTrue( $result, "false mtime: expired expected" );
 
         // NULL TTL + mtime < expiry: expired
@@ -398,7 +398,7 @@ abstract class eZClusterFileHandlerAbstractTest extends ezpDatabaseTestCase
         $expiry = time();
         $curtime = time();
         $ttl = null;
-        $result = $ch->isFileExpired( $fname, $mtime, $expiry, $curtime, $ttl);
+        $result = $ch::isFileExpired( $fname, $mtime, $expiry, $curtime, $ttl);
         self::assertTrue( $result,
             "no TTL + mtime < expiry: expired expected" );
 
@@ -407,7 +407,7 @@ abstract class eZClusterFileHandlerAbstractTest extends ezpDatabaseTestCase
         $expiry = time() - 3600; // expires in the future
         $curtime = time();
         $ttl = null;
-        $result = $ch->isFileExpired( $fname, $mtime, $expiry, $curtime, $ttl);
+        $result = $ch::isFileExpired( $fname, $mtime, $expiry, $curtime, $ttl);
         self::assertFalse( $result,
             "no TTL + mtime > expiry: not expired expected" );
 
@@ -416,7 +416,7 @@ abstract class eZClusterFileHandlerAbstractTest extends ezpDatabaseTestCase
         $expiry = -1; // disable expiry check
         $curtime = time();
         $ttl = 60; // 60 seconds TTL
-        $result = $ch->isFileExpired( $fname, $mtime, $expiry, $curtime, $ttl);
+        $result = $ch::isFileExpired( $fname, $mtime, $expiry, $curtime, $ttl);
         self::assertFalse( $result,
             "TTL + ( mtime < ( curtime - ttl ) ): !expired expected" );
 
@@ -425,7 +425,7 @@ abstract class eZClusterFileHandlerAbstractTest extends ezpDatabaseTestCase
         $expiry = -1; // disable expiry check
         $curtime = time();
         $ttl = 60; // 60 seconds TTL
-        $result = $ch->isFileExpired( $fname, $mtime, $expiry, $curtime, $ttl);
+        $result = $ch::isFileExpired( $fname, $mtime, $expiry, $curtime, $ttl);
         self::assertTrue( $result,
             "TTL + ( mtime > ( curtime - ttl ) ): expired expected" );
 
@@ -434,7 +434,7 @@ abstract class eZClusterFileHandlerAbstractTest extends ezpDatabaseTestCase
         $expiry = time(); // file is expired
         $curtime = time();
         $ttl = 60; // 60 seconds TTL
-        $result = $ch->isFileExpired( $fname, $mtime, $expiry, $curtime, $ttl);
+        $result = $ch::isFileExpired( $fname, $mtime, $expiry, $curtime, $ttl);
         self::assertTrue( $result,
             "TTL + ( mtime < expiry ): expired expected" );
 
@@ -443,7 +443,7 @@ abstract class eZClusterFileHandlerAbstractTest extends ezpDatabaseTestCase
         $expiry = time() - 90;
         $curtime = time();
         $ttl = 60;
-        $result = $ch->isFileExpired( $fname, $mtime, $expiry, $curtime, $ttl);
+        $result = $ch::isFileExpired( $fname, $mtime, $expiry, $curtime, $ttl);
         self::assertFalse( $result,
             "TTL + ( mtime > expiry ): !expired expected" );
     }


### PR DESCRIPTION
At the moment, `eZFSFileHandler` doesn't implement the `eZClusterFileHandler` interface which can cause problems when we use `eZClusterFileHandler::instance()`, get an `eZFSFileHandler` as a result and then use methods which are not implemented.

https://jira.ez.no/browse/EZP-21775

This PR makes `eZFSFileHandler` implement `eZClusterFileHandler`.

The method `isFileExpired` had to be changed to non-static, but will not break when called statically. (In general, IMO, the method _should_ be static, but this is not in the scope of this PR.)

I made the new methods call `isFileExpired` statically, because the same is done in `eZDFSFileHandler`.

Cheers
:octocat: Jérôme
