### PR TITLE
EZP-21802: eZImageManagerTest suite only gets executed when ImageMagick and GD are present

### DIFF
--- a/tests/tests/lib/ezimage/ezimagemanager_test.php
+++ b/tests/tests/lib/ezimage/ezimagemanager_test.php
@@ -61,8 +61,8 @@ class eZImageManagerTest extends ezpTestCase
      */
     public function testMultiHandlerAlias()
     {
-        if ( !self::gdIsEnabled() or !self::imageMagickIsEnabled() )
-            $this->markTestSkipped( 'GD and/or ImageMagick are not enabled' );
+        if ( !self::gdIsEnabled() && !self::imageMagickIsEnabled() )
+            $this->markTestSkipped( 'Neither GD nor ImageMagick are enabled' );
 
         $aliasList = $this->imageIni->variable( 'AliasSettings', 'AliasList' );
         array_push( $aliasList, 'multihandler' );


### PR DESCRIPTION
The `eZImageManagerTest` Suite only gets executed when ImageMagick _and_ GD are installed, not when only one of them is present, due to this check:

``` php
if ( !self::gdIsEnabled() or !self::imageMagickIsEnabled() )
            $this->markTestSkipped( 'GD and/or ImageMagick are not enabled' );
```

This PR aims to fix that by replacing `or` with `&&`.

Cheers
:octocat: Jérôme
