### PR TITLE
EZP-22399 : When calling the method eZContentObject::relatedObjectCount with the IgnoreVisibility parameter, the count is not correct

### DIFF
--- a/kernel/classes/ezcontentobject.php
+++ b/kernel/classes/ezcontentobject.php
@@ -3528,7 +3528,11 @@ class eZContentObject extends eZPersistentObject
         {
             if ( isset( $params['IgnoreVisibility'] ) )
             {
-                $showInvisibleNodesCond = self::createFilterByVisibilitySQLString( $params['IgnoreVisibility'], 'inner_object' );
+                $showInvisibleNodesCond = self::createFilterByVisibilitySQLString(
+                    $params['IgnoreVisibility'],
+                    // inner_object represents the source of relation while outer_object represents the target
+                    $reverseRelatedObjects ? 'inner_object' : 'outer_object'
+                );
             }
         }
 


### PR DESCRIPTION
Since inner_objet represents the source while outer_objet represents the target of the relationship, in the case of direct relationship, we want to check the visibility of the target, but not of the source !
On the other side, in the case of reverse relationships, outer_object and inner_object both represent the source object of the SQL query, and they could be interchanged on the condition $showInvisibleNodesCond without changing the result. (the SQL query is not symmetric).

Link: https://jira.ez.no/browse/EZP-22399
