### PR TITLE
Fix EZP-21740: Added DFS cluster DB update script

### DIFF
--- a/update/database/mysql/5.2/dbupdate-cluster-5.1.0-to-5.2.0.sql
+++ b/update/database/mysql/5.2/dbupdate-cluster-5.1.0-to-5.2.0.sql
@@ -1,0 +1,15 @@
+CREATE TABLE ezdfsfile_cache (
+  `name` text NOT NULL,
+  name_trunk text NOT NULL,
+  name_hash varchar(34) NOT NULL DEFAULT '',
+  datatype varchar(255) NOT NULL DEFAULT 'application/octet-stream',
+  scope varchar(25) NOT NULL DEFAULT '',
+  size bigint(20) unsigned NOT NULL DEFAULT '0',
+  mtime int(11) NOT NULL DEFAULT '0',
+  expired tinyint(1) NOT NULL DEFAULT '0',
+  PRIMARY KEY (name_hash),
+  KEY ezdfsfile_name (`name`(250)),
+  KEY ezdfsfile_name_trunk (name_trunk(250)),
+  KEY ezdfsfile_mtime (mtime),
+  KEY ezdfsfile_expired_name (expired,`name`(250))
+) ENGINE=InnoDB;


### PR DESCRIPTION
When upgrading eZ Publish 5.1 to 5.2 the necessary MySQL file for DFS is missing with the new table added.

Note: This is a separate file
