### PR TITLE
Fix EZP-21929: eZOE searchreplace plugin interface is broken

### DIFF
--- a/extension/ezoe/design/standard/stylesheets/skins/default/dialog.css
+++ b/extension/ezoe/design/standard/stylesheets/skins/default/dialog.css
@@ -85,6 +85,7 @@ td.charmap, #charmap a {width:18px; height:18px; color:#000; border:1px solid #A
 .tabs a:link, .tabs a:visited, .tabs a:hover {color:black;}
 
 /* Panels */
+.panel_wrapper div.panel {display:none;}
 .panel_wrapper div.current {display:block; width:100%; height:auto; overflow:visible;}
 .panel_wrapper {border:1px solid #919B9C; border-top:0px; padding:10px; padding-top:5px; clear:both; background:white;}
 .panel_wrapper div.current:after /* Terminate floating elements flow */

--- a/extension/ezoe/design/standard/stylesheets/skins/o2k7/dialog.css
+++ b/extension/ezoe/design/standard/stylesheets/skins/o2k7/dialog.css
@@ -83,6 +83,7 @@ td.charmap, #charmap a {width:18px; height:18px; color:#000; border:1px solid #A
 .tabs a:link, .tabs a:visited, .tabs a:hover {color:black;}
 
 /* Panels */
+.panel_wrapper div.panel {display:none;}
 .panel_wrapper div.current {display:block; width:100%; height:auto; overflow:visible;}
 .panel_wrapper {border:1px solid #919B9C; border-top:0px; padding:10px; padding-top:5px; clear:both; background:white;}
 .panel_wrapper div.current:after /* Terminate floating elements flow */

--- a/extension/ezoe/design/standard/templates/ezoe/customattributes/link.tpl
+++ b/extension/ezoe/design/standard/templates/ezoe/customattributes/link.tpl
@@ -93,7 +93,7 @@ eZOEPopupUtils.settings.onInitDoneArray.push( function( editorElement )
     // setup navigation on bookmark / browse / search links to their 'boxes' (panels)
     jQuery( 'a.atr_link_search_link, a.atr_link_browse_link, a.atr_link_bookmark_link' ).click( function(){
         ezoeLinkAttribute.id = ezoeLinkAttribute.lid( this.id );
-        jQuery('div.panel').hide();
+        jQuery('div.panel, div.link-dialog').hide();
         jQuery('#' + ezoeLinkAttribute.box( this.id ) ).show();
         jQuery('#' + ezoeLinkAttribute.box( this.id ) + ' input[type=text]:first').focus();
     });
@@ -195,8 +195,8 @@ var ezoeLinkAttribute = {
     {
         ezoeLinkAttribute.id = null;
         jQuery('div.panel').hide();
-        jQuery('div.panel:first').show();
-        jQuery('div.panel:first input[type=text]:first').focus();
+        jQuery('div.link-dialog').show();
+        jQuery('div.link-dialog input[type=text]:first').focus();
     }
 };
 

--- a/extension/ezoe/design/standard/templates/ezoe/tag_link.tpl
+++ b/extension/ezoe/design/standard/templates/ezoe/tag_link.tpl
@@ -31,7 +31,7 @@ tinyMCEPopup.onInit.add( eZOEPopupUtils.BIND( eZOEPopupUtils.init, window, {
 
 
 <div class="panel_wrapper" style="min-height: 300px;">
-    <div class="panel">
+    <div class="link-dialog">
         <div class="attribute-title">
             <h2 style="padding: 0 0 4px 0;" id="tag-edit-title">{'New %tag_name tag'|i18n('design/standard/ezoe', '', hash( '%tag_name', concat('&lt;', $tag_name_alias, '&gt;') ))}</h2>
         </div>


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-21929
# Description

This issue is actually a regression introduced in https://github.com/ezsystems/ezoe/commit/c44396d (by me...) while fixing [EZP-18216](https://jira.ez.no/browse/EZP-18216). So this patch partially reverts https://github.com/ezsystems/ezoe/commit/c44396d to not break the searchreplace plugin interface (and others TinyMCE plugins) and properly fixes EZP-18216 instead.
# Test

Manual tests on the searchreplace plugin and ezoe specific interfaces.
