### PR TITLE
Fix EZP-21758: Custom variables are not correctly exposed in legacy templates when doing a sub-request

### DIFF
--- a/kernel/classes/eznodeviewfunctions.php
+++ b/kernel/classes/eznodeviewfunctions.php
@@ -151,6 +151,15 @@ class eZNodeviewfunctions
         $tpl->setVariable( 'collection_attributes', $collectionAttributes );
         $tpl->setVariable( 'validation', $validation );
         $tpl->setVariable( 'persistent_variable', false );
+        if ( isset( $viewParameters['_custom'] ) )
+        {
+            foreach ( $viewParameters['_custom'] as $customVarName => $customValue )
+            {
+                $tpl->setVariable( $customVarName, $customValue );
+            }
+
+            unset( $viewParameters['_custom'] );
+        }
 
         $parents = $node->attribute( 'path' );
 

--- a/kernel/content/view.php
+++ b/kernel/content/view.php
@@ -91,11 +91,16 @@ if ( isset( $keys['layout'] ) )
 else
     $layout = false;
 
-$viewParameters = array( 'offset' => $Offset,
-                         'year' => $Year,
-                         'month' => $Month,
-                         'day' => $Day,
-                         'namefilter' => false );
+$viewParameters = array(
+    'offset' => $Offset,
+    'year' => $Year,
+    'month' => $Month,
+    'day' => $Day,
+    'namefilter' => false,
+    '_custom' => $UserParameters
+);
+// Keep the following array_merge for BC
+// All user parameters will be exposed as direct variables in template.
 $viewParameters = array_merge( $viewParameters, $UserParameters );
 
 $user = eZUser::currentUser();


### PR DESCRIPTION
[EZP-21758](https://jira.ez.no/browse/EZP-21758)

See issue description. Basically, user parameters need to be exposed as regular variables in legacy templates.
Please note that user parameters can only be passed by calling eZModule directly, which is done in ezpublish-kernel for [legacy LocationViewProvider](https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/MVC/Legacy/View/Provider/Location.php#L77).

This is a blocker for DemoBundle, so should be in 5.2.
