### PR TITLE
Fix EZP-22372: Workflow cannot be edited if you remove a user and/or a group

### DIFF
--- a/kernel/classes/workflowtypes/event/ezapprove/ezapprovetype.php
+++ b/kernel/classes/workflowtypes/event/ezapprove/ezapprovetype.php
@@ -378,6 +378,14 @@ class eZApproveType extends eZWorkflowEventType
         return $returnState;
     }
 
+    /**
+     * @param eZHTTPTool $http
+     * @param $base
+     * @param eZWorkflowEvent $workflowEvent
+     * @param $validation
+     *
+     * @return bool|int
+     */
     function validateHTTPInput( $http, $base, $workflowEvent, &$validation )
     {
         $returnState = eZInputValidator::STATE_ACCEPTED;
@@ -385,6 +393,15 @@ class eZApproveType extends eZWorkflowEventType
 
         if ( !$http->hasSessionVariable( 'BrowseParameters' ) )
         {
+            // No validation when deleting to avoid blocking deletion of invalid items
+            if (
+                $http->hasPostVariable( 'DeleteApproveUserIDArray_' . $workflowEvent->attribute( 'id' ) ) ||
+                $http->hasPostVariable( 'DeleteApproveGroupIDArray_' . $workflowEvent->attribute( 'id' ) )
+            )
+            {
+                return eZInputValidator::STATE_ACCEPTED;
+            }
+
             // check approve-users
             $approversIDs = array_unique( $this->attributeDecoder( $workflowEvent, 'approve_users' ) );
             if ( is_array( $approversIDs ) and


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-22372
## Description

If a user or a group is deleted, when you edit a event/approve workflow, error messages are blocking edition (which is ok). But it also blocks the removal of the deleted user/group blocking the whole edition. This patch allows to delete those removed user/groups.
## Test

Manual tests
