### PR TITLE
Fix EZP-21844: Added split DFS cleanup script

### DIFF
--- a/kernel/private/classes/clusterfilehandlers/dfsbackends/mysqli.php
+++ b/kernel/private/classes/clusterfilehandlers/dfsbackends/mysqli.php
@@ -1888,6 +1888,34 @@ class eZDFSFileHandlerMySQLiBackend implements eZClusterEventNotifier
     }
 
     /**
+     * Deletes a batch of cache files from the storage table.
+     *
+     * @param int $limit
+     *
+     * @return int The number of moved rows
+     *
+     * @throws RuntimeException if a MySQL query occurs
+     * @throws InvalidArgumentException if the split table feature is disabled
+     */
+    public function deleteCacheFiles( $limit )
+    {
+        if ( $this->metaDataTable === $this->metaDataTableCache )
+        {
+            throw new InvalidArgumentException( "The split table features is disabled: cache and storage table are identical" );
+        }
+
+        $like = addcslashes( eZSys::cacheDirectory(), '_' ) . DIRECTORY_SEPARATOR . '%';
+
+        $query = "DELETE FROM {$this->metaDataTable} WHERE name LIKE '$like' LIMIT $limit";
+        if ( !mysqli_query( $this->db, $query ) )
+        {
+            throw new RuntimeException( "MySQLi error in $query\n" . mysqli_error( $this->db ), mysqli_errno( $this->db ) );
+        }
+
+        return mysqli_affected_rows( $this->db );
+    }
+
+    /**
      * DB connexion handle
      * @var handle
      */

--- a/update/common/scripts/5.2/cleanupdfscache.php
+++ b/update/common/scripts/5.2/cleanupdfscache.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * File containing the cleanupdfscache.php script
+ *
+ * @copyright Copyright (C) 2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+require_once 'autoload.php';
+
+$cli = eZCLI::instance();
+
+$script = eZScript::instance(
+    array(
+        'description' => "Deletes cache records from the DFS storage table.\n" .
+            "Can be used on a live site to cleanup cache leftovers in ezdfsfile.",
+        'use-session' => true,
+        'use-modules' => false,
+        'use-extensions' => true
+    )
+);
+$script->startup();
+
+$options = $script->getOptions(
+    "[iteration-sleep:][iteration-limit:]",
+    "",
+    array(
+        'iteration-sleep' => 'Sleep duration between batches, in milliseconds (default: 100)',
+        'iteration-limit' => 'Batch size (default: 1000)'
+    )
+);
+$optIterationSleep = (int)$options['iteration-sleep'] ?: 100;
+$optIterationLimit = (int)$options['iteration-limit'] ?: 1000;
+
+$script->initialize();
+
+$mysqliDFSBackend = new eZDFSFileHandlerMySQLiBackend();
+try
+{
+    $mysqliDFSBackend->_connect();
+}
+catch ( eZClusterHandlerDBNoConnectionException $e )
+{
+    $script->shutdown( 2, "Unable to connect to the cluster database. Is this instance configured to use the feature ?" );
+}
+
+
+$clusterHandler = eZClusterFileHandler::instance();
+
+try
+{
+    while ( $deletedCount = $mysqliDFSBackend->deleteCacheFiles( $optIterationLimit ) )
+    {
+        $cli->output( "Deleted $deletedCount cache record(s)" );
+        usleep( $optIterationSleep * 1000 );
+    }
+}
+catch ( InvalidArgumentException $e )
+{
+    $script->shutdown( 0, "The cache and storage tables are identical, nothing to do" );
+}
+catch ( RuntimeException $e )
+{
+    $script->shutdown( 1, "A database error occured:\n" . $e->getMessage() );
+}
+$cli->output( "Done" );
+
+$script->shutdown();


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-21844

Not much to describe. Iterates over batches of 1000 cache records from the storage table, and deletes them.
Must also be documented on doc.ez.no in the 5.2 upgrade section.
