### PR TITLE
Fix EZP-21982: Updated linkcheck.php https warning message

### DIFF
--- a/cronjobs/linkcheck.php
+++ b/cronjobs/linkcheck.php
@@ -66,7 +66,7 @@ foreach ( $linkList as $link )
         }
         else
         {
-            $cli->output( "Couldn't check https protocol" );
+            $cli->output( "HTTPS protocol is not supported by linkcheck" );
         }
     }
     else


### PR DESCRIPTION
Link : https://jira.ez.no/browse/EZP-21982
## Description

HTTPS is not supported by linkcheck.php and the warning message was misleading.
## Test

Manual test
