### PR TITLE
Fix EZP-22177: eZPersistentObject::handleRows() adds bogus rows

### DIFF
--- a/kernel/classes/ezpersistentobject.php
+++ b/kernel/classes/ezpersistentobject.php
@@ -950,9 +950,10 @@ class eZPersistentObject
 
         if ( is_array( $rows ) )
         {
-            for ( $i = 0; $i < count( $rows ); $i++ )
+            $db = eZDB::instance();
+            foreach( $rows as $row )
             {
-                self::replaceFieldsWithLongNames( eZDB::instance(), $objectDefinition['fields'], $rows[$i] );
+                self::replaceFieldsWithLongNames( $db, $objectDefinition['fields'], $row );
             }
         }
 


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-22177

Unfortunately I can't explain why and how, but the change introduced in this commit https://github.com/ezsystems/ezpublish-legacy/commit/fcad133995a1e060792d7cd195c83f8895098b54 causes `eZPersistentObject::fetchObjectList()` to return a wrong number of rows when using the `$offset` parameter.

It might have something to do with the fact the `count( $rows )` is executed in each iteration and might change.

I tested the change manually in a current project and the problem went away.

Cheers
:octocat: Jérôme
