### PR TITLE
EZP-21768: eZCollaborationItemGroupLink: Changed wrong var comparison to assignments

### DIFF
--- a/kernel/classes/ezcollaborationitemgrouplink.php
+++ b/kernel/classes/ezcollaborationitemgrouplink.php
@@ -108,7 +108,10 @@ class eZCollaborationItemGroupLink extends eZPersistentObject
     function fetch( $collaborationID, $groupID, $userID = false, $asObject = true )
     {
         if ( $userID == false )
-            $userID == eZUser::currentUserID();
+        {
+            $userID = eZUser::currentUserID();
+        }
+
         return eZPersistentObject::fetchObject( eZCollaborationItemGroupLink::definition(),
                                                 null,
                                                 array( 'collaboration_id' => $collaborationID,
@@ -120,7 +123,10 @@ class eZCollaborationItemGroupLink extends eZPersistentObject
     function fetchList( $collaborationID, $userID = false, $asObject = true )
     {
         if ( $userID == false )
-            $userID == eZUser::currentUserID();
+        {
+            $userID = eZUser::currentUserID();
+        }
+
         return eZPersistentObject::fetchObjectList( eZCollaborationItemGroupLink::definition(),
                                                     null,
                                                     array( 'collaboration_id' => $collaborationID,


### PR DESCRIPTION
When `$userID` is not provided (or `false` is given) to the methods `fetch()` and `fetchList()` the current user's ID should be used. Currently, `$userID` would remain `false` because `$userID` is compared to `eZUser::currentUserID();` instead of assigning it to the former.

https://jira.ez.no/browse/EZP-21768

Cheers
:octocat: Jérôme
