### PR TITLE
Fix EZP-21820: eZUser::getUserCacheByUserId() may return an eZClusterFil...

### DIFF
--- a/kernel/classes/datatypes/ezuser/ezuser.php
+++ b/kernel/classes/datatypes/ezuser/ezuser.php
@@ -1288,11 +1288,19 @@ WHERE user_id = '" . $userID . "' AND
     {
         $cacheFilePath = eZUser::getCacheDir( $userId ). "/user-data-{$userId}.cache.php" ;
         $cacheFile = eZClusterFileHandler::instance( $cacheFilePath );
-        return $cacheFile->processCache( array( 'eZUser', 'retrieveUserCacheFromFile' ),
-                                         array( 'eZUser', 'generateUserCacheForFile' ),
-                                         null,
-                                         self::userInfoExpiry(),
-                                         $userId );
+        $userCache = $cacheFile->processCache( array( 'eZUser', 'retrieveUserCacheFromFile' ),
+                                               array( 'eZUser', 'generateUserCacheForFile' ),
+                                               null,
+                                               self::userInfoExpiry(),
+                                               $userId );
+
+        if ( $userCache instanceof eZClusterFileFailure )
+        {
+            $userCache = self::generateUserCacheForFile( null, $userId );
+            $userCache = $userCache['content'];
+        }
+
+        return $userCache;
     }
 
     /**


### PR DESCRIPTION
...eFailure instead of an array
