### PR TITLE
Fix EZP-22232: Fatal Error when calling eZContentOperationCollection::re...

### DIFF
--- a/kernel/content/ezcontentoperationcollection.php
+++ b/kernel/content/ezcontentoperationcollection.php
@@ -484,9 +484,19 @@ class eZContentOperationCollection
     static public function removeOldNodes( $objectID, $versionNum )
     {
         $object = eZContentObject::fetch( $objectID );
-
+        if ( !$object instanceof eZContentObject )
+        {
+            eZDebug::writeError( 'Unable to find object #' . $objectID, __METHOD__ );
+            return;
+        }
 
         $version = $object->version( $versionNum );
+        if ( !$version instanceof eZContentObjectVersion )
+        {
+            eZDebug::writeError( 'Unable to find version #' . $versionNum . ' for object #' . $objectID, __METHOD__ );
+            return;
+        }
+
         $moveToTrash = true;
 
         $assignedExistingNodes = $object->attribute( 'assigned_nodes' );

--- a/tests/tests/kernel/content/ezcontentoperationcollection_test.php
+++ b/tests/tests/kernel/content/ezcontentoperationcollection_test.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * File containing eZContentOperationCollectionTest class
+ *
+ * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ * @package tests
+ */
+
+class eZContentOperationCollectionTest extends ezpDatabaseTestCase
+{
+    public function __construct( $name = NULL, array $data = array(), $dataName = '' )
+    {
+        parent::__construct( $name, $data, $dataName );
+        $this->setName( "eZContentOperationCollection Tests" );
+    }
+
+    /**
+     * Fatal Error when calling eZContentOperationCollection::removeOldNodes()
+     * with inexistant object/object version
+     *
+     * @link http://issues.ez.no/22232
+     */
+    public function testRemoveOldNodes()
+    {
+        eZContentOperationCollection::removeOldNodes( 1234, 1234 );
+    }
+}

--- a/tests/tests/kernel/content/suite.php
+++ b/tests/tests/kernel/content/suite.php
@@ -17,6 +17,7 @@ class eZKernelContentTestSuite extends ezpDatabaseTestSuite
 
         $this->addTestSuite( 'ezpContentPublishingBehaviourTest' );
         $this->addTestSuite( 'eZContentOperationDeleteObjectRegression' );
+        $this->addTestSuite( 'eZContentOperationCollectionTest' );
     }
 
     public static function suite()


### PR DESCRIPTION
...moveOldNodes() with inexistant object/object version

Include unittest

Link: https://jira.ez.no/browse/EZP-22232
