### PR TITLE
Fix: when there is a connect error to mysql cluster db, php warnings are...

### DIFF
--- a/kernel/clustering/dfsmysqli.php
+++ b/kernel/clustering/dfsmysqli.php
@@ -17,7 +17,7 @@ class ezpDfsMySQLiClusterGateway extends ezpClusterGateway
     {
         if ( !$this->db = mysqli_connect( $this->host, $this->user, $this->password, $this->name, $this->port ) )
             throw new RuntimeException( "Failed connecting to the MySQL database " .
-                "(error #". mysqli_errno( $this->db ).": " . mysqli_error( $this->db ) );
+                "(error #". mysqli_connect_errno().": " . mysqli_connect_error() );
 
         if ( !mysqli_set_charset( $this->db, $this->charset ) )
             throw new RuntimeException( "Failed to set database charset to '$this->charset' " .


### PR DESCRIPTION
... generated instead of getting proper error info

(no time right now for issue creation and paperwork, sorry)
