### PR TITLE
Fix EZP-22032: don't create an empty ezmedia row

### DIFF
--- a/kernel/classes/datatypes/ezmedia/ezmediatype.php
+++ b/kernel/classes/datatypes/ezmedia/ezmediatype.php
@@ -347,6 +347,11 @@ class eZMediaType extends eZDataType
             $fileHandler = eZClusterFileHandler::instance();
             $fileHandler->fileStore( $filePath, 'media', true, $mime );
         }
+        else if ( $media->attribute( 'filename' ) == '' )
+        {
+            $media->remove();
+            return false;
+        }
 
         $media->store();
         $contentObjectAttribute->setContent( $media );


### PR DESCRIPTION
eZMediaType was creating the ezmedia persistent object even if no media file was selected.
# TODO
- [x] Check that editing a new version without uploading a media object won't remove the ezmedia row used by the previous version(s)
