### PR TITLE
Fix EZP-21903: Copy & paste with chrome insert non break space

### DIFF
--- a/extension/ezoe/design/standard/templates/content/datatype/edit/ezxmltext_ezoe.tpl
+++ b/extension/ezoe/design/standard/templates/content/datatype/edit/ezxmltext_ezoe.tpl
@@ -130,10 +130,34 @@
         //atd_button_url              : "atdbuttontr.gif",
         atd_css_url : {'javascript/plugins/AtD/css/content.css'|ezdesign},
         paste_preprocess : function(pl, o) {ldelim}
+            var ed = pl.editor, uid, elt, prev;
+
             // Strip <a> HTML tags from clipboard content (Happens on Internet Explorer)
             o.content = o.content.replace( /(\s[a-z]+=")<a\s[^>]+>([^<]+)<\/a>/gi, '$1$2' );
             // Strip namespaced tags, avoids issues with Word's "Smart Tags"
             o.content = o.content.replace(/<\/?[^<>\s]+:[^<>]+>/g, '');
+            
+            {literal}
+            // Workaround for https://jira.ez.no/browse/EZP-21903
+            // http://www.tinymce.com/develop/bugtracker_view.php?id=6483
+            if ( tinymce.isWebKit ) {
+                uid = tinymce.DOM.uniqueId();
+                ed.focus();
+                ed.execCommand('mceInsertContent', false, '<span id="' + uid + '"></span>');
+                elt = ed.getDoc().getElementById(uid);
+
+                if ( !elt.nextSibling || elt.nextSibling.nodeValue === "" ) {
+                    // we are at the end of the line
+                    // if it ends with only a non break space, we transform it into a normal space
+                    prev = elt.previousSibling;
+
+                    if ( prev && prev.nodeType === 3 && !prev.nodeValue.match(/ \u00a0$/) ) {
+                        prev.nodeValue = prev.nodeValue.replace(/\u00a0$/, ' ');
+                    }
+                }
+                ed.dom.remove(elt);
+            }
+            {/literal}
         {rdelim},
         paste_postprocess: function(pl, o) {ldelim}
             // removes \n after <br />, this is for paste of text


### PR DESCRIPTION
JIRA issue: https://jira.ez.no/browse/EZP-21903
# Description

In Chrome, when you hit space at the end of a line, it adds a non breaking space, if you type something after, TinyMCE transforms it to a normal space but this transformation does not occur if you are pasting something instead of typing. As a result, the resulting HTML might contain several non breaking spaces which might break the website layout.

This is a [TinyMCE issue](http://www.tinymce.com/develop/bugtracker_view.php?id=6483) which also affect the last versions of TinyMCE (4.0.x) and this patch is actually a more workaround to this. Unfortunately, it also creates a (very?) minor issue because when we remove the non breaking space we don't know if it was created automatically or if it was added by the user and in such case we should probably not remove it.
# Tests

manual tests in Chrome in various copy / paste scenarios.
