### PR TITLE
Move eZScript instance into ezpTestSuite, simplifies runtests.php

### DIFF
--- a/tests/runtests.php
+++ b/tests/runtests.php
@@ -14,43 +14,19 @@ set_time_limit( 0 );
 require_once 'autoload.php';
 require_once 'PHPUnit/Autoload.php';
 
-$cli = eZCLI::instance();
-$script = eZScript::instance( array( 'description' => ( "eZ Publish Test Runner\n\n" .
-        "sets up an eZ Publish testing environment" .
-        "\n" ),
-        'use-session' => false,
-        'use-modules' => true,
-        'use-extensions' => true ) );
-
-
 if ( !class_exists( 'ezpTestRunner', true ) )
 {
     echo "The ezpTestRunner class isn't defined. Are the tests autoloads generated ?\n"
-        . "You can generate them using php bin/php/ezpgenerateautoloads.php -s";
-
-    $script->shutdown(1);
+        . "You can generate them using php bin/php/ezpgenerateautoloads.php -s\n";
+    exit(1);
 }
-
-// Override INI override folder from settings/override to
-// tests/settings to not read local override settings
-$ini = eZINI::instance();
-$ini->setOverrideDirs( array( array( 'tests/settings', true ) ), 'override' );
-$ini->loadCache();
-
-// Be sure to have clean content language data
-eZContentLanguage::expireCache();
-
-$script->startup();
-$script->initialize();
-
-// Avoids Fatal error: eZ Publish did not finish its request if die() is used.
-eZExecution::setCleanExit();
 
 $version = PHPUnit_Runner_Version::id();
 
-if ( version_compare( $version, '3.5.0' ) == -1 && $version !== '@package_version@' )
+if ( version_compare( $version, '3.7.0' ) == -1 && $version !== '@package_version@' )
 {
-    die( "PHPUnit 3.5.0 (or later) is required to run this test suite.\n" );
+    echo "PHPUnit 3.7.0 (or later) is required to run this test suite.\n";
+    exit(1);
 }
 
 try
@@ -60,10 +36,8 @@ try
 }
 catch ( Exception $e )
 {
-    $cli->error( $e->getMessage() . ' in ' . $e->getFile() . ' on line ' . $e->getLine() );
-    $cli->error( $e->getTraceAsString() );
+    echo $e->getMessage() . ' in ' . $e->getFile() . ' on line ' . $e->getLine() . "\n";
+    echo $e->getTraceAsString();
 }
-
-$script->shutdown();
 
 ?>

--- a/tests/toolkit/ezptestsuite.php
+++ b/tests/toolkit/ezptestsuite.php
@@ -11,6 +11,51 @@
 class ezpTestSuite extends PHPUnit_Framework_TestSuite
 {
     protected $sharedFixture;
+
+    /**
+     * @var eZScript
+     */
+    protected static $script;
+
+    public function __construct($theClass = '', $name = '')
+    {
+        parent::__construct($theClass, $name);
+
+        if ( !( self::$script instanceof eZScript ) )
+        {
+            self::$script = eZScript::instance(
+                array(
+                    'description' => "eZ Publish Test Runner\n\nsets up an eZ Publish testing environment\n",
+                    'use-session' => false,
+                    'use-modules' => true,
+                    'use-extensions' => true
+                )
+            );
+
+            // Override INI override folder from settings/override to
+            // tests/settings to not read local override settings
+            $ini = eZINI::instance();
+            $ini->setOverrideDirs( array( array( 'tests/settings', true ) ), 'override' );
+            $ini->loadCache();
+
+            // Be sure to have clean content language data
+            eZContentLanguage::expireCache();
+
+            self::$script->startup();
+            self::$script->initialize();
+
+            // Avoids Fatal error: eZ Publish did not finish its request if die() is used.
+            eZExecution::setCleanExit();
+        }
+    }
+
+    public function __destruct()
+    {
+        if ( self::$script instanceof eZScript )
+        {
+            self::$script->shutdown(0);
+        }
+    }
 }
 
 ?>


### PR DESCRIPTION
This PR slims down eZ Publish dependencies in the `runtests.php` script to a minimum and moves the `eZScript` initialization into the base `ezpTestSuite`.

This puts the `eZScript` instance where it belongs (inside the Suite, not in the global scope) and is a preparation to get rid of the `runtests.php` in the long term.

Cheers
:octocat: Jérôme
