### PR TITLE
Fix EZP-22204: Make sure first Module/View AccessMode != 'keep' is final

### DIFF
--- a/kernel/classes/ezsslzone.php
+++ b/kernel/classes/ezsslzone.php
@@ -223,6 +223,9 @@ class eZSSLZone
         if ( !isset( $inSSL ) )
             return;
 
+        // disable any further redirection/usage of SSLZones
+        $GLOBALS['eZSSLZoneEnabled'] = false;
+
         // $nowSSl is true if current access mode is HTTPS.
         $nowSSL = eZSys::isSSLNow();
 
@@ -319,7 +322,7 @@ class eZSSLZone
          * i.e. it cannot choose access mode itself,
          * then do nothing.
          */
-        if ( !$redirect && !eZSSLZone::isKeepModeView( $module, $view ) )
+        if ( !eZSSLZone::isKeepModeView( $module, $view ) )
             return;
 
         $pathString = $node->attribute( 'path_string' );


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-22204

SSLZones first checks ModuleViewAccessMode, then SSLSubtrees.
If access mode for the module/view is 'keep', the SSLSubtree settings will take effect.

However, the first redirect action should be the last, which is not the case - for example when running multiple modules such as layout->content ( using '/layout/set/print/SomeNode' ).

This PR makes it possible to define a different setting in `[SSLZoneSettings]` to switch out of ssl 
(such as `ModuleViewAccessMode[layout/*]=http`), without causing a redirect loop.
