### PR TITLE
Store objects modified in relation_list

### DIFF
--- a/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
+++ b/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
@@ -42,7 +42,7 @@ class eZObjectRelationListType extends eZDataType
     function validateObjectAttributeHTTPInput( $http, $base, $contentObjectAttribute )
     {
         $postVariableName = $base . "_data_object_relation_list_" . $contentObjectAttribute->attribute( "id" );
-        if ( $http->hasPostVariable( $postVariableName ) && !( $contentObjectAttribute->validateIsRequired() && $http->postVariable( $postVariableName ) == array( "no_relation" ) ) )
+        if ( !$contentObjectAttribute->validateIsRequired() && ( !$http->hasPostVariable( $postVariableName ) || $http->postVariable( $postVariableName ) == array( "no_relation" )) )
         {
             return eZInputValidator::STATE_ACCEPTED;
         }


### PR DESCRIPTION
Objects modified or created in relation_list are not stored with correct values.
When POST variable _data_object_relation_list_ exist and has relations, the method validateObjectAttributeHTTPInput have to continue to create temp content ( POST values )
