### PR TITLE
EZP-22398 : purge imagealias cache does not remove the aliases in xml attribute data_text

### DIFF
--- a/kernel/classes/datatypes/ezimage/ezimagealiashandler.php
+++ b/kernel/classes/datatypes/ezimage/ezimagealiashandler.php
@@ -703,8 +703,12 @@ class eZImageAliasHandler
         }
 
         $doc = $this->ContentObjectAttributeData['DataTypeCustom']['dom_tree'];
-        foreach ( $doc->getElementsByTagName( 'alias' ) as $aliasNode )
+        $aliasNodes = $doc->getElementsByTagName( 'alias' );
+        // looping downward avoids the re-calculation of the range of valid child
+        // indices from 0 to length - 1 through each loop
+        for ( $index = $aliasNodes->length - 1; $index >= 0; $index-- )
         {
+            $aliasNode = $aliasNodes->item( $index );
             $aliasNode->parentNode->removeChild( $aliasNode );
         }
         $this->ContentObjectAttributeData['DataTypeCustom']['dom_tree'] = $doc;


### PR DESCRIPTION
You can't remove DOMNodes from a DOMNodeList as you're iterating over
them in a foreach loop
Though, making a queue of items to remove seems to work

Link: https://jira.ez.no/browse/EZP-22398
