### PR TITLE
Fix EZP-22178: Updating main node doesn't update search engine

### DIFF
--- a/kernel/content/ezcontentoperationcollection.php
+++ b/kernel/content/ezcontentoperationcollection.php
@@ -1210,6 +1210,8 @@ class eZContentOperationCollection
     {
         eZContentObjectTreeNode::updateMainNodeID( $mainAssignmentID, $ObjectID, false, $mainAssignmentParentID );
         eZContentCacheManager::clearContentCacheIfNeeded( $ObjectID );
+        eZContentOperationCollection::registerSearchObject( $ObjectID );
+
         return array( 'status' => true );
     }
 


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-22178
## Description

The search engine was not updated when a node was changed (unless we re indexed the whole thing).
## Test

Manual tests
