### PR TITLE
Fix EZP-21919: problems editing workflows concurrently in 2 browser windows

### DIFF
--- a/kernel/workflow/edit.php
+++ b/kernel/workflow/edit.php
@@ -116,7 +116,7 @@ if ( $http->hasPostVariable( "DiscardButton" ) )
     $db = eZDB::instance();
     $db->begin();
     $workflow->removeThis( true );
-    eZWorkflowGroupLink::removeWorkflowMembers( $WorkflowID, $WorkflowVersion );
+    eZWorkflowGroupLink::removeWorkflowMembers( $WorkflowID, 1 );
     $db->commit();
 
     $workflowGroups= eZWorkflowGroupLink::fetchGroupList( $WorkflowID, 0, true );


### PR DESCRIPTION
when user presses "cancel" in both windows, workflow gets removed from its groups
