### PR TITLE
Fix EZP-21930: searchreplace plugin generates an infinite loop while changing the case in IE9/10

### DIFF
--- a/extension/ezoe/design/standard/javascript/plugins/searchreplace/js/searchreplace.js
+++ b/extension/ezoe/design/standard/javascript/plugins/searchreplace/js/searchreplace.js
@@ -87,6 +87,10 @@ var SearchReplaceDialog = {
 
 						if (b) {
 							r.moveEnd("character", -(rs.length)); // Otherwise will loop forever
+						} else {
+							// to avoid looping for ever in MSIE 9/10 when just
+							// changing the case
+							r.moveStart("character", rs.length);
 						}
 					}
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-21930
# Description

This is actually a TinyMCE bug, I reported it in http://www.tinymce.com/develop/bugtracker_view.php?id=6528 and this PR is the same as the one I proposed upstream https://github.com/tinymce/tinymce/pull/281
# Tests

Manual test in IE 8/9/10 (In IE8 I did not notice any regression and in IE 9/10 the bug is of course fixed).
