### PR TITLE
Fix EZP-21988: async publishing should generate static cache

### DIFF
--- a/kernel/private/classes/ezpcontentpublishingprocess.php
+++ b/kernel/private/classes/ezpcontentpublishingprocess.php
@@ -259,6 +259,15 @@ class ezpContentPublishingProcess extends eZPersistentObject
         {
             $this->reset();
         }
+
+        // generate static cache
+        $ini = eZINI::instance();
+        if ( $ini->variable( 'ContentSettings', 'StaticCache' ) == 'enabled' )
+        {
+            $staticCacheHandlerClassName = $ini->variable( 'ContentSettings', 'StaticCacheHandler' );
+            $staticCacheHandlerClassName::executeActions();
+        }
+
         eZScript::instance()->shutdown();
         exit;
     }


### PR DESCRIPTION
http://jira.ez.no/browse/EZP-21988.

Static cache tasks weren't processed after publishing, since a call to static cache is done manually in the kernel, after module processing.
### Testing

Manual.
Static cache isn't generated at all without this patch. It works as expected with it.
