### PR TITLE
store can not be called here, because it clears object's data_map

### DIFF
--- a/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
+++ b/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
@@ -200,7 +200,6 @@ class eZObjectRelationListType extends eZDataType
         {
             $content['relation_list'] = array();
             $contentObjectAttribute->setContent( $content );
-            $contentObjectAttribute->store();
             return true;
         }
 


### PR DESCRIPTION
For example we have a content class, which consist of following attributes:
- attribute 1 (any datatype)
  ...
- attribute 10 (any datatype)
- attribute 11 (objectrelation list datatype)
- attribute 12 (any datatype)
  ...
- attribute 20 (any datatype)

When new content object of this type is published (without any relations in attribute 11). It`s datatype cache will be cleared. And it will be not possible to get valid object`s datamap in attribute 12 ... attribute 20.

Current changes fixes this bug.
