### PR TITLE
Fix 22030: Object Relations order changed upon concurrent edition

### DIFF
--- a/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
+++ b/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
@@ -203,6 +203,11 @@ class eZObjectRelationListType extends eZDataType
             $contentObjectAttribute->store();
             return true;
         }
+        // Type is browse and we have no http input
+        else if ( $selectedObjectIDArray === false )
+        {
+            return false;
+        }
 
         // Check if selection type is not browse
         if ( $classContent['selection_type'] != 0 )


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-22030
## Description

See steps to reproduce in the issue, they are very clear (thanks @jjCavalleri )

I checked the behavior of other eZDataType and noticed that this method is supposed to return `false` if the post variable is not available. Since in this scenario this is not, I added the return statement and it fixed the problem.
## Tests

Manual tests
