### PR TITLE
Fix EZP-21585: ORA-12899 when creating content in japanese

### DIFF
--- a/kernel/classes/eznamepatternresolver.php
+++ b/kernel/classes/eznamepatternresolver.php
@@ -37,6 +37,8 @@
  */
 class eZNamePatternResolver
 {
+    const FIELD_NAME_MAX_SIZE = 255;
+
     /**
      * Holds token groups
      *
@@ -130,15 +132,20 @@ class eZNamePatternResolver
         // Replace tokens with real values
         $objectName = $this->translatePattern();
 
-        // Make sure length is not longer then $limit unless it's 0
-        if ( !$limit || mb_strlen( $objectName, "utf-8" ) <= $limit )
+        $db = eZDB::instance();
+
+        $limit = $limit ?: self::FIELD_NAME_MAX_SIZE;
+
+        if ( $db->countStringSize( $objectName ) <= $limit )
         {
             return $objectName;
         }
-        else
-        {
-            return preg_replace( "/[\pZ\pC]+$/u", '', mb_substr( $objectName, 0, $limit - mb_strlen( $sequence, "utf-8" ), "utf-8" ) ) . $sequence;
-        }
+
+        return preg_replace(
+            "/[\pZ\pC]+$/u",
+            '',
+            $db->truncateString( $objectName, $limit, 'name', $sequence )
+        ). $sequence;
     }
 
     /**

--- a/kernel/classes/ezpersistentobject.php
+++ b/kernel/classes/ezpersistentobject.php
@@ -391,15 +391,13 @@ class eZPersistentObject
             if ( $value !== null                                &&
                  $field_def['datatype'] === 'string'            &&
                  array_key_exists( 'max_length', $field_def )   &&
-                 $field_def['max_length'] > 0                   &&
-                 mb_strlen( $value, "utf-8" ) > $field_def['max_length'] )
+                 $field_def['max_length'] > 0 )
             {
-                $obj->setAttribute( $field_name, mb_substr( $value, 0, $field_def['max_length'], "utf-8" ) );
-                eZDebug::writeDebug( $value, "truncation of $field_name to max_length=". $field_def['max_length'] );
+                $obj->setAttribute( $field_name, $db->truncateString( $value, $field_def['max_length'], $field_name ) );
             }
             $bindDataTypes = array( 'text' );
             if ( $db->bindingType() != eZDBInterface::BINDING_NO &&
-                 mb_strlen( $value, "utf-8" ) > 2000 &&
+                 $db->countStringSize( $value ) > 2000 &&
                  is_array( $field_def ) &&
                  in_array( $field_def['datatype'], $bindDataTypes  )
                  )
@@ -1202,7 +1200,7 @@ class eZPersistentObject
 
             $bindDataTypes = array( 'text' );
             if ( $db->bindingType() != eZDBInterface::BINDING_NO &&
-                 mb_strlen( $value, "utf-8" ) > 2000 &&
+                 $db->countStringSize( $value ) > 2000 &&
                  is_array( $fieldDef ) &&
                  in_array( $fieldDef['datatype'], $bindDataTypes  )
                  )

--- a/lib/ezdb/classes/ezdbinterface.php
+++ b/lib/ezdb/classes/ezdbinterface.php
@@ -1508,6 +1508,46 @@ class eZDBInterface
     }
 
     /**
+     * Truncates a $string to a $maxLength
+     *
+     * This method is meant to be overridden if needed by different DB implementation:
+     * for example oracle handles bytes and not char
+     *
+     * @param $string
+     * @param $maxLength
+     * @param $fieldName
+     * @param $truncationSuffix string to be added at the end, room will be left so it can be added later.
+     *
+     * @return string
+     */
+    public function truncateString( $string, $maxLength, $fieldName, $truncationSuffix = '' )
+    {
+        if ( mb_strlen( $string, "utf-8" ) <= $maxLength )
+        {
+            return $string;
+        }
+
+        eZDebug::writeDebug( $string, "truncation of $fieldName to max_length=". $maxLength );
+
+        return mb_substr(  $string , 0, $maxLength - mb_strlen( $truncationSuffix, "utf-8" ), "utf-8" );
+    }
+
+    /**
+     * Returns the size of the $string
+     *
+     * This method is meant to be overridden if needed by different DB implementation:
+     * for example oracle handles bytes and not char
+     *
+     * @param $string
+     *
+     * @return int
+     */
+    public function countStringSize( $string )
+    {
+        return mb_strlen( $string, "utf-8" );
+    }
+
+    /**
      * Contains the current server
      *
      * @access protected

--- a/tests/tests/kernel/classes/eznamepatternresolver_regression.php
+++ b/tests/tests/kernel/classes/eznamepatternresolver_regression.php
@@ -56,6 +56,14 @@ class eZNamePatternResolverRegression extends ezpTestCase
                 "name",
                 "私は簡単にパブリッシュの記事で使用することができるようなもの.."
             ),
+            array(// test a string that doesn't need to be modified
+                "A string that doesn't need to be altered",
+                0,
+                "..",
+                "<name>",
+                "name",
+                "A string that doesn't need to be altered"
+            )
         );
     }
 


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-21585

This fix is not finished, but feel free to check it out.
### Description

Externalize some string related operations in the eZDBInterface
so it is possible to override them to have a different
behavior depending on the DB in use.
### Tests

Manual tests
### TODO
- [x] Open the related ezoracle pull request
- [x] Test for regression on mysql (my env is currently on oracle)
