### PR TITLE
Fix EZP-21915: do not allow creation of approval event without approvers

### DIFF
--- a/kernel/classes/workflowtypes/event/ezapprove/ezapprovetype.php
+++ b/kernel/classes/workflowtypes/event/ezapprove/ezapprovetype.php
@@ -583,8 +583,8 @@ class eZApproveType extends eZWorkflowEventType
                                 } break;
                             }
                         }
-                        $http->removeSessionVariable( 'BrowseParameters' );
                     }
+                    $http->removeSessionVariable( 'BrowseParameters' );
                 }
             }
         }


### PR DESCRIPTION
This happens when user clicks CANCEL in the browse-mode for selecting the approver groups, then immediately OK in the workflow editing page
