### PR TITLE
Section edit seems to clear all view caches

### DIFF
--- a/kernel/classes/ezsection.php
+++ b/kernel/classes/ezsection.php
@@ -243,6 +243,11 @@ class eZSection extends eZPersistentObject
                     eZContentOperationCollection::updateSection( $node->attribute( "node_id" ), $sectionID );
                 }
             }
+            
+            foreach ( $assignedNodes as $node )
+            {
+               eZContentObjectTreeNode::clearViewCacheForSubtree($node, false);
+            }
         }
         else
         {
@@ -252,6 +257,7 @@ class eZSection extends eZPersistentObject
             $db->query( "UPDATE ezsearch_object_word_link SET section_id='$sectionID' WHERE  contentobject_id = '$objectID'" );
         }
         eZContentCacheManager::clearContentCacheIfNeeded( $object->attribute( "id" ) );
+         
         $db->commit();
     }
 }


### PR DESCRIPTION
I think we don't have to clear all view cache like this.
Moreover expireAllViewCache is a static method.

``` php

    static function expireAllViewCache()
    {
        eZExpiryHandler::registerShutdownFunction();
        $handler = eZExpiryHandler::instance();
        $handler->setTimestamp( 'content-view-cache', time() );
        $handler->store();
    }
```
