### PR TITLE
EZP-21825: Temporary files don't always get cleaned up, filling up disk space

### DIFF
--- a/kernel/private/classes/clusterfilehandlers/dfsbackends/dfs.php
+++ b/kernel/private/classes/clusterfilehandlers/dfsbackends/dfs.php
@@ -100,6 +100,11 @@ class eZDFSFileHandlerDFSBackend implements eZDFSFileHandlerDFSBackendInterface
             $ret = $this->copyTimestamp( $srcFilePath, $dstFilePath );
         }
 
+        if ( !$ret && file_exists( $dstFilePath ) )
+        {
+            unlink( $dstFilePath );
+        }
+
         $this->accumulatorStop();
 
         return $ret;


### PR DESCRIPTION
Temporary files could be left on the local FS when the copy from DFS to FS is considered unsuccessful.

In `eZDFSFileHandlerMySQLiBackend::_fetch()` the filename of the temporary file changes in every iteration of the loop, but gets deleted only after the loop.

So, when the loop gets iterated 3 times and the copy process is still unsuccessful, 2 temporary files remain on the file system.

https://jira.ez.no/browse/EZP-21825

Cheers
:octocat: Jérôme
