### PR TITLE
Fix EZP-21124: Checkbox custom attributes on custom tags are not stored

### DIFF
--- a/extension/ezoe/design/standard/javascript/ezoe/popup_utils.js
+++ b/extension/ezoe/design/standard/javascript/ezoe/popup_utils.js
@@ -451,7 +451,7 @@ var eZOEPopupUtils = {
         {
             var o = jQuery( el ), name = o.attr("name"), value, style;
             if ( o.hasClass('mceItemSkip') || !name ) return;
-            if ( o.attr("type") === 'checkbox' && !o.attr("checked") ) return;
+            if ( o.attr("type") === 'checkbox' && !o.prop("checked") ) return;
 
             // see if there is a save hander that needs to do some work on the value
             if ( handler[el.id] !== undefined && handler[el.id].call !== undefined )
@@ -486,7 +486,7 @@ var eZOEPopupUtils = {
         {
             var o = jQuery( el ), name = o.attr("name");
             if ( o.hasClass('mceItemSkip') || !name ) return;
-            if ( o.attr("type") === 'checkbox' && !o.attr("checked") ) return;
+            if ( o.attr("type") === 'checkbox' && !o.prop("checked") ) return;
             // see if there is a save hander that needs to do some work on the value
             if ( handler[el.id] !== undefined && handler[el.id].call !== undefined )
                 args[name] = handler[el.id].call( o, el, o.val() );


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-21124
# Description

The checkbox attributes of the custom tags are not stored in the ezxml, as a result, the UI in Online Editor does not take a previous user input into account.

This is fixed by using the correct jQuery method to retrieve the state of the checkbox (needed because of some BC breaks in jQuery...)
# Tests

manual test
