### PR TITLE
EZP-16144: Implement '--quiet' option in ezpgenerateautoloads.php script

### DIFF
--- a/bin/php/ezpgenerateautoloads.php
+++ b/bin/php/ezpgenerateautoloads.php
@@ -75,6 +75,11 @@ $helpOption->mandatory = false;
 $helpOption->shorthelp = "Show help information";
 $params->registerOption( $helpOption );
 
+$quietOption = new ezcConsoleOption( 'q', 'quiet', ezcConsoleInput::TYPE_NONE );
+$quietOption->mandatory = false;
+$quietOption->shorthelp = "do not give any output except when errors occur";
+$params->registerOption( $quietOption );
+
 $targetOption = new ezcConsoleOption( 't', 'target', ezcConsoleInput::TYPE_STRING );
 $targetOption->mandatory = false;
 $targetOption->shorthelp = "The directory to where the generated autoload file should be written.";
@@ -185,7 +190,7 @@ if ( defined( 'EZP_AUTOLOAD_OUTPUT' ) )
 }
 else
 {
-    $autoloadCliOutput = new ezpAutoloadCliOutput();
+    $autoloadCliOutput = new ezpAutoloadCliOutput( $quietOption->value );
 }
 
 $autoloadGenerator->setOutputObject( $autoloadCliOutput );

--- a/kernel/private/classes/ezpautoloadclioutput.php
+++ b/kernel/private/classes/ezpautoloadclioutput.php
@@ -42,10 +42,18 @@ class ezpAutoloadCliOutput implements ezpAutoloadOutput
      */
     protected $data = null;
 
-    public function __construct()
+    /**
+     * Constructor of the ezpAutoloadCliOutput class
+     *
+     * @param bool|null $quiet True to not display any messages/warnings to the output.
+     *                         False / null to display all messages.
+     * @return void
+     */
+    public function __construct( $quiet = false )
     {
         $this->output = new ezcConsoleOutput();
         $this->output->formats->warning->color = 'red';
+        $this->output->options->verbosityLevel = $quiet ? 0 : 1;
 
         $this->data = array();
         $this->data['phase1'] = array();


### PR DESCRIPTION
ezpgenerateautoloads script does not implement the '--quiet' option, as do the other scripts.

This PR adds such option, and adjusts verbosity level on ezcConsoleOutput accordingly.

JIRA: https://jira.ez.no/browse/EZP-16144
