### PR TITLE
Fix EZP-21656: PSpell plugin fails with eZFormToken

### DIFF
--- a/extension/ezoe/design/standard/templates/content/datatype/edit/ezxmltext_ezoe.tpl
+++ b/extension/ezoe/design/standard/templates/content/datatype/edit/ezxmltext_ezoe.tpl
@@ -115,6 +115,7 @@
         ez_tinymce_url : {'javascript/tiny_mce.js'|ezdesign},
         ez_contentobject_id : {$attribute.contentobject_id},
         ez_contentobject_version : {$attribute.version},
+        ez_form_token: "@$ezxFormToken@",
         spellchecker_rpc_url : {'/ezoe/spellcheck_rpc'|ezurl},
         spellchecker_languages : '{$spell_languages}',
         atd_rpc_url : {'/ezoe/atd_rpc?url='|ezurl},


### PR DESCRIPTION
# Description

The TinyMCE PSpell plugin generates AJAX POST request without the form token, as a result those requests always fail.

Unfortunately, the Spellchecker and the internal TinyMCE components (JSONRequest and XHR utilities) are not extensible at all, so this patch roughly overrides the TinyMCE's XHR utility to take into account the form token.
Original XHR code is available at https://github.com/ezsystems/ezpublish-legacy/blob/master/extension/ezoe/design/standard/javascript/classes/util/XHR.js

Note: the spellchecker plugin is the only one in Online Editor to generate POST request.
# Tests

manual tests
