### PR TITLE
EZP-22321: Fix ezjscore cache not cleared on DFS

### DIFF
--- a/extension/ezjscore/classes/ezjsccachemanager.php
+++ b/extension/ezjscore/classes/ezjsccachemanager.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * File containing the ezjscCacheManager class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+class ezjscCacheManager
+{
+    /**
+     * Recursively expires the ezjscore public cache folder
+     * @param array $cacheItem
+     */
+    public static function clearCache( array $cacheItem )
+    {
+        eZClusterFileHandler::instance()->fileDeleteByDirList( array( $cacheItem['path'] ), eZSys::cacheDirectory(), '' );
+    }
+}

--- a/extension/ezjscore/settings/site.ini.append.php
+++ b/extension/ezjscore/settings/site.ini.append.php
@@ -30,6 +30,7 @@ tags[]=content
 tags[]=template
 path=public
 isClustered=true
+class=ezjscCacheManager
 
 
 


### PR DESCRIPTION
> **JIRA issue:** http://jira.ez.no/browse/EZP-22321
> **Alternative to** #893 

ezjscore cache with DFS isn't cleared correctly when cleared by id (ezjscore-packer). This is because the DFS implementation of `delete()` has never been recursive.

This fix adds a clear function (`ezjscCacheManager`) is added to the ezjscore cache item. It uses `deleteByDirList()` instead of `delete()` in order to recursively delete.
