### PR TITLE
Fix "Invalid package" issue of the installation wizard

### DIFF
--- a/kernel/classes/ezpackage.php
+++ b/kernel/classes/ezpackage.php
@@ -1160,7 +1160,7 @@ class eZPackage
             // Search for the files we want to extract
             foreach( $archive as $entry )
             {
-                if ( in_array( $entry->getPath(), $fileList ) )
+                if ( in_array( trim($entry->getPath(),DIRECTORY_SEPARATOR), $fileList ) )
                 {
                     if ( !$archive->extractCurrent( $archivePath ) )
                     {


### PR DESCRIPTION
When installing legacy eZ Publish with the installation wizard, the package installation always fail with the "Invalid package" error. 

Because in line 1163, $entry->getPath() returns an entry path with leading '/', but eZPackage::definitionFilename() is "package.xml", so "package.xml" will never be extracted.

The "Invalid package" issue is also related to another class in ezc, which I will post another fix.