### PR TITLE
EZP-21773: Make sure that image reference is false if ini setting 'Reference' is empty

### DIFF
--- a/lib/ezimage/classes/ezimagemanager.php
+++ b/lib/ezimage/classes/ezimagemanager.php
@@ -765,7 +765,10 @@ class eZImageManager
             $alias['filters'] = $filters;
         }
         if ( $ini->hasVariable( $iniGroup, 'Reference' ) )
-            $alias['reference'] = $ini->variable( $iniGroup, 'Reference' );
+        {
+            $alias['reference'] = trim( $ini->variable( $iniGroup, 'Reference' ) );
+            $alias['reference'] = ( $alias['reference'] !== '' ) ? $alias['reference'] : false;
+        }
         return $alias;
     }
 


### PR DESCRIPTION
This PR checks if the setting `Reference=` in _image.ini_ is empty and sets the corresponding alias setting in eZImageManager to `false` instead of an empty string (which is the current behaviour).

The default image aliases in _image.ini_ have the `reference` image alias as reference. Many (as well as eZFlow and eZMultiUpload) override this by setting the Reference variable to an empty value:

``` ini
Reference=
```

This has the effect that the image alias settings will receive an empty string instead of the expected `false` which will create an unneeded entry in the error.log:

```
The referenced alias '' for image alias 'my_alias' does not exist, cannot use it for reference.
Will use 'original' alias instead.
```

Cheers
:octocat: Jérôme
