### PR TITLE
EZP-21872: Check system user before executing script

### DIFF
--- a/kernel/classes/ezscript.php
+++ b/kernel/classes/ezscript.php
@@ -209,6 +209,21 @@ class eZScript
         {
             date_default_timezone_set( $timezone );
         }
+
+        // Check if the current system user is allowed to execute the script
+        $fileIni = eZINI::instance( 'file.ini' );
+        $checkSystemUser = $fileIni->variable( 'FileSettings', 'SystemUserCheck' ) == 'enabled' ;
+        if ( $checkSystemUser && function_exists( 'posix_geteuid' ) )
+        {
+            $currentUser = posix_getpwuid( posix_geteuid() );
+            $requiredUser = $fileIni->variable( 'FileSettings', 'RequiredSystemUser' );
+            if ( $currentUser['name'] !== $requiredUser )
+            {
+                $cli = eZCLI::instance();
+                $cli->error( "Scripts must be executed as '{$requiredUser}'." );
+                exit( 1 );
+            }
+        }
     }
 
     /*!

--- a/settings/file.ini
+++ b/settings/file.ini
@@ -20,6 +20,12 @@ Handler=eZFilePassthroughHandler
 #ExtensionRepositories[]
 
 [FileSettings]
+# (UNIX only) Whether to check if the user executing an eZScript is the same
+# as defined in the SystemUser setting. When the users don't match, the
+# script execution will be stopped.
+SystemUserCheck=disabled
+RequiredSystemUser=www-data
+
 Handlers[]
 # Generic gzip handler, uses the zlib or shell handlers to do the job
 Handlers[gzip]=ezgzipcompressionhandler


### PR DESCRIPTION
Sometimes it can happen that you forget to execute an eZ CLI script as the webserver user, which can result in files not being created or being created with the wrong owner and/or permission settings. Subsequent script calls with the correct user then also can be unsuccessful.

With this patch, we are able on UNIX systems to check the executing user against a predefined user name and can stop the script execution when the both don't match.

https://jira.ez.no/browse/EZP-21872

Cheers
:octocat: Jérôme

PS: See [the discussion in JIRA](https://jira.ez.no/browse/EZP-21872?focusedCommentId=84323&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-84323) for use cases.
