### PR TITLE
Fix EZP-21883: Regression from ezp-21357 with images with utf-8 names

### DIFF
--- a/lib/ezimage/classes/ezimageshellhandler.php
+++ b/lib/ezimage/classes/ezimageshellhandler.php
@@ -71,8 +71,8 @@ class eZImageShellHandler extends eZImageHandler
         // Still expand File*.jpg as the shell would do, however, this is only true for the file's basename part and not
         // for the whole path.
         $argumentList[] = eZSys::escapeShellArgument(
-            dirname( $sourceMimeData['url'] ) . DIRECTORY_SEPARATOR . addcslashes(
-                basename( $sourceMimeData['url'] ),
+            $sourceMimeData['dirpath'] . DIRECTORY_SEPARATOR . addcslashes(
+                $sourceMimeData['filename'],
                 // ImageMagick meta-characters
                 '~*?[]{}<>'
             )


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-21883
## Description

In https://jira.ez.no/browse/EZP-21357 wildcard shell characters had been escaped to avoid ImageMagick's side effects.

The basename() and dirname() methods are using the default locale to deal with utf-8 strings and it could cause problems if the setlocale() hasn't been set.

$sourceMimeData variable  already contains "utf-8 friendly information" regarding the dir and the basename of the image, so this PR replaces the call to the methods by these values.
## Test

Manual tests
