### PR TITLE
EZP-21829: Avoid notice when overriding a nonexisting variable

### DIFF
--- a/tests/toolkit/ezpinihelper.php
+++ b/tests/toolkit/ezpinihelper.php
@@ -35,7 +35,8 @@ class ezpINIHelper
         }
 
         // backup the value
-        self::$modifiedINISettings[] = array( $file, $block, $variable, $ini->variable( $block, $variable ) );
+        $oldValue = $ini->hasVariable( $block, $variable ) ? $ini->variable( $block, $variable ) : null;
+        self::$modifiedINISettings[] = array( $file, $block, $variable, $oldValue );
 
         // change the value
         $ini->setVariable( $block, $variable, $value );


### PR DESCRIPTION
When trying to override an INI setting in an Unit Test which doesn't exist yet in an INI file, `ezpINIHelper` triggers a notice that the variable doesn't exist.

This can happen if a variable is not present in a default INI file, but has been set in an override INI in `settings/override` - as the standard `settings/override` dir is disabled during tests, this can lead to this behavior.

https://jira.ez.no/browse/EZP-21829

Cheers
:octocat: Jérôme
