### PR TITLE
Fix EZP-22124: Disable align option if inline is checked

### DIFF
--- a/extension/ezoe/design/standard/templates/ezoe/tag_embed_images.tpl
+++ b/extension/ezoe/design/standard/templates/ezoe/tag_embed_images.tpl
@@ -101,6 +101,16 @@ function inlineSelectorChange( e, el )
         var classValue = jQuery.trim( editorEl.className.replace(/(webkit-[\w\-]+|Apple-[\w\-]+|mceItem\w+|ezoeAlign\w+|ezoeItem\w+|mceVisualAid)/g, '') );
     }
 
+    // If inline is checked disabling aligment selection
+    var embedAlign = jQuery( '#embed_align' );
+
+    if ( inline ){
+        jQuery( '#embed_align_source' ).val("");
+        embedAlign.hide();
+    }else{
+        embedAlign.show();
+    }
+
     if ( viewValue && viewListData[ tag ].join !== undefined && (' ' + viewListData[ tag ].join(' ') + ' ').indexOf( ' ' + viewValue + ' ' ) !== -1 )
         viewList.val( viewValue );
     else if ( def['view'] !== undefined )


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-22124
## Description

In ezoe, in the embed image configuration window, when checking inline and setting up an align option, incoherent positioning options would be generated. This patch makes sure the two options can't be combined.
## Test

Manual tests
