### PR TITLE
EZP-21619: Updated INI doc for redirectAfterPublish feature

### DIFF
--- a/settings/site.ini
+++ b/settings/site.ini
@@ -1184,9 +1184,8 @@ DatatypeBlackListForExternal[]=ezuser
 
 # Use this setting to change the redirection after publishing a node.
 # It can contain the following values:
-# - parentNode - redirect to the parent of the edited node (default value)
-# - node       - redirect to the current edited node
-# - mainNode   - redirect to the main node of the current edited node (if multipositoned object)
+# - parentNode - redirect to the parent of the edited object's main node (default value)
+# - node       - redirect to the edited object's main node
 # - rootNode   - redirect to siteaccess root node (ie. content.ini/NodeSettings/rootNode )
 # - uri        - redirect to a specific URI (see RedirectAfterPublishUri settings below)
 RedirectAfterPublish=parentNode


### PR DESCRIPTION
See http://jira.ez.no/browse/EZP-21619

Not much here. The redirect code only knows about the published object, not the edited node. The reference node is obtained using $object->mainNode(), and that means that node & mainNode are equivalent.

Clarified by removing the mainNode value from the doc, and mentioned that the redirect node is always based on the main location.
