### PR TITLE
Fix EZP-21914: reset ezcDb link from ezasynchronouspublishing.php

### DIFF
--- a/kernel/private/classes/ezpcontentpublishingprocess.php
+++ b/kernel/private/classes/ezpcontentpublishingprocess.php
@@ -172,6 +172,25 @@ class ezpContentPublishingProcess extends eZPersistentObject
         $db = null;
         eZDB::setInstance( null );
 
+        // Force the new stack DB connection closed as well
+        try
+        {
+            $kernel = ezpKernel::instance();
+            if ( $kernel->hasServiceContainer() )
+            {
+                $serviceContainer = $kernel->getServiceContainer();
+                $dbHandler = $serviceContainer->get( 'ezpublish.connection' );
+                $factory = $serviceContainer->get( 'ezpublish.api.storage_engine.legacy.dbhandler.factory' );
+                $dbHandler->setDbHandler(
+                    $factory->buildLegacyDbHandler()->getDbHandler()
+                );
+            }
+        }
+        catch ( LogicException $e )
+        {
+            // we just ignore this, since it means that we are running in a pure legacy context
+        }
+
         // Force the cluster DB connection closed if the cluster handler is DB based
         $cluster = eZClusterFileHandler::instance();
 


### PR DESCRIPTION
http://jira.ez.no/browse/EZP-21914

Depends on #831 and https://github.com/ezsystems/ezpublish-kernel/pull/602.

Resets the DB link by explicitely calling the factory service, and re-injecting a fresh ezcDb connection.
