### PR TITLE
Fix EZP-20574: Creating a user with an existing username disables the us...

### DIFF
--- a/design/standard/templates/content/datatype/edit/ezuser.tpl
+++ b/design/standard/templates/content/datatype/edit/ezuser.tpl
@@ -18,7 +18,8 @@
 {* Username. *}
 <div class="element">
     <label for="{$id_base}_login">{'Username'|i18n( 'design/standard/content/datatype' )}:</label>
-    {if $attribute.content.has_stored_login}
+    {def $has_publish_object_same_login = $attribute.content.has_publish_object_same_login}
+    {if $has_publish_object_same_login}
         <input id="{$id_base}_login" type="text" name="{$attribute_base}_data_user_login_{$attribute.id}_stored_login" size="16" value="{$attribute.content.login|wash()}" disabled="disabled" />
         <input id="{$id_base}_login_hidden" type="hidden" name="{$attribute_base}_data_user_login_{$attribute.id}" value="{$attribute.content.login|wash()}" />
     {else}
@@ -29,13 +30,13 @@
 {* Password #1. *}
 <div class="element">
     <label for="{$id_base}_password">{'Password'|i18n( 'design/standard/content/datatype' )}:</label>
-    <input id="{$id_base}_password" class="ezcc-{$attribute.object.content_class.identifier} ezcca-{$attribute.object.content_class.identifier}_{$attribute.contentclass_attribute_identifier}" type="password" name="{$attribute_base}_data_user_password_{$attribute.id}" size="16" value="{if $attribute.content.original_password}{$attribute.content.original_password}{else}{if $attribute.content.has_stored_login}_ezpassword{/if}{/if}" />
+    <input id="{$id_base}_password" class="ezcc-{$attribute.object.content_class.identifier} ezcca-{$attribute.object.content_class.identifier}_{$attribute.contentclass_attribute_identifier}" type="password" name="{$attribute_base}_data_user_password_{$attribute.id}" size="16" value="{if $attribute.content.original_password}{$attribute.content.original_password}{else}{if $has_publish_object_same_login}_ezpassword{/if}{/if}" />
 </div>
 
 {* Password #2. *}
 <div class="element">
     <label for="{$id_base}_password_confirm">{'Confirm password'|i18n( 'design/standard/content/datatype' )}:</label>
-    <input id="{$id_base}_password_confirm" class="ezcc-{$attribute.object.content_class.identifier} ezcca-{$attribute.object.content_class.identifier}_{$attribute.contentclass_attribute_identifier}" type="password" name="{$attribute_base}_data_user_password_confirm_{$attribute.id}" size="16" value="{if $attribute.content.original_password_confirm}{$attribute.content.original_password_confirm}{else}{if $attribute.content.has_stored_login}_ezpassword{/if}{/if}" />
+    <input id="{$id_base}_password_confirm" class="ezcc-{$attribute.object.content_class.identifier} ezcca-{$attribute.object.content_class.identifier}_{$attribute.contentclass_attribute_identifier}" type="password" name="{$attribute_base}_data_user_password_confirm_{$attribute.id}" size="16" value="{if $attribute.content.original_password_confirm}{$attribute.content.original_password_confirm}{else}{if $has_publish_object_same_login}_ezpassword{/if}{/if}" />
 </div>
 
 {* Email. *}


### PR DESCRIPTION
...ername field

Link : https://jira.ez.no/browse/EZP-20574
## Description
### Functional description

There are 3 ways to use the user edit form to handle login fields:
- Create a user (with no errors, all data entered by user are valid): login field should be enabled
- Edit a user: login field should be disabled
- Create a user with an existing login, it will reload the page and display an error message: login field should be enabled and the password cleared - before using this patch it is not the case.

The condition to disable the login field must be: No other user_account has the same login and the object containing the user_account has been published.
### Technical description

ezuser is not versioned, there is not draft management for this attribute. Data are directly created in database. 

So when an error pops up (like when a login is not available), the line has already been inserted while creating the attribute in the database. Making `hasStoredLogin()` returning `true`  making the field disabled.

This fix makes sure the object containing the ezuser attribute has not been published (you can edit the login has long has the object has never been published).
## Tests

Manual tests
