### PR TITLE
Fix EZP-22085: "Tab" characters in node name error (urlalias_iri)

### DIFF
--- a/lib/ezi18n/classes/ezchartransform.php
+++ b/lib/ezi18n/classes/ezchartransform.php
@@ -411,10 +411,10 @@ class eZCharTransform
     static function commandUrlCleanupIRI( $text, $charsetName )
     {
         // With IRI support we keep all characters except some reserved ones,
-        // they are space, ampersand, semi-colon, forward slash, colon, equal sign, question mark,
+        // they are space, tab, ampersand, semi-colon, forward slash, colon, equal sign, question mark,
         //          square brackets, parenthesis, plus.
         //
-        // Note: Space is turned into a dash to make it easier for people to
+        // Note: Spaces and tabs are turned into a dash to make it easier for people to
         //       paste urls from the system and have the whole url recognized
         //       instead of being broken off
         $sep  = eZCharTransform::wordSeparator();
@@ -422,7 +422,7 @@ class eZCharTransform
         $prepost = " ." . $sepQ;
         if ( $sep != "-" )
             $prepost .= "-";
-        $text = preg_replace( array( "#[ \\\\%\#&;/:=?\[\]()+]+#",
+        $text = preg_replace( array( "#[ \t\\\\%\#&;/:=?\[\]()+]+#",
                                      "#^[\.]+|[!\.]+$#", # Remove dots at beginning/end
                                      "#\.\.+#", # Remove double dots
                                      "#[{$sepQ}]+#", # Turn multiple separators into one

--- a/tests/tests/kernel/classes/urlaliasml_test.php
+++ b/tests/tests/kernel/classes/urlaliasml_test.php
@@ -330,7 +330,7 @@ class eZURLAliasMLTest extends ezpDatabaseTestCase
 
         // ---------------------------------------------------------------- //
         // Not safe characters, all of these should be removed.
-        $e1 = " &;/:=?%[]()+#";
+        $e1 = " &;/:=?%[]()+#\t";
         $e1Result = "_1";
 
         // Safe characters. No char should be removed.


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-22085
## Description

When having a tab character in a node name, the link to the node was broken. This patch makes the code deal with tabs the way it does with spaces (replace by a separator).
## To fix existing broken nodes

Once the patch applied, editing the node's name will regenerate it or use php bin/php/updateniceurls.php to do bulk node updates.
## Tests

Updated unit test and manual test.
