### PR TITLE
Fix EZP-22027 location/url alias SPI cache not updated.

### DIFF
--- a/kernel/content/urlalias.php
+++ b/kernel/content/urlalias.php
@@ -51,6 +51,7 @@ if ( $Module->isCurrentAction( 'RemoveAllAliases' ) )
         $filter->prepare();
     }
     $infoCode = "feedback-removed-all";
+    ezpEvent::getInstance()->notify( 'content/cache', array( $NodeID ) );
 }
 else if ( $Module->isCurrentAction( 'RemoveAlias' ) )
 {
@@ -70,6 +71,7 @@ else if ( $Module->isCurrentAction( 'RemoveAlias' ) )
             }
         }
         $infoCode = "feedback-removed";
+        ezpEvent::getInstance()->notify( 'content/cache', array( $NodeID ) );
     }
 }
 else if ( $Module->isCurrentAction( 'NewAlias' ) )
@@ -151,6 +153,7 @@ else if ( $Module->isCurrentAction( 'NewAlias' ) )
                 $infoCode = "feedback-alias-created";
             }
             $aliasText = false;
+            ezpEvent::getInstance()->notify( 'content/cache', array( $NodeID ) );
         }
     }
 }


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-22027

Modifications to custom url alias in the administration interface should trigger a `content/cache` event, even if ObjectViewCache does not need to be cleared.

See also https://github.com/ezsystems/ezpublish-kernel/pull/677 for PR implementing 'content/location/cache' event listener
