### PR TITLE
Fix EZP-22234: Only show published users in multiplexer edit

### DIFF
--- a/kernel/classes/workflowtypes/event/ezmultiplexer/ezmultiplexertype.php
+++ b/kernel/classes/workflowtypes/event/ezmultiplexer/ezmultiplexertype.php
@@ -135,8 +135,15 @@ class eZMultiplexerType extends eZWorkflowEventType
 
             case 'usergroups':
             {
-                $groups = eZPersistentObject::fetchObjectList( eZContentObject::definition(), array( 'id', 'name' ),
-                                                                array( 'contentclass_id' => 3 ), null, null, false );
+                $groups = eZPersistentObject::fetchObjectList(
+                    eZContentObject::definition(),
+                    array( 'id', 'name' ),
+                    array( 'contentclass_id' => 3, 'status' => eZContentObject::STATUS_PUBLISHED ),
+                    null,
+                    null,
+                    false
+                );
+
                 foreach ( $groups as $key => $group )
                 {
                     $groups[$key]['Name'] = $group['name'];


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-22234
## Description

Unpublished user groups (in trash etc.) were present in the workflow multiplexer edit page.
`'status' => eZContentObject::STATUS_PUBLISHED )` has been added to filter the fetch
## Test

Manual tests
