### PR TITLE
EZP-22221: Modified alt. pagelayout to use ezjscore

### DIFF
--- a/design/standard/templates/fullscreen_pagelayout.tpl
+++ b/design/standard/templates/fullscreen_pagelayout.tpl
@@ -4,15 +4,14 @@
 <html lang="{$site.http_equiv.Content-language|wash}">
 
 <head>
-{section name=JavaScript loop=ezini( 'JavaScriptSettings', 'JavaScriptList', 'design.ini' ) }
-    <script type="text/javascript" src={concat( 'javascript/',$:item )|ezdesign}></script>
-{/section}
-    <link rel="stylesheet" type="text/css" href={"stylesheets/core.css"|ezdesign} />
-<style type="text/css">
-{section var=css_file loop=ezini( 'StylesheetSettings', 'CSSFileList', 'design.ini' )}
-    @import url({concat( 'stylesheets/',$css_file )|ezdesign});
-{/section}
-</style>
+{ezcss_load( array(
+    'core.css',
+    ezini( 'StylesheetSettings', 'CSSFileList', 'design.ini' )
+) )}
+
+{ezscript_load( array(
+    ezini( 'JavaScriptSettings', 'JavaScriptList', 'design.ini' )
+) )}
 
 {include uri="design:page_head.tpl"}
 

--- a/design/standard/templates/pagelayout.tpl
+++ b/design/standard/templates/pagelayout.tpl
@@ -4,23 +4,18 @@
 <html lang="{$site.http_equiv.Content-language|wash}">
 
 <head>
-{section name=JavaScript loop=ezini( 'JavaScriptSettings', 'JavaScriptList', 'design.ini' ) }
-<script type="text/javascript" src={concat( 'javascript/',$:item )|ezdesign}></script>
-{/section}
-{section name=JavaScript loop=ezini( 'JavaScriptSettings', 'FrontendJavaScriptList', 'design.ini' ) }
-<script type="text/javascript" src={concat( 'javascript/',$:item )|ezdesign}></script>
-{/section}
 
-    <link rel="stylesheet" type="text/css" href={"stylesheets/core.css"|ezdesign} />
-    <link rel="stylesheet" type="text/css" href={"stylesheets/debug.css"|ezdesign} />
-<style type="text/css">
-{section var=css_file loop=ezini( 'StylesheetSettings', 'CSSFileList', 'design.ini' )}
-    @import url({concat( 'stylesheets/',$css_file )|ezdesign});
-{/section}
-{section var=css_file loop=ezini( 'StylesheetSettings', 'FrontendCSSFileList', 'design.ini' )}
-    @import url({concat( 'stylesheets/',$css_file )|ezdesign});
-{/section}
-</style>
+{ezcss_load( array(
+    'core.css',
+    'debug.css',
+    ezini( 'StylesheetSettings', 'CSSFileList', 'design.ini' ),
+    ezini( 'StylesheetSettings', 'FrontendCSSFileList', 'design.ini' )
+) )}
+
+{ezscript_load( array(
+    ezini( 'JavaScriptSettings', 'JavaScriptList', 'design.ini' ),
+    ezini( 'JavaScriptSettings', 'FrontendJavaScriptList', 'design.ini' )
+) )}
 
 {include uri="design:page_head.tpl"}
 

--- a/design/standard/templates/popup_pagelayout.tpl
+++ b/design/standard/templates/popup_pagelayout.tpl
@@ -4,7 +4,8 @@
 <html lang="{$site.http_equiv.Content-language|wash}">
 
 <head>
-    <link rel="stylesheet" type="text/css" href={"stylesheets/core.css"|ezdesign} />
+
+{ezcss_load( array( 'core.css' ) )}
 
 {include uri="design:page_head.tpl"}
 

--- a/design/standard/templates/print_pagelayout.tpl
+++ b/design/standard/templates/print_pagelayout.tpl
@@ -4,16 +4,16 @@
 <html lang="{$site.http_equiv.Content-language|wash}">
 
 <head>
-{section name=JavaScript loop=ezini( 'JavaScriptSettings', 'JavaScriptList', 'design.ini' ) }
-    <script type="text/javascript" src={concat( 'javascript/',$:item )|ezdesign}></script>
-{/section}
-    <link rel="stylesheet" type="text/css" href={"stylesheets/core.css"|ezdesign} />
 
-<style type="text/css">
-{section var=css_file loop=ezini( 'StylesheetSettings', 'CSSFileList', 'design.ini' )}
-    @import url({concat( 'stylesheets/',$css_file )|ezdesign});
-{/section}
-</style>
+{ezcss_load( array(
+    'core.css',
+    ezini( 'StylesheetSettings', 'CSSFileList', 'design.ini' )
+) )}
+
+{ezscript_load( array(
+    ezini( 'JavaScriptSettings', 'JavaScriptList', 'design.ini' )
+) )}
+
 {include uri="design:page_head.tpl" enable_print=false()}
 </head>
 


### PR DESCRIPTION
http://jira.ez.no/browse/EZP-22221.

Changes all `pagelayout.tpl` files from the standard design to use ezjscore instead of the old, native way of loading assets.

Tested with ezstarrating on default webin content.
