### PR TITLE
Fix EZP-16372: deleting of content lasts very long

### DIFF
--- a/doc/bc/5.3/changes-5.3.txt
+++ b/doc/bc/5.3/changes-5.3.txt
@@ -1,0 +1,40 @@
+Changes to BC and behavior in version 5.3
+=========================================
+
+INI setting changes
+-------------------
+
+
+Change of behavior
+------------------
+
+- Fix EZP-16372: deleting of content lasts very long
+
+  The prototypes of eZSearch::removeObject() and eZSearch::removeObjectById() have changed :
+
+  static function removeObject( $contentObject, $commit = true )
+  becomes
+  static function removeObject( $contentObject, $commit = null )
+
+  This change is needed to make ezfind.ini[IndexOptions]\DisableDeleteCommits option of eZFind actually work.
+
+
+Removed features
+----------------
+
+
+
+
+Removed constants
+-----------------
+
+
+
+Removed globals
+---------------
+
+
+
+
+Deprecated
+----------

--- a/kernel/classes/ezsearch.php
+++ b/kernel/classes/ezsearch.php
@@ -62,7 +62,7 @@ class eZSearch
      * @param bool $commit Whether to commit after removing the object
      * @return bool True if the operation succeed.
      */
-    static function removeObject( $contentObject, $commit = true )
+    static function removeObject( $contentObject, $commit = null )
     {
         $searchEngine = eZSearch::getEngine();
 
@@ -82,7 +82,7 @@ class eZSearch
      * @param bool $commit Whether to commit after removing the object
      * @return bool True if the operation succeed.
      */
-    static function removeObjectById( $contentObjectId, $commit = true )
+    static function removeObjectById( $contentObjectId, $commit = null )
     {
         $searchEngine = eZSearch::getEngine();
         if ( $searchEngine instanceof ezpSearchEngine )

--- a/kernel/content/ezcontentoperationcollection.php
+++ b/kernel/content/ezcontentoperationcollection.php
@@ -587,7 +587,7 @@ class eZContentOperationCollection
         if ( eZSearch::needRemoveWithUpdate() )
         {
             eZDebug::accumulatorStart( 'remove_object', 'search_total', 'remove object' );
-            eZSearch::removeObjectById( $objectID, $needCommit );
+            eZSearch::removeObjectById( $objectID );
             eZDebug::accumulatorStop( 'remove_object' );
         }
 

--- a/kernel/private/interfaces/ezpsearchengine.php
+++ b/kernel/private/interfaces/ezpsearchengine.php
@@ -49,7 +49,7 @@ interface ezpSearchEngine
      * @param bool $commit Whether to commit after removing the object
      * @return bool True if the operation succeed.
      */
-    public function removeObject( $contentObject, $commit = true );
+    public function removeObject( $contentObject, $commit = null );
 
     /**
      * Removes a content object by Id from the search database.
@@ -59,7 +59,7 @@ interface ezpSearchEngine
      * @param bool $commit Whether to commit after removing the object
      * @return bool True if the operation succeed.
      */
-    public function removeObjectById( $contentObjectId, $commit = true );
+    public function removeObjectById( $contentObjectId, $commit = null );
 
     /**
      * Searches $searchText in the search database.

--- a/kernel/search/plugins/ezsearchengine/ezsearchengine.php
+++ b/kernel/search/plugins/ezsearchengine/ezsearchengine.php
@@ -377,7 +377,7 @@ class eZSearchEngine implements ezpSearchEngine
      * @param bool $commit Whether to commit after removing the object
      * @return bool True if the operation succeed.
      */
-    public function removeObject( $contentObject, $commit = true )
+    public function removeObject( $contentObject, $commit = null )
     {
         return $this->removeObjectById( $contentObject->attribute( "id" ), $commit );
     }
@@ -390,7 +390,7 @@ class eZSearchEngine implements ezpSearchEngine
      * @param bool $commit Whether to commit after removing the object
      * @return bool True if the operation succeed.
      */
-    public function removeObjectById( $contentObjectId, $commit = true )
+    public function removeObjectById( $contentObjectId, $commit = null )
     {
         $db = eZDB::instance();
         $doDelete = false;


### PR DESCRIPTION
The prototypes of `removeObject()` and `removeObjectById()` differ between `eZSearch` and `eZFind`, i.e:

`static function removeObject( $contentObject, $commit = true )`
versus
`function removeObject( $contentObject, $commit = null )`

When `eZContentObject` calls `eZSearch::removeObjectById( $delID )`, `removeObjectById()` is called by `eZSearch` with its default value, `$commit = true`.

So the check :
`if ( !isset( $commit ) && ( $this->FindINI->variable( 'IndexOptions', 'DisableDeleteCommits' ) === 'true' ) )`

is always false, because `$commit` is always defined.

So unify the prototypes between them, setting $commit default value to null.
