### PR TITLE
Added or replaced meaningful label for eZDebug messages

### DIFF
--- a/doc/bc/5.3/changes-5.3.txt
+++ b/doc/bc/5.3/changes-5.3.txt
@@ -18,6 +18,9 @@ Change of behavior
 
   This change is needed to make ezfind.ini[IndexOptions]\DisableDeleteCommits option of eZFind actually work.
 
+- Debug messages triggered by eZDebug::write* now consistently contain the method names in which they were triggered.
+
+  If you rely on the previously static labels, e.g. for log parsing, please consider adapting your parsers.
 
 Removed features
 ----------------

--- a/extension/ezoe/ezxmltext/handlers/input/ezoeinputparser.php
+++ b/extension/ezoe/ezxmltext/handlers/input/ezoeinputparser.php
@@ -266,7 +266,7 @@ class eZOEInputParser extends eZXMLInputParser
                     }
                     else
                     {
-                        eZDebug::writeWarning( "No namespace defined for prefix '$prefix'.", 'eZXML input parser' );
+                        eZDebug::writeWarning( "No namespace defined for prefix '$prefix'.", __METHOD__ );
                     }
                 }
                 else

--- a/kernel/class/copy.php
+++ b/kernel/class/copy.php
@@ -80,7 +80,7 @@ switch ( $classRedirect )
 
     default:
     {
-        eZDebug::writeWarning( "Invalid ClassRedirect value '$classRedirect', use one of: grouplist, classlist, classedit or classview" );
+        eZDebug::writeWarning( "Invalid ClassRedirect value '$classRedirect', use one of: grouplist, classlist, classedit or classview", __METHOD__ );
     }
 
     case 'classedit':

--- a/kernel/classes/clusterfilehandlers/ezfsfilehandler.php
+++ b/kernel/classes/clusterfilehandlers/ezfsfilehandler.php
@@ -68,7 +68,7 @@ class eZFSFileHandler implements eZClusterFileHandlerInterface
             }
             if ( !$mutex->steal() )
             {
-                eZDebug::writeWarning( "Failed to steal lock for file " . $this->filePath . " from PID $oldPid" );
+                eZDebug::writeWarning( "Failed to steal lock for file " . $this->filePath . " from PID $oldPid", __METHOD__ );
                 return false;
             }
             $mutex->setMeta( 'pid', getmypid() );
@@ -499,7 +499,7 @@ class eZFSFileHandler implements eZClusterFileHandlerInterface
         if ( $binaryData === null &&
              $fileContent === null )
         {
-            eZDebug::writeError( "Write callback need to set the 'content' or 'binarydata' entry" );
+            eZDebug::writeError( "Write callback need to set the 'content' or 'binarydata' entry", __METHOD__ );
             return null;
         }
 

--- a/kernel/classes/datatypes/ezauthor/ezauthortype.php
+++ b/kernel/classes/datatypes/ezauthor/ezauthortype.php
@@ -241,7 +241,7 @@ class eZAuthorType extends eZDataType
             }break;
             default :
             {
-                eZDebug::writeError( "Unknown custom HTTP action: " . $action, "eZAuthorType" );
+                eZDebug::writeError( "Unknown custom HTTP action: " . $action, __METHOD__ );
             }break;
         }
     }

--- a/kernel/classes/datatypes/ezbinaryfile/ezbinaryfile.php
+++ b/kernel/classes/datatypes/ezbinaryfile/ezbinaryfile.php
@@ -208,12 +208,12 @@ class eZBinaryFile extends eZPersistentObject
             }
             else
             {
-                eZDebug::writeWarning( "Plugin for $this->MimeType was not found", 'eZBinaryFile' );
+                eZDebug::writeWarning( "Plugin for $this->MimeType was not found", __METHOD__ );
             }
         }
         else
         {
-            eZDebug::writeWarning( "Mimetype $this->MimeType not supported for indexing", 'eZBinaryFile' );
+            eZDebug::writeWarning( "Mimetype $this->MimeType not supported for indexing", __METHOD__ );
         }
 
         return $metaData;

--- a/kernel/classes/datatypes/ezenum/ezenumtype.php
+++ b/kernel/classes/datatypes/ezenum/ezenumtype.php
@@ -322,7 +322,7 @@ class eZEnumType extends eZDataType
             }break;
             default :
             {
-                eZDebug::writeError( 'Unknown custom HTTP action: ' . $action, 'eZEnumType' );
+                eZDebug::writeError( 'Unknown custom HTTP action: ' . $action, __METHOD__ );
             }break;
         }
     }

--- a/kernel/classes/datatypes/ezfloat/ezfloattype.php
+++ b/kernel/classes/datatypes/ezfloat/ezfloattype.php
@@ -260,7 +260,7 @@ class eZFloatType extends eZDataType
                     else
                     {
                         $state = eZInputValidator::STATE_INTERMEDIATE;
-                        eZDebug::writeNotice( "Integer minimum value great than maximum value." );
+                        eZDebug::writeNotice( "Integer minimum value greater than maximum value.", __METHOD__ );
                         return $state;
                     }
                 }

--- a/kernel/classes/datatypes/ezinteger/ezintegertype.php
+++ b/kernel/classes/datatypes/ezinteger/ezintegertype.php
@@ -283,7 +283,7 @@ class eZIntegerType extends eZDataType
                     else
                     {
                         $state = eZInputValidator::STATE_INTERMEDIATE;
-                        eZDebug::writeNotice( "Integer minimum value great than maximum value." );
+                        eZDebug::writeNotice( "Integer minimum value greater than maximum value.", __METHOD__ );
                         return $state;
                     }
                 }

--- a/kernel/classes/datatypes/ezmatrix/ezmatrixtype.php
+++ b/kernel/classes/datatypes/ezmatrix/ezmatrixtype.php
@@ -197,7 +197,7 @@ class eZMatrixType extends eZDataType
             }break;
             default :
             {
-                eZDebug::writeError( 'Unknown custom HTTP action: ' . $action, 'eZMatrixType' );
+                eZDebug::writeError( 'Unknown custom HTTP action: ' . $action, __METHOD__ );
             }break;
         }
     }
@@ -375,7 +375,7 @@ class eZMatrixType extends eZDataType
             }break;
             default :
             {
-                eZDebug::writeError( 'Unknown custom HTTP action: ' . $action, 'eZEnumType' );
+                eZDebug::writeError( 'Unknown custom HTTP action: ' . $action, __METHOD__ );
             }break;
         }
     }

--- a/kernel/classes/datatypes/ezmedia/ezmediatype.php
+++ b/kernel/classes/datatypes/ezmedia/ezmediatype.php
@@ -338,7 +338,7 @@ class eZMediaType extends eZDataType
             }
 
             $orig_dir = $mediaFile->storageDir( "original" );
-            eZDebug::writeNotice( "dir=$orig_dir" );
+            eZDebug::writeNotice( "dir=$orig_dir", __METHOD__ );
             $media->setAttribute( "filename", basename( $mediaFile->attribute( "filename" ) ) );
             $media->setAttribute( "original_filename", $mediaFile->attribute( "original_filename" ) );
             $media->setAttribute( "mime_type", $mime );

--- a/kernel/classes/datatypes/ezmultioption/ezmultioptiontype.php
+++ b/kernel/classes/datatypes/ezmultioption/ezmultioptiontype.php
@@ -270,7 +270,7 @@ class eZMultiOptionType extends eZDataType
 
                 default:
                 {
-                    eZDebug::writeError( "Unknown custom HTTP action: " . $action, "eZMultiOptionType" );
+                    eZDebug::writeError( "Unknown custom HTTP action: " . $action, __METHOD__ );
                 } break;
             }
         }

--- a/kernel/classes/datatypes/ezmultioption2/ezmultioption2type.php
+++ b/kernel/classes/datatypes/ezmultioption2/ezmultioption2type.php
@@ -466,7 +466,7 @@ class eZMultiOption2Type extends eZDataType
         }
         else
         {
-            eZDebug::writeError( "Unknown custom HTTP action: " . $action, "eZMultiOptionType" );
+            eZDebug::writeError( "Unknown custom HTTP action: " . $action, __METHOD__ );
         }
     }
 

--- a/kernel/classes/datatypes/ezmultiprice/ezmultipricetype.php
+++ b/kernel/classes/datatypes/ezmultiprice/ezmultipricetype.php
@@ -258,7 +258,7 @@ class eZMultiPriceType extends eZDataType
 
             default :
             {
-                eZDebug::writeError( 'Unknown custom HTTP action: ' . $action, 'eZMultiPriceType' );
+                eZDebug::writeError( 'Unknown custom HTTP action: ' . $action, __METHOD__ );
             }break;
         }
     }

--- a/kernel/classes/datatypes/ezobjectrelation/ezobjectrelationtype.php
+++ b/kernel/classes/datatypes/ezobjectrelation/ezobjectrelationtype.php
@@ -339,7 +339,7 @@ class eZObjectRelationType extends eZDataType
 
             default :
             {
-                eZDebug::writeError( "Unknown custom HTTP action: " . $action, "eZObjectRelationType" );
+                eZDebug::writeError( "Unknown custom HTTP action: " . $action, __METHOD__ );
             } break;
         }
     }
@@ -562,7 +562,7 @@ class eZObjectRelationType extends eZDataType
             $relatedObject = eZContentObject::fetch( $relatedObjectID );
             if ( !$relatedObject )
             {
-                eZDebug::writeNotice( 'Related object with ID: ' . $relatedObjectID . ' does not exist.' );
+                eZDebug::writeNotice( 'Related object with ID: ' . $relatedObjectID . ' does not exist.', __METHOD__ );
             }
             else
             {

--- a/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
+++ b/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
@@ -1091,7 +1091,7 @@ class eZObjectRelationListType extends eZDataType
         else
         {
             eZDebug::writeError( "Unknown custom HTTP action: " . $action,
-                                 'eZObjectRelationListType' );
+                                 __METHOD__ );
         }
     }
 
@@ -1597,7 +1597,7 @@ class eZObjectRelationListType extends eZDataType
             }
             else
             {
-                eZDebug::writeWarning( $objectID, "Can not create relation because object is missing" );
+                eZDebug::writeWarning( "Can not create relation because object {$objectID} is missing", __METHOD__ );
             }
         }
         $contentObjectAttribute->setContent( $content );
@@ -1769,7 +1769,7 @@ class eZObjectRelationListType extends eZDataType
                         $success = $relationItem->removeAttribute( $attribute->localName );
                         if ( !$success )
                         {
-                            eZDebug::writeError( 'failed removing attribute ' . $attrName . ' from relation-item element' );
+                            eZDebug::writeError( 'failed removing attribute ' . $attrName . ' from relation-item element', __METHOD__ );
                         }
                     }
                 }

--- a/kernel/classes/datatypes/ezoption/ezoptiontype.php
+++ b/kernel/classes/datatypes/ezoption/ezoptiontype.php
@@ -236,7 +236,7 @@ class eZOptionType extends eZDataType
             }break;
             default :
             {
-                eZDebug::writeError( "Unknown custom HTTP action: " . $action, "eZOptionType" );
+                eZDebug::writeError( "Unknown custom HTTP action: " . $action, __METHOD__ );
             }break;
         }
     }

--- a/kernel/classes/datatypes/ezuser/ezuser.php
+++ b/kernel/classes/datatypes/ezuser/ezuser.php
@@ -1190,13 +1190,13 @@ WHERE user_id = '" . $userID . "' AND
         if ( !$currentUser )
         {
             $currentUser = eZUser::fetch( self::anonymousId() );
-            eZDebug::writeWarning( 'User not found, returning anonymous' );
+            eZDebug::writeWarning( 'User not found, returning anonymous', __METHOD__ );
         }
 
         if ( !$currentUser )
         {
             $currentUser = new eZUser( array( 'id' => -1, 'login' => 'NoUser' ) );
-            eZDebug::writeWarning( 'Anonymous user not found, returning NoUser' );
+            eZDebug::writeWarning( 'Anonymous user not found, returning NoUser', __METHOD__ );
         }
 
         $GLOBALS["eZUserGlobalInstance_$id"] = $currentUser;
@@ -2272,14 +2272,14 @@ WHERE user_id = '" . $userID . "' AND
                         if ( !empty( $buffer ) or $ret === false )
                         {
                             eZDebug::writeError( "There was an error while evaluating the policy functions value of the '$moduleName/$viewName' view. " .
-                                                 "Please check the '$moduleName/module.php' file." );
+                                                 "Please check the '$moduleName/module.php' file.", __METHOD__ );
                             $accessAllowed = false;
                         }
                     }
                     else
                     {
                         eZDebug::writeError( "There is a mistake in the functions array data of the '$moduleName/$viewName' view. " .
-                                             "Please check the '$moduleName/module.php' file." );
+                                             "Please check the '$moduleName/module.php' file.", __METHOD__ );
                         $accessAllowed = false;
                     }
                 }

--- a/kernel/classes/datatypes/ezxmltext/ezxmlinputparser.php
+++ b/kernel/classes/datatypes/ezxmltext/ezxmlinputparser.php
@@ -655,7 +655,7 @@ class eZXMLInputParser
                     }
                     else
                     {
-                        eZDebug::writeWarning( "No namespace defined for prefix '$prefix'.", 'eZXML input parser' );
+                        eZDebug::writeWarning( "No namespace defined for prefix '$prefix'.", __METHOD__ );
                     }
                 }
                 else
@@ -1147,7 +1147,7 @@ class eZXMLInputParser
             }
             else
             {
-                eZDebug::writeWarning( "'$handlerName' input handler for tag <$tagName> doesn't exist: '" . $thisInputTag[$handlerName] . "'.", 'eZXML input parser' );
+                eZDebug::writeWarning( "'$handlerName' input handler for tag <$tagName> doesn't exist: '" . $thisInputTag[$handlerName] . "'.", __METHOD__ );
             }
         }
         return $result;
@@ -1166,7 +1166,7 @@ class eZXMLInputParser
             }
             else
             {
-                eZDebug::writeWarning( "'$handlerName' output handler for tag <$element->nodeName> doesn't exist: '" . $thisOutputTag[$handlerName] . "'.", 'eZXML input parser' );
+                eZDebug::writeWarning( "'$handlerName' output handler for tag <$element->nodeName> doesn't exist: '" . $thisOutputTag[$handlerName] . "'.", __METHOD__ );
             }
         }
 

--- a/kernel/classes/datatypes/ezxmltext/ezxmloutputhandler.php
+++ b/kernel/classes/datatypes/ezxmltext/ezxmloutputhandler.php
@@ -342,7 +342,7 @@ class eZXMLOutputHandler
                     $classesList = $this->XMLSchema->getClassesList( $tagName );
                     if ( !in_array( $attrNode->value, $classesList ) )
                     {
-                        eZDebug::writeWarning( "Using tag '$tagName' with class '$attrNode->value' is not allowed.", 'XML output handler' );
+                        eZDebug::writeWarning( "Using tag '$tagName' with class '$attrNode->value' is not allowed.", __METHOD__ );
                         return array( true, '' );
                     }
                 }
@@ -637,7 +637,7 @@ class eZXMLOutputHandler
         }
         else
         {
-            eZDebug::writeWarning( "'$handlerName' render handler for tag <$element->nodeName> doesn't exist: '" . $thisOutputTag[$handlerName] . "'.", 'eZXML converter' );
+            eZDebug::writeWarning( "'$handlerName' render handler for tag <$element->nodeName> doesn't exist: '" . $thisOutputTag[$handlerName] . "'.", __METHOD__ );
         }
         return $result;
     }

--- a/kernel/classes/datatypes/ezxmltext/handlers/input/ezsimplifiedxmleditoutput.php
+++ b/kernel/classes/datatypes/ezxmltext/handlers/input/ezsimplifiedxmleditoutput.php
@@ -297,7 +297,7 @@ class eZSimplifiedXMLEditOutput
             }
             else
             {
-                eZDebug::writeWarning( "'$handlerName' output handler for tag <$element->nodeName> doesn't exist: '" . $thisOutputTag[$handlerName] . "'.", 'eZXML converter' );
+                eZDebug::writeWarning( "'$handlerName' output handler for tag <$element->nodeName> doesn't exist: '" . $thisOutputTag[$handlerName] . "'.", __METHOD__ );
             }
         }
         return $result;

--- a/kernel/classes/datatypes/ezxmltext/handlers/output/ezxhtmlxmloutput.php
+++ b/kernel/classes/datatypes/ezxmltext/handlers/output/ezxhtmlxmloutput.php
@@ -211,7 +211,7 @@ class eZXHTMLXMLOutput extends eZXMLOutputHandler
             }
             else
             {
-                eZDebug::writeWarning( "Node #$nodeID doesn't exist", "XML output handler: link" );
+                eZDebug::writeWarning( "Node #$nodeID doesn't exist", __METHOD__ );
             }
         }
         elseif ( $element->getAttribute( 'object_id' ) != null )
@@ -233,12 +233,12 @@ class eZXHTMLXMLOutput extends eZXMLOutputHandler
                 }
                 else
                 {
-                    eZDebug::writeWarning( "Object #$objectID doesn't have assigned nodes", "XML output handler: link" );
+                    eZDebug::writeWarning( "Object #$objectID doesn't have assigned nodes", __METHOD__ );
                 }
             }
             else
             {
-                eZDebug::writeWarning( "Object #$objectID doesn't exist", "XML output handler: link" );
+                eZDebug::writeWarning( "Object #$objectID doesn't exist", __METHOD__ );
             }
         }
         elseif ( $element->getAttribute( 'href' ) != null )
@@ -286,7 +286,7 @@ class eZXHTMLXMLOutput extends eZXMLOutputHandler
                 }
                 else
                 {
-                    eZDebug::writeWarning( "Node #$nodeID doesn't exist", "XML output handler: embed" );
+                    eZDebug::writeWarning( "Node #$nodeID doesn't exist", __METHOD__ );
                     return $ret;
                 }
             }
@@ -294,12 +294,12 @@ class eZXHTMLXMLOutput extends eZXMLOutputHandler
 
         if ( !isset( $object ) || !$object || !( $object instanceof eZContentObject ) )
         {
-            eZDebug::writeWarning( "Can't fetch object #$objectID", "XML output handler: embed" );
+            eZDebug::writeWarning( "Can't fetch object #$objectID", __METHOD__ );
             return $ret;
         }
         if ( $object->attribute( 'status' ) != eZContentObject::STATUS_PUBLISHED )
         {
-            eZDebug::writeWarning( "Object #$objectID is not published", "XML output handler: embed" );
+            eZDebug::writeWarning( "Object #$objectID is not published", __METHOD__ );
             return $ret;
         }
 
@@ -310,7 +310,7 @@ class eZXHTMLXMLOutput extends eZXMLOutputHandler
                 // embed with a node ID
                 if ( $node->attribute( 'is_invisible' ) )
                 {
-                    eZDebug::writeNotice( "Node #{$nodeID} is invisible", "XML output handler: embed" );
+                    eZDebug::writeNotice( "Node #{$nodeID} is invisible", __METHOD__ );
                     return $ret;
                 }
             }

--- a/kernel/classes/ezcontentobjectassignmenthandler.php
+++ b/kernel/classes/ezcontentobjectassignmenthandler.php
@@ -146,13 +146,13 @@ class eZContentObjectAssignmentHandler
             if ( isset( $assignmentRules[1] ) )
                 $mainID = $assignmentRules[1];
         }
-        eZDebug::writeDebug( $assignments, 'assignments' );
+        eZDebug::writeDebug( $assignments, __METHOD__ );
         if ( $assignments )
         {
             if ( $mainID )
                 $mainID = $this->nodeID( $mainID );
             $nodeList = $this->nodeIDList( $assignments );
-            eZDebug::writeDebug( $nodeList, 'nodeList' );
+            eZDebug::writeDebug( $nodeList, __METHOD__ );
             $assignmentCount = 0;
             eZDebug::writeDebug( $this->CurrentObject->attribute( 'id' ), 'current object' );
             eZDebug::writeDebug( $this->CurrentVersion->attribute( 'version' ), 'current version' );
@@ -163,12 +163,12 @@ class eZContentObjectAssignmentHandler
                     continue;
                 $parentContentObject = $node->attribute( 'object' );
 
-                eZDebug::writeDebug( "Checking for '$nodeID'" );
+                eZDebug::writeDebug( "Checking for '$nodeID'", __METHOD__ );
                 if ( $parentContentObject->checkAccess( 'create',
                                                         $contentClassID,
                                                         $parentContentObject->attribute( 'contentclass_id' ) ) == '1' )
                 {
-                    eZDebug::writeDebug( "Adding to '$nodeID' and main = '$mainID'" );
+                    eZDebug::writeDebug( "Adding to '$nodeID' and main = '$mainID'", __METHOD__ );
                     if ( $mainID === false )
                     {
                         $isMain = ( $assignmentCount == 0 );

--- a/kernel/classes/ezcontentobjecttreenode.php
+++ b/kernel/classes/ezcontentobjecttreenode.php
@@ -716,7 +716,7 @@ class eZContentObjectTreeNode extends eZPersistentObject
                                 }
                                 else
                                 {
-                                    eZDebug::writeError( "Unknown content object state group '$stateGroupID'" );
+                                    eZDebug::writeError( "Unknown content object state group '$stateGroupID'", __METHOD__ );
                                     continue 2;
                                 }
                             }
@@ -1334,7 +1334,7 @@ class eZContentObjectTreeNode extends eZPersistentObject
 
                 if ( $totalAttributesFiltersCount == $invalidAttributesFiltersCount )
                 {
-                    eZDebug::writeNotice( "Attribute filter returned false" );
+                    eZDebug::writeNotice( "Attribute filter returned false", __METHOD__ );
                     $filterSQL = false;
                 }
                 else
@@ -1958,7 +1958,7 @@ class eZContentObjectTreeNode extends eZPersistentObject
         $classCondition          = eZContentObjectTreeNode::createClassFilteringSQLString( $params['ClassFilterType'], $params['ClassFilterArray'] );
         if ( $classCondition === false )
         {
-            eZDebug::writeNotice( "Class filter returned false" );
+            eZDebug::writeNotice( "Class filter returned false", __METHOD__ );
             return null;
         }
 
@@ -2124,7 +2124,7 @@ class eZContentObjectTreeNode extends eZPersistentObject
     {
         if( !is_array( $nodesParams ) || !count( $nodesParams ) )
         {
-            eZDebug::writeWarning( __METHOD__.': Nodes parameter must be an array with at least one key.' );
+            eZDebug::writeWarning( 'Nodes parameter must be an array with at least one key.', __METHOD__ );
             return null;
         }
 
@@ -2154,7 +2154,7 @@ class eZContentObjectTreeNode extends eZPersistentObject
 
             if ( !is_numeric( $nodeID ) && !is_array( $nodeID ) )
             {
-                eZDebug::writeWarning( __METHOD__.': Nodes parameter must be numeric or an array with numeric values.' );
+                eZDebug::writeWarning( 'Nodes parameter must be numeric or an array with numeric values.', __METHOD__ );
                 $retValue = null;
                 return $retValue;
             }
@@ -2978,7 +2978,7 @@ class eZContentObjectTreeNode extends eZPersistentObject
         }
         else if ( count( $nodeListArray ) > 1 )
         {
-            eZDebug::writeError( $nodeListArray , "There are more then one main_node for objectID: $objectID" );
+            eZDebug::writeError( "There are more then one main_node for objectID $objectID: " . implode( ', ', $nodeListArray ), __METHOD__ );
         }
 
         return null;
@@ -6093,13 +6093,13 @@ class eZContentObjectTreeNode extends eZPersistentObject
     {
         if ( !$node )
         {
-            eZDebug::writeWarning( 'No such node to update visibility for.' );
+            eZDebug::writeWarning( 'No such node to update visibility for.', __METHOD__ );
             return;
         }
 
         if ( !$parentNode )
         {
-            eZDebug::writeWarning( 'No parent node found when updating node visibility' );
+            eZDebug::writeWarning( 'No parent node found when updating node visibility', __METHOD__ );
             return;
         }
 

--- a/kernel/classes/ezcontentobjecttreenodeoperations.php
+++ b/kernel/classes/ezcontentobjecttreenodeoperations.php
@@ -114,7 +114,7 @@ class eZContentObjectTreeNodeOperations
         }
         else
         {
-            eZDebug::writeError( "Node $nodeID was moved to $newParentNodeID but fetching the new node failed" );
+            eZDebug::writeError( "Node $nodeID was moved to $newParentNodeID but fetching the new node failed", __METHOD__ );
         }
 
         $db->commit();

--- a/kernel/classes/ezcontentobjectversion.php
+++ b/kernel/classes/ezcontentobjectversion.php
@@ -1580,7 +1580,7 @@ class eZContentObjectVersion extends eZPersistentObject
             }
             if ( count( $parentNodeIDList ) == 0 )
             {
-                eZDebug::writeWarning( $this, "unable to get parent nodes for version" );
+                eZDebug::writeWarning( "Unable to get parent nodes for ContentobjectID {$this->attribute( 'contentobject_id' )}, Version {$this->attribute( 'version' )}", __METHOD__ );
                 return;
             }
             $parentNodeIDString = implode( ',' , $parentNodeIDList );
@@ -1596,7 +1596,7 @@ class eZContentObjectVersion extends eZPersistentObject
         }
         else
         {
-            eZDebug::writeWarning( $this, "trying to unpublish non published version" );
+            eZDebug::writeWarning( "Trying to unpublish non published version {$this->attribute( 'version' )} of Contentobject {$this->attribute( 'contentobject_id' )}", __METHOD__ );
         }
 
     }

--- a/kernel/classes/ezdatatype.php
+++ b/kernel/classes/ezdatatype.php
@@ -1284,7 +1284,7 @@ class eZDataType
             {
                 eZDebug::writeWarning( "Extension '$extensionDirectory' does not have the subdirectory 'datatypes'\n" .
                                        "Looked for directory '" . $extensionPath . "'\n" .
-                                       "Cannot look for datatype '$type' in this extension." );
+                                       "Cannot look for datatype '$type' in this extension.", __METHOD__ );
             }
         }
         $foundEventType = false;

--- a/kernel/classes/eznodeassignment.php
+++ b/kernel/classes/eznodeassignment.php
@@ -193,7 +193,7 @@ class eZNodeAssignment extends eZPersistentObject
     {
         if ( !isset( $parameters['contentobject_id'] ) )
         {
-            eZDebug::writeError( $parameters, "Cannot create node assignment without contentobject_id" );
+            eZDebug::writeError( "Cannot create node assignment without contentobject_id, got: " . var_export( $parameters ), __METHOD__ );
             $retValue = null;
             return $retValue;
         }

--- a/kernel/classes/ezpackage.php
+++ b/kernel/classes/ezpackage.php
@@ -509,7 +509,7 @@ class eZPackage
             }
             else
             {
-                eZDebug::writeError( "Could not open file $file for md5sum calculation" );
+                eZDebug::writeError( "Could not open file $file for md5sum calculation", __METHOD__ );
             }
         }
         else
@@ -1107,7 +1107,7 @@ class eZPackage
     {
         if ( is_dir( $archiveName ) )
         {
-            eZDebug::writeError( "Importing from directory is not supported." );
+            eZDebug::writeError( "Importing from directory is not supported.", __METHOD__ );
             $retValue = false;
             return $retValue;
         }
@@ -1141,7 +1141,7 @@ class eZPackage
                 {
                     if ( !$archive->extractCurrent( $archivePath ) )
                     {
-                        eZDebug::writeError( "Failed extracting package definition file from $archivePath" );
+                        eZDebug::writeError( "Failed extracting package definition file from $archivePath", __METHOD__ );
                         return false;
                     }
                 }
@@ -1186,12 +1186,12 @@ class eZPackage
                 $package = eZPackage::fetch( $packageName, $fullRepositoryPath, false, $dbAvailable );
                 if ( !$package )
                 {
-                    eZDebug::writeError( "Failed loading imported package $packageName from $fullRepositoryPath" );
+                    eZDebug::writeError( "Failed loading imported package $packageName from $fullRepositoryPath", __METHOD__ );
                 }
             }
             else
             {
-                eZDebug::writeError( "Failed loading temporary package $packageName" );
+                eZDebug::writeError( "Failed loading temporary package $packageName", __METHOD__ );
             }
 
             return $package;
@@ -1281,7 +1281,7 @@ class eZPackage
         }
         else
         {
-            eZDebug::writeError( "Failed to write package '$filename'" );
+            eZDebug::writeError( "Failed to write package '$filename'", __METHOD__ );
         }
         return false;
     }
@@ -1870,7 +1870,7 @@ class eZPackage
         {
             if ( !$this->installItem( $item, $installParameters ) )
             {
-                eZDebug::writeDebug( $item, 'item which failed installing' );
+                eZDebug::writeDebug( 'item which failed installing: ' . var_export( $item ), __METHOD__ );
                 $installResult = false;
             }
         }

--- a/kernel/classes/ezpathelement.php
+++ b/kernel/classes/ezpathelement.php
@@ -97,7 +97,7 @@ class eZPathElement extends eZPersistentObject
      */
     function store( $fieldFilters = null )
     {
-        eZDebug::writeError( "Cannot store objects of eZPathElement, use eZURLAliasML instead" );
+        eZDebug::writeError( "Cannot store objects of eZPathElement, use eZURLAliasML instead", __METHOD__ );
         return;
     }
 
@@ -106,7 +106,7 @@ class eZPathElement extends eZPersistentObject
      */
     function removeThis()
     {
-        eZDebug::writeError( "Cannot remove objects of eZPathElement, use eZURLAliasML instead" );
+        eZDebug::writeError( "Cannot remove objects of eZPathElement, use eZURLAliasML instead", __METHOD__ );
         return;
     }
 

--- a/kernel/classes/ezpendingactions.php
+++ b/kernel/classes/ezpendingactions.php
@@ -69,7 +69,7 @@ class eZPendingActions extends eZPersistentObject
         {
             if( count( $aCreationDateFilter ) != 2 )
             {
-                eZDebug::writeError( __CLASS__.'::'.__METHOD__.' : Wrong number of entries for Creation date filter array' );
+                eZDebug::writeError( 'Wrong number of entries for Creation date filter array', __METHOD__ );
                 return null;
             }
 
@@ -77,7 +77,7 @@ class eZPendingActions extends eZPersistentObject
             $aAuthorizedFilterTokens = array( '=', '<', '>', '<=', '>=' );
             if( !is_string( $filterToken ) || !in_array( $filterToken, $aAuthorizedFilterTokens ) )
             {
-                eZDebug::writeError( __CLASS__.'::'.__METHOD__.' : Wrong filter type for creation date filter' );
+                eZDebug::writeError( 'Wrong filter type for creation date filter', __METHOD__ );
                 return null;
             }
 

--- a/kernel/classes/ezpreferences.php
+++ b/kernel/classes/ezpreferences.php
@@ -56,7 +56,7 @@ class eZPreferences
             $user = eZUser::fetch( $storeUserID );
             if ( !is_object( $user ) )
             {
-                eZDebug::writeError( "Cannot set preference for user $storeUserID, the user does not exist" );
+                eZDebug::writeError( "Cannot set preference for user $storeUserID, the user does not exist", __METHOD__ );
                 return false;
             }
         }

--- a/kernel/classes/ezsearch.php
+++ b/kernel/classes/ezsearch.php
@@ -493,8 +493,8 @@ class eZSearch
             }
         }
 
-        eZDebug::writeDebug( 'Unable to find the search engine:' . $searchEngineString, 'eZSearch' );
-        eZDebug::writeDebug( 'Tried paths: ' . implode( ', ', $directoryList ), 'eZSearch' );
+        eZDebug::writeDebug( 'Unable to find the search engine:' . $searchEngineString, __METHOD__ );
+        eZDebug::writeDebug( 'Tried paths: ' . implode( ', ', $directoryList ), __METHOD__ );
         return false;
     }
 

--- a/kernel/classes/ezsiteaccess.php
+++ b/kernel/classes/ezsiteaccess.php
@@ -313,7 +313,7 @@ class eZSiteAccess
                                 default:
                                 {
                                     $hasHostMatch = false;
-                                    eZDebug::writeError( "Unknown host_uri host match: $matchHostMethod", "access" );
+                                    eZDebug::writeError( "Unknown host_uri host match: $matchHostMethod", __METHOD__ );
                                 } break;
                             }
 
@@ -364,7 +364,7 @@ class eZSiteAccess
                 } break;
                 default:
                 {
-                    eZDebug::writeError( "Unknown access match: $matchprobe", "access" );
+                    eZDebug::writeError( "Unknown access match: $matchprobe", __METHOD__ );
                 } break;
             }
 

--- a/kernel/classes/ezsslzone.php
+++ b/kernel/classes/ezsslzone.php
@@ -461,7 +461,7 @@ class eZSSLZone
         if ( $sslPriority && $keepModePriority && $sslPriority == $keepModePriority )
         {
             eZDebug::writeError( "Configuration error: view $module/$view is defined both as 'ssl' and 'keep'",
-                                 'eZSSLZone' );
+                                 __METHOD__ );
             return;
         }
 

--- a/kernel/classes/eztextinputparser.php
+++ b/kernel/classes/eztextinputparser.php
@@ -55,7 +55,7 @@ class eZTextInputParser
                                                 "Text" => $textChunk,
                                                 "TagName" => "#text" );
 
-                        eZDebug::writeNotice( $textChunk, "New text chunk in input" );
+                        eZDebug::writeNotice( "New text chunk in input: {$textChunk}", __METHOD__ );
                     }
                 }
                 // get the tag
@@ -75,14 +75,14 @@ class eZTextInputParser
                                         );
 
                 $pos += $tagEnd - $pos;
-                eZDebug::writeNotice( $tagChunk, "New tag chunk in input" );
+                eZDebug::writeNotice( "New tag chunk in input: {$tagChunk}", __METHOD__ );
             }
             else
             {
 
                 // just plain text in the rest
                 $textChunk = substr( $text, $pos, strlen( $text ) );
-                eZDebug::writeNotice( $textChunk, "New text chunk in input" );
+                eZDebug::writeNotice( "New text chunk in input: {$textChunk}", __METHOD__ );
 
                 if ( strlen( trim( $textChunk ) ) != 0 )
                 {

--- a/kernel/classes/ezurlaliasml.php
+++ b/kernel/classes/ezurlaliasml.php
@@ -1188,7 +1188,7 @@ class eZURLAliasML extends eZPersistentObject
                 // Check for a valid path
                 if ( $lastID !== false && $lastID != $paren )
                 {
-                    eZDebug::writeError( "The parent ID $paren of element with ID $id does not point to the last entry which had ID $lastID, incorrect path would be calculated, aborting" );
+                    eZDebug::writeError( "The parent ID $paren of element with ID $id does not point to the last entry which had ID $lastID, incorrect path would be calculated, aborting", __METHOD__ );
                     return null;
                 }
                 $lastID = $id;
@@ -1778,7 +1778,7 @@ class eZURLAliasML extends eZPersistentObject
                     }
                     else
                     {
-                        eZDebug::writeError( "Lookup of parent ID $paren failed, cannot perform reverse lookup of alias." );
+                        eZDebug::writeError( "Lookup of parent ID $paren failed, cannot perform reverse lookup of alias.", __METHOD__ );
                         return false;
                     }
                 }
@@ -2065,7 +2065,7 @@ class eZURLAliasML extends eZPersistentObject
     {
         if ( !preg_match( "#^([a-zA-Z0-9_]+):(.+)?$#", $action, $matches ) )
         {
-            eZDebug::writeError( "Action is not of valid syntax '{$action}'" );
+            eZDebug::writeError( "Action is not of valid syntax '{$action}'", __METHOD__ );
             return false;
         }
 
@@ -2078,7 +2078,7 @@ class eZURLAliasML extends eZPersistentObject
             case 'eznode':
                 if ( !is_numeric( $args ) )
                 {
-                    eZDebug::writeError( "Arguments to eznode action must be an integer, got '{$args}'" );
+                    eZDebug::writeError( "Arguments to eznode action must be an integer, got '{$args}'", __METHOD__ );
                     return false;
                 }
                 $url = 'content/view/full/' . $args;
@@ -2093,7 +2093,7 @@ class eZURLAliasML extends eZPersistentObject
                 break;
 
             default:
-                eZDebug::writeError( "Unknown action type '{$type}', cannot handle it" );
+                eZDebug::writeError( "Unknown action type '{$type}', cannot handle it", __METHOD__ );
                 return false;
         }
         return $url;

--- a/kernel/classes/ezurlaliasquery.php
+++ b/kernel/classes/ezurlaliasquery.php
@@ -205,7 +205,7 @@ class eZURLAliasQuery
     {
         if ( !in_array( $this->type, array( 'name', 'alias', 'all' ) ) )
         {
-            eZDebug::writeError( "Parameter \$type must be one of name, alias or all. The value which was used was '{$this->type}'." );
+            eZDebug::writeError( "Parameter \$type must be one of name, alias or all. The value which was used was '{$this->type}'.", __METHOD__ );
             return null;
         }
 

--- a/kernel/classes/ezvatmanager.php
+++ b/kernel/classes/ezvatmanager.php
@@ -30,7 +30,7 @@ class eZVATManager
         {
             if ( $handler === true )
             {
-                eZDebug::writeWarning( "No VAT handler specified but dynamic VAT charging is used." );
+                eZDebug::writeWarning( "No VAT handler specified but dynamic VAT charging is used.", __METHOD__ );
             }
 
             return null;
@@ -45,7 +45,7 @@ class eZVATManager
 
         if ( !$country && $requireUserCountry )
         {
-            eZDebug::writeNotice( "User country is not specified." );
+            eZDebug::writeNotice( "User country is not specified.", __METHOD__ );
         }
 
         return $handler->getVatPercent( $object, $country );
@@ -120,7 +120,7 @@ class eZVATManager
             $country = eZShopFunctions::getPreferredUserCountry();
             if ( $country )
             {
-                eZDebug::writeDebug( "Applying user's preferred country <$country> while charging VAT" );
+                eZDebug::writeDebug( "Applying user's preferred country <$country> while charging VAT", __METHOD__ );
                 return $country;
             }
         }

--- a/kernel/classes/packagehandlers/ezcontentclass/ezcontentclasspackagehandler.php
+++ b/kernel/classes/packagehandlers/ezcontentclass/ezcontentclasspackagehandler.php
@@ -215,10 +215,10 @@ class eZContentClassPackageHandler extends eZPackageHandler
             case self::ACTION_REPLACE:
                 if ( eZContentClassOperations::remove( $class->attribute( 'id' ) ) == false )
                 {
-                    eZDebug::writeWarning( "Unable to remove class '$className'." );
+                    eZDebug::writeWarning( "Unable to remove class '$className'.", __METHOD__ );
                     return true;
                 }
-                eZDebug::writeNotice( "Class '$className' will be replaced.", 'eZContentClassPackageHandler' );
+                eZDebug::writeNotice( "Class '$className' will be replaced.", __METHOD__ );
                 break;
 
             case self::ACTION_SKIP:

--- a/kernel/classes/packagehandlers/ezdb/ezdbpackagehandler.php
+++ b/kernel/classes/packagehandlers/ezdb/ezdbpackagehandler.php
@@ -56,18 +56,18 @@ class eZDBPackageHandler extends eZPackageHandler
 
             if ( $canInsert )
             {
-                eZDebug::writeDebug( "Installing SQL file $path/$filename" );
+                eZDebug::writeDebug( "Installing SQL file $path/$filename", __METHOD__ );
                 $db->insertFile( $path, $filename, false );
                 return true;
             }
             else
             {
-                eZDebug::writeDebug( "Skipping SQL file $path/$filename" );
+                eZDebug::writeDebug( "Skipping SQL file $path/$filename", __METHOD__ );
             }
         }
         else
         {
-            eZDebug::writeError( "Could not find SQL file $path/$filename" );
+            eZDebug::writeError( "Could not find SQL file $path/$filename", __METHOD__ );
         }
         return false;
     }

--- a/kernel/classes/vathandlers/ezdefaultvathandler.php
+++ b/kernel/classes/vathandlers/ezdefaultvathandler.php
@@ -61,7 +61,7 @@ class eZDefaultVATHandler
         if ( !$ini->hasVariable( 'VATSettings', 'ProductCategoryAttribute' ) )
         {
             eZDebug::writeError( "Cannot find product category: please specify its attribute identifier " .
-                                 "in the following setting: shop.ini.[VATSettings].ProductCategoryAttribute" );
+                                 "in the following setting: shop.ini.[VATSettings].ProductCategoryAttribute", __METHOD__ );
             return null;
         }
 
@@ -70,7 +70,7 @@ class eZDefaultVATHandler
         if ( !$categoryAttributeName )
         {
             eZDebug::writeError( "Cannot find product category: empty attribute name specified " .
-                                 "in the following setting: shop.ini.[VATSettings].ProductCategoryAttribute" );
+                                 "in the following setting: shop.ini.[VATSettings].ProductCategoryAttribute", __METHOD__ );
 
             return null;
         }

--- a/kernel/classes/workflowtypes/event/ezwaituntildate/ezwaituntildatetype.php
+++ b/kernel/classes/workflowtypes/event/ezwaituntildate/ezwaituntildatetype.php
@@ -174,12 +174,12 @@ class eZWaitUntilDateType  extends eZWorkflowEventType
                 }
                 else
                 {
-                    eZDebug::writeError( "no class selected" );
+                    eZDebug::writeError( "no class selected", __METHOD__ );
                 }
             }break;
             default :
             {
-                eZDebug::writeError( "Unknown custom HTTP action: " . $action, "eZEnumType" );
+                eZDebug::writeError( "Unknown custom HTTP action: " . $action, __METHOD__ );
             }break;
         }
 

--- a/kernel/common/ezkerneloperator.php
+++ b/kernel/common/ezkerneloperator.php
@@ -93,7 +93,7 @@ class eZKernelOperator
 
             default:
             {
-                eZDebug::writeError( "Unknown kernel operator: $operatorName" );
+                eZDebug::writeError( "Unknown kernel operator: $operatorName", __METHOD__ );
             }break;
         }
     }

--- a/kernel/common/eztopmenuoperator.php
+++ b/kernel/common/eztopmenuoperator.php
@@ -82,7 +82,7 @@ class eZTopMenuOperator
 
         if ( !$ini->hasVariable( 'TopAdminMenu', 'Tabs' ) )
         {
-            eZDebug::writeError( 'Top Admin menu is not configured. Ini  setting [TopAdminMenu] Tabs[] is missing' );
+            eZDebug::writeError( 'Top Admin menu is not configured. Ini  setting [TopAdminMenu] Tabs[] is missing', __METHOD__ );
             $operatorValue = array();
             return;
         }

--- a/kernel/common/eztreemenuoperator.php
+++ b/kernel/common/eztreemenuoperator.php
@@ -70,7 +70,7 @@ class eZTreeMenuOperator
         // node_id is not used anymore
         if ( !empty( $namedParameters['node_id'] ) )
         {
-            eZDebug::writeNotice( 'Deprecated parameter "node_id" in treemenu template operator' );
+            eZDebug::writeNotice( 'Deprecated parameter "node_id" in treemenu template operator', __METHOD__ );
         }
 
         if ( $classFilter === false )

--- a/kernel/common/ezwordtoimageoperator.php
+++ b/kernel/common/ezwordtoimageoperator.php
@@ -362,7 +362,7 @@ class eZWordToImageOperator
 
             default:
             {
-                eZDebug::writeError( "Unknown operator: $operatorName", "ezwordtoimageoperator.php" );
+                eZDebug::writeError( "Unknown operator: $operatorName", "ezwordtoimageoperator.php", __METHOD__ );
             }
 
         }

--- a/kernel/content/ezcontentfunctioncollection.php
+++ b/kernel/content/ezcontentfunctioncollection.php
@@ -1068,7 +1068,7 @@ class eZContentFunctionCollection
              $type = "data_text";
         else
         {
-            eZDebug::writeError( "DatatypeString not supported in fetch same_classattribute_node, use int, float or text" );
+            eZDebug::writeError( "DatatypeString not supported in fetch same_classattribute_node, use int, float or text", __METHOD__ );
             return false;
         }
         $db = eZDB::instance();
@@ -1273,7 +1273,7 @@ class eZContentFunctionCollection
             }
             else
             {
-                eZDebug::writeError( "Function parameter 'SortBy' should be an array.", 'content/fetchRelatedObjects' );
+                eZDebug::writeError( "Function parameter 'SortBy' should be an array.", __METHOD__ );
             }
         }
 
@@ -1313,7 +1313,7 @@ class eZContentFunctionCollection
             $attributeID = eZContentObjectTreeNode::classAttributeIDByIdentifier( $attributeID );
             if ( !$attributeID )
             {
-                eZDebug::writeError( "Can't get class attribute ID by identifier" );
+                eZDebug::writeError( "Can't get class attribute ID by identifier", __METHOD__ );
                 return false;
             }
         }
@@ -1364,7 +1364,7 @@ class eZContentFunctionCollection
             $attributeID = eZContentObjectTreeNode::classAttributeIDByIdentifier( $attributeID );
             if ( !$attributeID )
             {
-                eZDebug::writeError( "Can't get class attribute ID by identifier" );
+                eZDebug::writeError( "Can't get class attribute ID by identifier", __METHOD__ );
                 return false;
             }
         }
@@ -1401,7 +1401,7 @@ class eZContentFunctionCollection
             }
             else
             {
-                eZDebug::writeError( "Function parameter 'SortBy' should be an array.", 'content/fetchReverseRelatedObjects' );
+                eZDebug::writeError( "Function parameter 'SortBy' should be an array.", __METHOD__ );
             }
         }
         if ( isset( $ignoreVisibility ) )
@@ -1434,7 +1434,7 @@ class eZContentFunctionCollection
             $attributeID = eZContentObjectTreeNode::classAttributeIDByIdentifier( $attributeID );
             if ( !$attributeID )
             {
-                eZDebug::writeError( "Can't get class attribute ID by identifier" );
+                eZDebug::writeError( "Can't get class attribute ID by identifier", __METHOD__ );
                 return false;
             }
         }
@@ -1489,7 +1489,7 @@ class eZContentFunctionCollection
             $attributeID = eZContentObjectTreeNode::classAttributeIDByIdentifier( $attributeID );
             if ( !$attributeID )
             {
-                eZDebug::writeError( "Can't get class attribute ID by identifier" );
+                eZDebug::writeError( "Can't get class attribute ID by identifier", __METHOD__ );
                 return false;
             }
         }

--- a/kernel/private/classes/clusterfilehandlers/dfsbackends/mysqli.php
+++ b/kernel/private/classes/clusterfilehandlers/dfsbackends/mysqli.php
@@ -1369,7 +1369,7 @@ class eZDFSFileHandlerMySQLiBackend implements eZClusterEventNotifier
     {
         if ( $res === false )
         {
-            eZDebug::writeError( "SQL failed" );
+            eZDebug::writeError( "SQL failed", __METHOD__ );
         }
         elseif ( $res instanceof eZMySQLBackendError )
         {
@@ -1552,7 +1552,7 @@ class eZDFSFileHandlerMySQLiBackend implements eZClusterEventNotifier
             if ( $errno != 1062 )
             {
                 eZDebug::writeError( "Unexpected error #$errno when trying to start cache generation on $filePath (".mysqli_error( $this->db ).")", __METHOD__ );
-                eZDebug::writeDebug( $query, '$query' );
+                eZDebug::writeDebug( $query, __METHOD__ );
 
                 // @todo Make this an actual error, maybe an exception
                 return array( 'res' => 'ko' );

--- a/kernel/private/classes/clusterfilehandlers/ezdfsfilehandler.php
+++ b/kernel/private/classes/clusterfilehandlers/ezdfsfilehandler.php
@@ -953,7 +953,7 @@ class eZDFSFileHandler implements eZClusterFileHandlerInterface, ezpDatabaseBase
     public function fileDeleteByWildcard( $wildcard )
     {
         $wildcard = self::cleanPath( $wildcard );
-        eZDebug::writeWarning( "Using " . __METHOD__ . " is not recommended since it has some severe performance issues" );
+        eZDebug::writeWarning( "Using " . __METHOD__ . " is not recommended since it has some severe performance issues", __METHOD__ );
         eZDebugSetting::writeDebug( 'kernel-clustering', "dfs::fileDeleteByWildcard( '$wildcard' )" );
 
         self::$dbbackend->_deleteByWildcard( $wildcard );
@@ -1327,7 +1327,7 @@ class eZDFSFileHandler implements eZClusterFileHandlerInterface, ezpDatabaseBase
                 return false;
             }
         } catch( RuntimeException $e ) {
-            eZDebug::writeError( "An error occured ending cache generation on '$this->realFilePath'", 'cluster.log' );
+            eZDebug::writeError( "An error occured ending cache generation on '$this->realFilePath'", __METHOD__ );
         }
     }
 

--- a/kernel/private/classes/ezpkernelweb.php
+++ b/kernel/private/classes/ezpkernelweb.php
@@ -815,7 +815,7 @@ class ezpKernelWeb implements ezpWebBasedKernelHandler
             }
             else if ( $moduleCheck['result'] )
             {
-                eZDebug::writeError( "Undefined module: $moduleName", "index" );
+                eZDebug::writeError( "Undefined module: $moduleName", __METHOD__ );
                 $this->module = new eZModule( "", "", $moduleName );
                 $GLOBALS['eZRequestedModule'] = $this->module;
                 $moduleResult = $this->module->handleError( eZError::KERNEL_MODULE_NOT_FOUND, 'kernel', array( 'module' => $moduleName ) );
@@ -823,9 +823,9 @@ class ezpKernelWeb implements ezpWebBasedKernelHandler
             else
             {
                 if ( $moduleCheck['view_checked'] )
-                    eZDebug::writeError( "View '" . $moduleCheck['view'] . "' in module '" . $moduleCheck['module'] . "' is disabled", "index" );
+                    eZDebug::writeError( "View '" . $moduleCheck['view'] . "' in module '" . $moduleCheck['module'] . "' is disabled", __METHOD__ );
                 else
-                    eZDebug::writeError( "Module '" . $moduleCheck['module'] . "' is disabled", "index" );
+                    eZDebug::writeError( "Module '" . $moduleCheck['module'] . "' is disabled", __METHOD__ );
                 $GLOBALS['eZRequestedModule'] = $this->module = new eZModule( "", "", $moduleCheck['module'] );
                 $moduleResult = $this->module->handleError( eZError::KERNEL_MODULE_DISABLED, 'kernel', array( 'check' => $moduleCheck ) );
             }
@@ -838,7 +838,7 @@ class ezpKernelWeb implements ezpWebBasedKernelHandler
                     $this->siteBasics['module-run-required'] = true;
                 }
                 else
-                    eZDebug::writeError( 'No rerun URI specified, cannot continue', 'index.php' );
+                    eZDebug::writeError( 'No rerun URI specified, cannot continue', __METHOD__ );
             }
 
             if ( is_array( $moduleResult ) )

--- a/kernel/rss/feed.php
+++ b/kernel/rss/feed.php
@@ -10,7 +10,7 @@ $Module = $Params['Module'];
 
 if ( !isset ( $Params['RSSFeed'] ) )
 {
-    eZDebug::writeError( 'No RSS feed specified' );
+    eZDebug::writeError( 'No RSS feed specified', __METHOD__ );
     return $Module->handleError( eZError::KERNEL_NOT_AVAILABLE, 'kernel' );
 }
 

--- a/kernel/search/plugins/ezsearchengine/ezsearchengine.php
+++ b/kernel/search/plugins/ezsearchengine/ezsearchengine.php
@@ -439,7 +439,7 @@ class eZSearchEngine implements ezpSearchEngine
         if ( isset( $this->CreatedTempTablesNames[$index] ) )
         {
             eZDebug::writeWarning( "CreatedTempTablesNames[\$index] already exists " .
-                                   "and contains '" . $this->CreatedTempTablesNames[$index] . "'" );
+                                   "and contains '" . $this->CreatedTempTablesNames[$index] . "'", __METHOD__ );
         }
         $this->CreatedTempTablesNames[$index] = $tableName;
     }
@@ -2173,7 +2173,7 @@ class eZSearchEngine implements ezpSearchEngine
     {
         if ( !method_exists( $this, $methodName ) )
         {
-            eZDebug::writeError( $methodName, "Method does not exist in ez search engine" );
+            eZDebug::writeError( $methodName, "Method does not exist in ez search engine", __METHOD__ );
             return false;
         }
 

--- a/kernel/setup/steps/ezstep_site_types.php
+++ b/kernel/setup/steps/ezstep_site_types.php
@@ -58,7 +58,7 @@ class eZStepSiteTypes extends eZStepInstaller
     {
         $fileName = $outDir . "/" . ( $forcedFileName ? $forcedFileName : basename( $url ) );
 
-        eZDebug::writeNotice( "Downloading file '$fileName' from $url" );
+        eZDebug::writeNotice( "Downloading file '$fileName' from $url", __METHOD__ );
 
         // Create the out directory if not exists.
         if ( !file_exists( $outDir ) )
@@ -159,7 +159,7 @@ class eZStepSiteTypes extends eZStepInstaller
             }
             else
             {
-                eZDebug::writeNotice( "Skipping download of package '$packageName': package already exists." );
+                eZDebug::writeNotice( "Skipping download of package '$packageName': package already exists.", __METHOD__ );
                 return $package;
             }
         }
@@ -167,7 +167,7 @@ class eZStepSiteTypes extends eZStepInstaller
         $archiveName = $this->downloadFile( $packageUrl, /* $outDir = */ eZStepSiteTypes::tempDir() );
         if ( $archiveName === false )
         {
-            eZDebug::writeWarning( "Download of package '$packageName' from '$packageUrl' failed: $this->ErrorMsg" );
+            eZDebug::writeWarning( "Download of package '$packageName' from '$packageUrl' failed: $this->ErrorMsg", __METHOD__ );
             $this->ErrorMsg = ezpI18n::tr( 'design/standard/setup/init',
                                       'Download of package \'%pkg\' failed. You may upload the package manually.',
                                       false, array( '%pkg' => $packageName ) );
@@ -185,11 +185,11 @@ class eZStepSiteTypes extends eZStepInstaller
         {
             if ( $package == eZPackage::STATUS_INVALID_NAME )
             {
-                eZDebug::writeNotice( "The package name $packageName is invalid" );
+                eZDebug::writeNotice( "The package name $packageName is invalid", __METHOD__ );
             }
             else
             {
-                eZDebug::writeNotice( "Invalid package" );
+                eZDebug::writeNotice( "Invalid package", __METHOD__ );
             }
 
             $this->ErrorMsg = ezpI18n::tr( 'design/standard/setup/init', 'Invalid package' );
@@ -258,7 +258,7 @@ class eZStepSiteTypes extends eZStepInstaller
             {
                 if ( !isset( $remotePackagesInfo[$requiredPackageName]['url'] ) )
                 {
-                    eZDebug::writeWarning( "Download of package '$requiredPackageName' failed: the URL is unknown." );
+                    eZDebug::writeWarning( "Download of package '$requiredPackageName' failed: the URL is unknown.", __METHOD__ );
                     $this->ErrorMsg = ezpI18n::tr( 'design/standard/setup/init',
                                               'Download of package \'%pkg\' failed. You may upload the package manually.',
                                               false, array( '%pkg' => $requiredPackageName ) );
@@ -321,7 +321,7 @@ class eZStepSiteTypes extends eZStepInstaller
         }
         elseif ( $package == eZPackage::STATUS_ALREADY_EXISTS )
         {
-            eZDebug::writeWarning( "Package '$packageName' already exists." );
+            eZDebug::writeWarning( "Package '$packageName' already exists.", __METHOD__ );
         }
         else
         {
@@ -666,7 +666,7 @@ class eZStepSiteTypes extends eZStepInstaller
                                       'Retrieving remote site packages list failed. ' .
                                       'You may upload packages manually.' );
 
-            eZDebug::writeNotice( "Cannot download remote packages index file from '$this->XMLIndexURL'." );
+            eZDebug::writeNotice( "Cannot download remote packages index file from '$this->XMLIndexURL'.", __METHOD__ );
             return false;
         }
 
@@ -679,7 +679,7 @@ class eZStepSiteTypes extends eZStepInstaller
 
         if ( !$success )
         {
-            eZDebug::writeError( "Unable to open index file." );
+            eZDebug::writeError( "Unable to open index file.", __METHOD__ );
             return false;
         }
 
@@ -687,7 +687,7 @@ class eZStepSiteTypes extends eZStepInstaller
 
         if ( $root->localName != 'packages' )
         {
-            eZDebug::writeError( "Malformed index file." );
+            eZDebug::writeError( "Malformed index file.", __METHOD__ );
             return false;
         }
 

--- a/kernel/shop/classes/ezpaymentobject.php
+++ b/kernel/shop/classes/ezpaymentobject.php
@@ -137,7 +137,7 @@ class eZPaymentObject extends eZPersistentObject
             $bodyMemento = eZOperationMemento::fetchChild( $theProcess->attribute( 'memento_key' ) );
             if ( $bodyMemento === null )
             {
-                eZDebug::writeError( $bodyMemento, "Empty body memento in workflow.php" );
+                eZDebug::writeError( "Empty body memento in workflow.php", __METHOD__ );
                 return $operationResult;
             }
             $bodyMementoData =  $bodyMemento->data();

--- a/kernel/shop/ezshopoperationcollection.php
+++ b/kernel/shop/ezshopoperationcollection.php
@@ -43,7 +43,7 @@ class eZShopOperationCollection
 
         if ( !$order )
         {
-            eZDebug::writeError( "No such order: $orderID" );
+            eZDebug::writeError( "No such order: $orderID", __METHOD__ );
             return array( 'status' => eZModuleOperationInfo::STATUS_CANCELLED );
         }
 
@@ -317,7 +317,7 @@ class eZShopOperationCollection
 
         if ( !$priceFound )
         {
-            eZDebug::writeError( 'Attempted to add object without price to basket.' );
+            eZDebug::writeError( 'Attempted to add object without price to basket.', __METHOD__ );
             return array( 'status' => eZModuleOperationInfo::STATUS_CANCELLED );
         }
 
@@ -373,7 +373,7 @@ class eZShopOperationCollection
         $collection = $basket->attribute( 'productcollection' );
         if ( !$collection )
         {
-            eZDebug::writeError( 'Unable to find product collection.' );
+            eZDebug::writeError( 'Unable to find product collection.', __METHOD__ );
             return array( 'status' => eZModuleOperationInfo::STATUS_CANCELLED );
         }
         else

--- a/kernel/user/ezuseroperationcollection.php
+++ b/kernel/user/ezuseroperationcollection.php
@@ -127,7 +127,7 @@ class eZUserOperationCollection
             if ( $verifyUserTypeClass && method_exists( $verifyUserTypeClass, 'verifyUser' ) )
                 $sendUserMail  = call_user_func( array( $verifyUserTypeClass, 'verifyUser' ), $user, $tpl );
             else
-                eZDebug::writeWarning( "Unknown VerifyUserType '$verifyUserType'", 'user/register' );
+                eZDebug::writeWarning( "Unknown VerifyUserType '$verifyUserType'", __METHOD__ );
         }
 
         // send verification mail to user if email type or custum verify user type returned true
@@ -188,7 +188,7 @@ class eZUserOperationCollection
         $object = eZContentObject::fetch( $userID );
         if( $object->attribute( 'current_version' ) !== '1' )
         {
-            eZDebug::writeError( 'Current version is wrong for the user object. User ID: ' . $userID , 'user/register' );
+            eZDebug::writeError( 'Current version is wrong for the user object. User ID: ' . $userID, __METHOD__ );
             return array( 'status' => eZModuleOperationInfo::STATUS_CANCELLED );
         }
         eZDebugSetting::writeNotice( 'kernel-user' , 'publishing user object', 'user register' );

--- a/lib/ezdb/classes/ezdb.php
+++ b/lib/ezdb/classes/ezdb.php
@@ -308,7 +308,7 @@ class eZDB
             $stack = $db->generateFailedTransactionStack();
             if ( $stack !== false )
             {
-                eZDebug::writeError( $stack, 'Transaction stack' );
+                eZDebug::writeError( "Transaction stack:" . var_export( $stack ), __METHOD__ );
             }
             $ini = eZINI::instance();
             // In debug mode the transaction will be invalidated causing the top-level commit

--- a/lib/ezdb/classes/ezmysqlidb.php
+++ b/lib/ezdb/classes/ezmysqlidb.php
@@ -38,7 +38,7 @@ class eZMySQLiDB extends eZDBInterface
                                             'text' => 'MySQLi extension was not found, the DB handler will not be initialized.' ) );
                 $this->IsConnected = false;
             }
-            eZDebug::writeWarning( 'MySQLi extension was not found, the DB handler will not be initialized.', 'eZMySQLiDB' );
+            eZDebug::writeWarning( 'MySQLi extension was not found, the DB handler will not be initialized.', __METHOD__ );
             return;
         }
 

--- a/lib/ezdb/classes/ezpostgresqldb.php
+++ b/lib/ezdb/classes/ezpostgresqldb.php
@@ -35,7 +35,7 @@ class eZPostgreSQLDB extends eZDBInterface
                                             'text' => 'PostgreSQL extension was not found, the DB handler will not be initialized.' ) );
                 $this->IsConnected = false;
             }
-            eZDebug::writeWarning( 'PostgreSQL extension was not found, the DB handler will not be initialized.', 'eZPostgreSQLDB' );
+            eZDebug::writeWarning( 'PostgreSQL extension was not found, the DB handler will not be initialized.', __METHOD__ );
             return;
         }
 
@@ -128,7 +128,7 @@ class eZPostgreSQLDB extends eZDBInterface
         else
         {
             $this->IsConnected = false;
-            eZDebug::writeError( "PostgreSQL support not compiled into PHP, contact your system administrator", "eZPostgreSQLDB" );
+            eZDebug::writeError( "PostgreSQL support not compiled into PHP, contact your system administrator", __METHOD__);
 
         }
     }
@@ -224,7 +224,7 @@ class eZPostgreSQLDB extends eZDBInterface
             if ( !$result )
             {
                 $this->setError();
-                eZDebug::writeError( "Error: error executing query: $sql: {$this->ErrorMessage}", "eZPostgreSQLDB" );
+                eZDebug::writeError( "Error: error executing query: $sql: {$this->ErrorMessage}", __METHOD__ );
                 if ( $this->errorHandling == eZDB::ERROR_HANDLING_EXCEPTIONS )
                 {
                     throw new eZDBException( $this->ErrorMessage, $this->ErrorNumber );

--- a/lib/ezdbschema/classes/ezdbschema.php
+++ b/lib/ezdbschema/classes/ezdbschema.php
@@ -97,7 +97,7 @@ class eZDbSchema
             }
             else
             {
-                eZDebug::writeError( "Unknown format for file $filename" );
+                eZDebug::writeError( "Unknown format for file $filename", __METHOD__ );
                 return false;
             }
         }

--- a/lib/ezdbschema/classes/ezdbschemainterface.php
+++ b/lib/ezdbschema/classes/ezdbschemainterface.php
@@ -409,7 +409,7 @@ class eZDBSchemaInterface
                 {
                     if ( !$this->DBInstance->query( $sql ) )
                     {
-                        eZDebug::writeError( "Failed inserting the SQL:\n$sql" );
+                        eZDebug::writeError( "Failed inserting the SQL:\n$sql", __METHOD__ );
                         return false;
                     }
                 }
@@ -437,7 +437,7 @@ class eZDBSchemaInterface
                 {
                     if ( !$this->DBInstance->query( $sql ) )
                     {
-                        eZDebug::writeError( "Failed inserting the SQL:\n$sql" );
+                        eZDebug::writeError( "Failed inserting the SQL:\n$sql", __METHOD__ );
                         $this->DBInstance->rollback();
                         return false;
                     }
@@ -917,7 +917,7 @@ class eZDBSchemaInterface
 
         if ( !$ini )
         {
-            eZDebug::writeError( "Error loading $schemaType schema transformation rules" );
+            eZDebug::writeError( "Error loading $schemaType schema transformation rules", __METHOD__ );
             return false;
         }
 
@@ -1001,7 +1001,7 @@ class eZDBSchemaInterface
                     $localIdxName = $val;
                     if ( !$tableName || !$genericIdxName || !$localIdxName )
                     {
-                        eZDebug::writeWarning( "Malformed index name translation rule: $key => $val" );
+                        eZDebug::writeWarning( "Malformed index name translation rule: $key => $val", __METHOD__ );
                         continue;
                     }
                     $transformationRules['index-name'][] = array( $tableName, $genericIdxName, $localIdxName );
@@ -1020,7 +1020,7 @@ class eZDBSchemaInterface
                 $colOptOverride = $val;
                 if ( !$tableName || !$colName || !$colOptOverride )
                 {
-                    eZDebug::writeWarning( "Malformed column option translation rule: $key => $val" );
+                    eZDebug::writeWarning( "Malformed column option translation rule: $key => $val", __METHOD__ );
                     continue;
                 }
                 $transformationRules['column-option'][] = array( $tableName, $colName, $colOptOverride );
@@ -1297,7 +1297,7 @@ class eZDBSchemaInterface
                 } break;
                 default:
                 {
-                    eZDebug::writeWarning( "Column option override '$colOptOverride' is not supported" );
+                    eZDebug::writeWarning( "Column option override '$colOptOverride' is not supported", __METHOD__ );
                 } break;
             }
 

--- a/lib/ezdiff/classes/ezdiff.php
+++ b/lib/ezdiff/classes/ezdiff.php
@@ -27,7 +27,7 @@ class eZDiff
         if ( $diffEngineType )
         {
             $this->DiffEngine = $diffEngineType;
-            eZDebug::writeNotice( "Diff engine type: " . $diffEngineType, 'eZDiff' );
+            eZDebug::writeNotice( "Diff engine type: " . $diffEngineType, __METHOD__ );
         }
     }
 
@@ -41,7 +41,7 @@ class eZDiff
         if ( isset( $diffEngineType ) )
         {
             $this->DiffEngine = $diffEngineType;
-            eZDebug::writeNotice( "Changing diff engine to type: " . $diffEngineType, 'eZDiff' );
+            eZDebug::writeNotice( "Changing diff engine to type: " . $diffEngineType, __METHOD__ );
         }
     }
 

--- a/lib/ezdiff/classes/ezdiffcontent.php
+++ b/lib/ezdiff/classes/ezdiffcontent.php
@@ -107,7 +107,7 @@ class eZDiffContent
 
             default:
             {
-                eZDebug::writeError( "Attribute '$attrName' does not exist", 'eZDiffContent' );
+                eZDebug::writeError( "Attribute '$attrName' does not exist", __METHOD__ );
                 return null;
             }break;
         }

--- a/lib/ezi18n/classes/ezcodemapper.php
+++ b/lib/ezi18n/classes/ezcodemapper.php
@@ -993,7 +993,7 @@ class eZCodeMapper
                 $subTable = $this->mappingTable( $identifier );
                 if ( !$subTable )
                 {
-                    eZDebug::writeError( "Failed to fetch mapping table for identifier: '$identifier'" );
+                    eZDebug::writeError( "Failed to fetch mapping table for identifier: '$identifier'", __METHOD__ );
                 }
                 else
                 {
@@ -1401,7 +1401,7 @@ class eZCodeMapper
         $codec = eZTextCodec::instance( 'unicode', $charset );
         if ( !$codec )
         {
-            eZDebug::writeError( "Failed to create textcodec for charset '$charset'" );
+            eZDebug::writeError( "Failed to create textcodec for charset '$charset'", __METHOD__ );
             return false;
         }
 
@@ -1649,7 +1649,7 @@ class eZCodeMapper
                 }
                 else
                 {
-                    eZDebug::writeError( "Could not locate include file '$path' for transformation '" . $command['command'] . "'" );
+                    eZDebug::writeError( "Could not locate include file '$path' for transformation '" . $command['command'] . "'", __METHOD__ );
                 }
             }
         }
@@ -1792,7 +1792,7 @@ class eZCodeMapper
                 }
                 else
                 {
-                    eZDebug::writeError( "Could not locate include file '$path' for transformation '" . $command['command'] . "'" );
+                    eZDebug::writeError( "Could not locate include file '$path' for transformation '" . $command['command'] . "'", __METHOD__ );
                 }
             }
         }

--- a/lib/ezi18n/classes/ezcodepage.php
+++ b/lib/ezi18n/classes/ezcodepage.php
@@ -521,7 +521,7 @@ class eZCodePage
 
         if ( !file_exists( $file ) )
         {
-            eZDebug::writeWarning( "Couldn't load codepage file $file", "eZCodePage" );
+            eZDebug::writeWarning( "Couldn't load codepage file $file", "eZCodePage", __METHOD__ );
             return;
         }
         $file_m = filemtime( $file );

--- a/lib/ezi18n/classes/ezcodepagemapper.php
+++ b/lib/ezi18n/classes/ezcodepagemapper.php
@@ -117,12 +117,12 @@ class eZCodePageMapper
         $output_codepage = eZCodePage::instance( $this->OutputCharsetCode );
         if ( !$input_codepage->isValid() )
         {
-            eZDebug::writeError( "Input codepage for " . $this->InputCharsetCode . " is not valid", "eZCodePageMapper" );
+            eZDebug::writeError( "Input codepage for " . $this->InputCharsetCode . " is not valid", __METHOD__ );
             return false;
         }
         if ( !$output_codepage->isValid() )
         {
-            eZDebug::writeError( "Output codepage for " . $this->OutputCharsetCode . " is not valid", "eZCodePageMapper" );
+            eZDebug::writeError( "Output codepage for " . $this->OutputCharsetCode . " is not valid", __METHOD__ );
             return false;
         }
         $this->SubstituteInputChar = chr( $input_codepage->unicodeToCode( $char_code ) );
@@ -141,13 +141,13 @@ class eZCodePageMapper
         if ( !eZCodePage::exists( $this->InputCharsetCode ) )
         {
             $input_file = eZCodePage::fileName( $this->InputCharsetCode );
-            eZDebug::writeWarning( "Couldn't load input codepage file $input_file", "eZCodePageMapper" );
+            eZDebug::writeWarning( "Couldn't load input codepage file $input_file", __METHOD__ );
             return false;
         }
         if ( !eZCodePage::exists( $this->OutputCharsetCode ) )
         {
             $output_file = eZCodePage::fileName( $this->OutputCharsetCode );
-            eZDebug::writeWarning( "Couldn't load output codepage file $output_file", "eZCodePageMapper" );
+            eZDebug::writeWarning( "Couldn't load output codepage file $output_file", __METHOD__ );
             return false;
         }
 
@@ -180,12 +180,12 @@ class eZCodePageMapper
 
         if ( !$input_codepage->isValid() )
         {
-            eZDebug::writeError( "Input codepage for " . $this->InputCharsetCode . " is not valid", "eZCodePageMapper" );
+            eZDebug::writeError( "Input codepage for " . $this->InputCharsetCode . " is not valid", __METHOD__ );
             return false;
         }
         if ( !$output_codepage->isValid() )
         {
-            eZDebug::writeError( "Output codepage for " . $this->OutputCharsetCode . " is not valid", "eZCodePageMapper" );
+            eZDebug::writeError( "Output codepage for " . $this->OutputCharsetCode . " is not valid", __METHOD__ );
             return false;
         }
 

--- a/lib/ezi18n/classes/ezmbstringmapper.php
+++ b/lib/ezi18n/classes/ezmbstringmapper.php
@@ -35,16 +35,16 @@ class eZMBStringMapper
         $this->Valid = false;
         if ( !$this->isCharsetSupported( $input_charset_code ) )
         {
-            eZDebug::writeError( "Input charset $input_charset_code not supported", "eZMBStringMapper" );
+            eZDebug::writeError( "Input charset $input_charset_code not supported", __METHOD__ );
         }
         else if ( !$this->isCharsetSupported( $output_charset_code ) )
         {
-            eZDebug::writeError( "Output charset $output_charset_code not supported", "eZMBStringMapper" );
+            eZDebug::writeError( "Output charset $output_charset_code not supported", __METHOD__ );
         }
         else if ( $this->hasMBStringExtension() )
             $this->Valid = true;
         else
-            eZDebug::writeError( "No mbstring functions available", "eZMBStringMapper" );
+            eZDebug::writeError( "No mbstring functions available", __METHOD__ );
     }
 
     /*!

--- a/lib/ezi18n/classes/eztextcodec.php
+++ b/lib/ezi18n/classes/eztextcodec.php
@@ -197,7 +197,7 @@ class eZTextCodec
         {
             eZDebug::writeError( "Cannot create textcodec from characterset " . $this->RequestedInputCharsetCode .
                                  " to characterset " . $this->RequestedOutputCharsetCode,
-                                 "eZTextCodec" );
+                                 __METHOD__ );
             if ( !$conversionFunction )
                 $conversionFunction = $noneConversionFunction;
             if ( !$strlenFunction )

--- a/lib/ezi18n/classes/eztranslatorgroup.php
+++ b/lib/ezi18n/classes/eztranslatorgroup.php
@@ -135,7 +135,7 @@ class eZTranslatorGroup extends eZTranslatorHandler
     {
         if ( !$this->isKeyBased() and $handler->isKeyBased() )
         {
-            eZDebug::writeError( "Cannot register keybased handler for non-keybased group", "eZTranslatorGroup" );
+            eZDebug::writeError( "Cannot register keybased handler for non-keybased group", __METHOD__ );
             return false;
         }
         $this->Handlers[] = $handler;

--- a/lib/ezimage/classes/ezimagemanager.php
+++ b/lib/ezimage/classes/ezimagemanager.php
@@ -792,7 +792,7 @@ class eZImageManager
         $aliasList = $this->aliasList();
         if ( !isset( $aliasList[$aliasName] ) )
         {
-            eZDebug::writeWarning( "Alias name $aliasName does not exist, cannot create it" );
+            eZDebug::writeWarning( "Alias name $aliasName does not exist, cannot create it", __METHOD__ );
             return false;
         }
 
@@ -827,7 +827,7 @@ class eZImageManager
         {
             if ( $referenceAlias == 'original' )
             {
-                eZDebug::writeError( "Original alias does not exist, cannot create other aliases without it" );
+                eZDebug::writeError( "Original alias does not exist, cannot create other aliases without it", __METHOD__ );
                 return false;
             }
             if ( !$this->createImageAlias( $referenceAlias, $existingAliasList, $parameters ) )

--- a/lib/ezimage/classes/ezimagetextlayer.php
+++ b/lib/ezimage/classes/ezimagetextlayer.php
@@ -138,7 +138,7 @@ class eZImageTextLayer extends eZImageLayer
             return $Return;
         if ( !function_exists( 'ImageTTFBBox' ) )
         {
-            eZDebug::writeError( 'ImageTTFBBox function not in PHP, check PHP compilation', 'ezimagetextlayer.php' );
+            eZDebug::writeError( 'ImageTTFBBox function not in PHP, check PHP compilation', __METHOD__ );
             return $Return;
         }
         $bbox = ImageTTFBBox( $font->pointSize(), $angle, $font->realFile(), $text );

--- a/lib/ezlocale/classes/ezlocale.php
+++ b/lib/ezlocale/classes/ezlocale.php
@@ -193,7 +193,7 @@ class eZLocale
         else
         {
             $this->IsValid = false;
-            eZDebug::writeError( 'Could not load country settings for ' . $this->CountryCode, 'eZLocale' );
+            eZDebug::writeError( 'Could not load country settings for ' . $this->CountryCode, __METHOD__ );
         }
 
         // Load language information
@@ -204,7 +204,7 @@ class eZLocale
         else
         {
             $this->IsValid = false;
-            eZDebug::writeError( 'Could not load language settings for ' . $this->LanguageCode, 'eZLocale' );
+            eZDebug::writeError( 'Could not load language settings for ' . $this->LanguageCode, __METHOD__ );
         }
 
 

--- a/lib/ezpdf/classes/class.pdf.php
+++ b/lib/ezpdf/classes/class.pdf.php
@@ -3749,7 +3749,7 @@ class Cpdf
         }
         if ( $error )
         {
-            eZDebug::writeError( 'Adding PNG file, '. $file .', to PDF failed: '.$errormsg, 'Cpdf::addPngFromFile' );
+            eZDebug::writeError( 'Adding PNG file, '. $file .', to PDF failed: '.$errormsg, __METHOD__ );
             $this->addMessage('PNG error - ('.$file.') '.$errormsg);
             return false;
         }

--- a/lib/ezpdf/classes/ezpdf.php
+++ b/lib/ezpdf/classes/ezpdf.php
@@ -101,7 +101,7 @@ class eZPDF
                 }
                 $operatorValue .= '>';
 
-                eZDebug::writeNotice( 'PDF: Changed font.' );
+                eZDebug::writeNotice( 'PDF: Changed font.', __METHOD__ );
             } break;
 
             case 'table':
@@ -1067,7 +1067,7 @@ class eZPDF
     {
         $this->PDF = new eZPDFTable( $paper, $orientation );
         $this->PDF->selectFont( 'lib/ezpdf/classes/fonts/Helvetica' );
-        eZDebug::writeNotice( 'PDF: File created' );
+        eZDebug::writeNotice( 'PDF: File created', __METHOD__ );
     }
 
     /// The array of operators, used for registering operators

--- a/lib/ezsoap/classes/ezsoapresponse.php
+++ b/lib/ezsoap/classes/ezsoapresponse.php
@@ -99,12 +99,12 @@ class eZSOAPResponse extends eZSOAPEnvelope
             }
             else
             {
-                eZDebug::writeError( "Got error from server" );
+                eZDebug::writeError( "Got error from server", __METHOD__ );
             }
         }
         else
         {
-            eZDebug::writeError( "Could not process XML in response" );
+            eZDebug::writeError( "Could not process XML in response", __METHOD__ );
         }
     }
 

--- a/lib/eztemplate/classes/eztemplate.php
+++ b/lib/eztemplate/classes/eztemplate.php
@@ -537,11 +537,11 @@ class eZTemplate
                 if ( eZTemplate::isDebugEnabled() )
                 {
                     $fname = $resourceData['template-filename'];
-                    eZDebug::writeDebug( "FETCH START URI: $template, $fname" );
+                    eZDebug::writeDebug( "FETCH START URI: $template, $fname", __METHOD__ );
                 }
                 $this->process( $root, $text, "", "" );
                 if ( eZTemplate::isDebugEnabled() )
-                    eZDebug::writeDebug( "FETCH END URI: $template, $fname" );
+                    eZDebug::writeDebug( "FETCH END URI: $template, $fname", __METHOD__ );
             }
 
             eZDebug::accumulatorStop( 'template_processing' );
@@ -642,10 +642,10 @@ class eZTemplate
              is_object( $func ) )
         {
             if ( eZTemplate::isMethodDebugEnabled() )
-                eZDebug::writeDebug( "START FUNCTION: $functionName" );
+                eZDebug::writeDebug( "START FUNCTION: $functionName", __METHOD__ );
             $value = $func->process( $this, $textElements, $functionName, $functionChildren, $functionParameters, $functionPlacement, $rootNamespace, $currentNamespace );
             if ( eZTemplate::isMethodDebugEnabled() )
-                eZDebug::writeDebug( "END FUNCTION: $functionName" );
+                eZDebug::writeDebug( "END FUNCTION: $functionName", __METHOD__ );
             return $value;
         }
         else
@@ -800,7 +800,7 @@ class eZTemplate
         $this->Level++;
         if ( $this->Level > $this->MaxLevel )
         {
-            eZDebug::writeError( $this->MaxLevelWarning, __METHOD__ . " Level: $this->Level @ $uri" );
+            eZDebug::writeError( $this->MaxLevelWarning, __METHOD__ . " Level: $this->Level @ $uri", __METHOD__ );
             $textElements[] = $this->MaxLevelWarning;
             $this->Level--;
             return;
@@ -833,11 +833,11 @@ class eZTemplate
             if ( eZTemplate::isDebugEnabled() )
             {
                 $fname = $resourceData['template-filename'];
-                eZDebug::writeDebug( "START URI: $uri, $fname" );
+                eZDebug::writeDebug( "START URI: $uri, $fname", __METHOD__ );
             }
             $this->process( $resourceData['root-node'], $text, $rootNamespace, $currentNamespace );
             if ( eZTemplate::isDebugEnabled() )
-                eZDebug::writeDebug( "END URI: $uri, $fname" );
+                eZDebug::writeDebug( "END URI: $uri, $fname", __METHOD__ );
             $this->setIncludeOutput( $uri, $text );
             $textElements[] = $text;
         }
@@ -1004,7 +1004,7 @@ class eZTemplate
             $template = $uri;
         if ( eZTemplate::isDebugEnabled() )
         {
-            eZDebug::writeNotice( "eZTemplate: Loading template \"$template\" with resource \"$res\"" );
+            eZDebug::writeNotice( "Loading template \"$template\" with resource \"$res\"", __METHOD__ );
         }
         if ( isset( $this->Resources[$res] ) and is_object( $this->Resources[$res] ) )
         {
@@ -1340,11 +1340,11 @@ class eZTemplate
             {
                 $value = $valueData['value'];
                 if ( eZTemplate::isMethodDebugEnabled() )
-                    eZDebug::writeDebug( "START OPERATOR: $operatorName" );
+                    eZDebug::writeDebug( "START OPERATOR: $operatorName", __METHOD__ );
                 $op->modify( $this, $operatorName, $operatorParameters, $rootNamespace, $currentNamespace, $value, $namedParameters,
                              $placement );
                 if ( eZTemplate::isMethodDebugEnabled() )
-                    eZDebug::writeDebug( "END OPERATOR: $operatorName" );
+                    eZDebug::writeDebug( "END OPERATOR: $operatorName", __METHOD__ );
                 $valueData['value'] = $value;
             }
             else
@@ -2242,7 +2242,7 @@ class eZTemplate
             {
                 eZDebug::writeWarning( "Path '$path' does not have the file 'eztemplateautoload.php' allthough it reported it had one.\n" .
                                        "Looked for file '" . $autoloadFile . "'\n" .
-                                       "Check the setting [TemplateSettings]/ExtensionAutoloadPath or AutoloadPathList in your site.ini settings." );
+                                       "Check the setting [TemplateSettings]/ExtensionAutoloadPath or AutoloadPathList in your site.ini settings.", __METHOD__ );
             }
         }
     }

--- a/lib/eztemplate/classes/eztemplatecompiler.php
+++ b/lib/eztemplate/classes/eztemplatecompiler.php
@@ -2240,7 +2240,7 @@ END;
                 }
                 else
                     eZDebug::writeWarning( "Unknown internal template node type $nodeType, ignoring node for code generation",
-                                           'eZTemplateCompiler:generatePHPCodeChildren' );
+                                           __METHOD__ );
             }
             else if ( $nodeType == eZTemplate::NODE_ROOT )
             {

--- a/lib/eztemplate/classes/eztemplatefileresource.php
+++ b/lib/eztemplate/classes/eztemplatefileresource.php
@@ -264,7 +264,7 @@ class eZTemplateFileResource
                 }
 
                 if ( eZTemplate::isDebugEnabled() )
-                    eZDebug::writeNotice( "$path, $charset" );
+                    eZDebug::writeNotice( "$path, $charset", __METHOD__ );
                 $codec = eZTextCodec::instance( $charset, false, false );
                 if ( $codec )
                 {

--- a/lib/eztemplate/classes/eztemplateiffunction.php
+++ b/lib/eztemplate/classes/eztemplateiffunction.php
@@ -155,7 +155,7 @@ class eZTemplateIfFunction
     {
         if ( count( $functionParameters ) == 0 || !count( $functionParameters['condition'] ) )
         {
-            eZDebug::writeError( "Not enough arguments passed to 'if' function." );
+            eZDebug::writeError( "Not enough arguments passed to 'if' function.", __METHOD__ );
             return;
         }
 
@@ -184,7 +184,7 @@ class eZTemplateIfFunction
                 {
                     if ( $foundElse  )
                     {
-                        eZDebug::writeError( "Duplicated 'else'" );
+                        eZDebug::writeError( "Duplicated 'else'", __METHOD__ );
                         $show = false;
                         continue;
                     }
@@ -197,7 +197,7 @@ class eZTemplateIfFunction
                 {
                     if ( $foundElse  )
                     {
-                        eZDebug::writeError( "There should be no more 'elseif' after 'else'" );
+                        eZDebug::writeError( "There should be no more 'elseif' after 'else'", __METHOD__ );
                         $show = false;
                         continue;
                     }

--- a/lib/eztemplate/classes/eztemplatewhilefunction.php
+++ b/lib/eztemplate/classes/eztemplatewhilefunction.php
@@ -114,7 +114,7 @@ class eZTemplateWhileFunction
     {
         if ( count( $functionParameters ) == 0 )
         {
-            eZDebug::writeError( "Not enough arguments passed to 'while' function." );
+            eZDebug::writeError( "Not enough arguments passed to 'while' function.", __METHOD__ );
             return;
         }
 

--- a/lib/ezutils/classes/ezextension.php
+++ b/lib/ezutils/classes/ezextension.php
@@ -396,7 +396,7 @@ class eZExtension
             }
             else if ( $extensionSubdir )
             {
-                eZDebug::writeWarning( "Extension '$extensionDirectory' does not have the subdirectory $extensionSubdir, looked for directory '" . $extensionPath . "'" );
+                eZDebug::writeWarning( "Extension '$extensionDirectory' does not have the subdirectory $extensionSubdir, looked for directory '" . $extensionPath . "'", __METHOD__ );
             }
         }
         $foundType = false;

--- a/lib/ezutils/classes/ezhttpfile.php
+++ b/lib/ezutils/classes/ezhttpfile.php
@@ -68,7 +68,7 @@ class eZHTTPFile
         if ( !$this->IsTemporary )
         {
             eZDebug::writeError( "Cannot store non temporary file: " . $this->Filename,
-                                 "eZHTTPFile" );
+                                 __METHOD__ );
             return false;
         }
         $this->IsTemporary = false;
@@ -111,7 +111,7 @@ class eZHTTPFile
 
         if ( !move_uploaded_file( $this->Filename, $dest_name ) )
         {
-            eZDebug::writeError( "Failed moving uploaded file " . $this->Filename . " to destination $dest_name" );
+            eZDebug::writeError( "Failed moving uploaded file " . $this->Filename . " to destination $dest_name", __METHOD__ );
             unlink( $dest_name );
             $ret = false;
         }
@@ -283,7 +283,7 @@ class eZHTTPFile
             else
             {
                 eZDebug::writeError( "Unknown file for post variable: $http_name",
-                                     "eZHTTPFile" );
+                                     __METHOD__ );
             }
         }
         return $GLOBALS["eZHTTPFile-$http_name"];

--- a/lib/ezutils/classes/ezhttptool.php
+++ b/lib/ezutils/classes/ezhttptool.php
@@ -53,7 +53,7 @@ class eZHTTPTool
         else if ( $ret === null )
         {
             eZDebug::writeWarning( "Undefined post variable: $var",
-                                   "eZHTTPTool" );
+                                   __METHOD__ );
         }
         return $ret;
     }
@@ -90,7 +90,7 @@ class eZHTTPTool
         else if ( $ret === null )
         {
             eZDebug::writeWarning( "Undefined get variable: $var",
-                                   "eZHTTPTool" );
+                                   __METHOD__ );
         }
         return $ret;
     }
@@ -139,7 +139,7 @@ class eZHTTPTool
         if ( $ret === null )
         {
             eZDebug::writeWarning( "Undefined post/get variable: $var",
-                                   "eZHTTPTool" );
+                                   __METHOD__ );
         }
         return $ret;
     }

--- a/lib/ezutils/classes/ezini.php
+++ b/lib/ezutils/classes/ezini.php
@@ -1288,7 +1288,7 @@ class eZINI
     function prependOverrideDir( $dir, $globalDir = false, $identifier = false, $scope = null )
     {
         if ( self::isDebugEnabled() )
-            eZDebug::writeNotice( "Prepending override dir '$dir'", "eZINI" );
+            eZDebug::writeNotice( "Prepending override dir '$dir'", __METHOD__ );
 
         if ( $this->UseLocalOverrides == true )
             $dirs =& $this->LocalOverrideDirArray;
@@ -1463,7 +1463,7 @@ class eZINI
             && !isset( self::$injectedSettings[$this->FileName][$blockName] )
         )
         {
-            eZDebug::writeError( "Undefined group: '$blockName' in " . $this->FileName, "eZINI" );
+            eZDebug::writeError( "Undefined group: '$blockName' in " . $this->FileName, __METHOD__ );
             return false;
         }
         foreach ( $varNames as $key => $varName )

--- a/lib/ezutils/classes/ezmodule.php
+++ b/lib/ezutils/classes/ezmodule.php
@@ -960,7 +960,7 @@ class eZModule
             if ( !isset( $allowedHosts[$urlComponents['host']] ) )
             {
                 // Non-authorized host, return only the URI (without host) + query string and fragment if present.
-                eZDebug::writeError( "Redirection requested on non-authorized host '{$urlComponents['host']}'" );
+                eZDebug::writeError( "Redirection requested on non-authorized host '{$urlComponents['host']}'", __METHOD__ );
                 header( $_SERVER['SERVER_PROTOCOL'] . ' 403 Forbidden' );
                 echo "Redirection requested on non-authorized host";
                 eZDB::checkTransactionCounter();
@@ -1643,7 +1643,7 @@ class eZModule
              !isset( $this->Functions[$functionName] ) )
         {
             eZDebug::writeError( "Undefined view: " . $this->Module["name"] . "::$functionName ",
-                                 "eZModule" );
+                                 __METHOD__ );
             $this->setExitStatus( self::STATUS_FAILED );
             $Return = null;
             return $Return;
@@ -1902,7 +1902,7 @@ class eZModule
                 {
                     eZDebug::writeWarning( "Extension '$extensionRepository' was reported to have modules but has not yet been activated.\n" .
                                            "Check the setting ModuleSettings/ExtensionRepositories in module.ini for your extensions\n" .
-                                           "or make sure it is activated in the setting ExtensionSettings/ActiveExtensions in site.ini." );
+                                           "or make sure it is activated in the setting ExtensionSettings/ActiveExtensions in site.ini.", __METHOD__ );
                 }
                 else if ( file_exists( $modulePath ) )
                 {
@@ -1912,13 +1912,13 @@ class eZModule
                 {
                     eZDebug::writeWarning( "Extension '$extensionRepository' was reported to have modules but the extension itself does not exist.\n" .
                                            "Check the setting ModuleSettings/ExtensionRepositories in module.ini for your extensions.\n" .
-                                           "You should probably remove this extension from the list." );
+                                           "You should probably remove this extension from the list.", __METHOD__ );
                 }
                 else
                 {
                     eZDebug::writeWarning( "Extension '$extensionRepository' does not have the subdirectory 'modules' allthough it reported it had modules.\n" .
                                            "Looked for directory '" . $modulePath . "'\n" .
-                                           "Check the setting ModuleSettings/ExtensionRepositories in module.ini for your extension." );
+                                           "Check the setting ModuleSettings/ExtensionRepositories in module.ini for your extension.", __METHOD__ );
                 }
             }
 
@@ -2126,7 +2126,7 @@ class eZModule
                 } break;
                 default:
                 {
-                    eZDebug::writeError( "Unknown access rule: $name=$value", 'Access' );
+                    eZDebug::writeError( "Unknown access rule: $name=$value", __METHOD__ );
                 } break;
             }
         }

--- a/lib/ezutils/classes/ezmodulefunctioninfo.php
+++ b/lib/ezutils/classes/ezmodulefunctioninfo.php
@@ -208,7 +208,7 @@ class eZModuleFunctionInfo
                 {
                     $parameterName = $resultArray['internal_error_parameter_name'];
                     eZDebug::writeError( "Missing parameter '$parameterName' for function '$functionName' in module '$moduleName'",
-                                         __METHOD__ . " $moduleName::$functionName" );
+                                         __METHOD__ );
                     return null;
                 } break;
                 default:

--- a/lib/ezutils/classes/ezphpcreator.php
+++ b/lib/ezutils/classes/ezphpcreator.php
@@ -777,7 +777,7 @@ $php->addInclude( 'lib/ezutils/classes/ezphpcreator.php' );
             $perm = octdec( $ini->variable( 'FileSettings', 'StorageFilePermissions' ) );
             $this->FileResource = @fopen( $this->FilePrefix . $path, "w" );
             if ( !$this->FileResource )
-                eZDebug::writeError( "Could not open file '$path' for writing, perhaps wrong permissions" );
+                eZDebug::writeError( "Could not open file '$path' for writing, perhaps wrong permissions", __METHOD__ );
             if ( $this->FileResource and
                  !$pathExisted )
                 chmod( $path, $perm );

--- a/lib/ezutils/classes/ezprocess.php
+++ b/lib/ezutils/classes/ezprocess.php
@@ -52,7 +52,7 @@ class eZProcess
         }
         else
             eZDebug::writeWarning( "PHP script $file does not exist, cannot run.",
-                                   "eZProcess" );
+                                   __METHOD__ );
         return $Result;
     }
 

--- a/tests/tests/kernel/classes/workflowtypes/ezapprovetype_regression.php
+++ b/tests/tests/kernel/classes/workflowtypes/ezapprovetype_regression.php
@@ -217,7 +217,7 @@ class eZApproveTypeRegression extends ezpDatabaseTestCase
                 $bodyMemento = eZOperationMemento::fetchChild( $process->attribute( 'memento_key' ) );
                 if ( is_null( $bodyMemento ) )
                 {
-                    eZDebug::writeError( $bodyMemento, "Empty body memento in workflow.php" );
+                    eZDebug::writeError( $bodyMemento, "Empty body memento in workflow.php", __METHOD__ );
                     continue;
                 }
                 $bodyMementoData = $bodyMemento->data();


### PR DESCRIPTION
Many `eZDebug::write*` calls don't have a label, have a fixed one which e.g. only includes a static string naming the class or are wrong due to copy and paste.

This PR adds `__METHOD__` as a label which makes it easier to check out where a message has been triggered.

In some cases, I also altered the message output, for example when an array or an object has been given as message. In these cases, I have transformed the non-string value to `var_export( $myNonStringValue )`.

Cheers
:octocat: Jérôme
