### PR TITLE
Fix for EZP-22435: Set a default checkbox value so it is saved

### DIFF
--- a/extension/ezoe/design/standard/templates/ezoe/customattributes/checkbox.tpl
+++ b/extension/ezoe/design/standard/templates/ezoe/customattributes/checkbox.tpl
@@ -1,2 +1,2 @@
 {set $custom_attribute_classes = $custom_attribute_classes|append( 'input_noborder' )}
-<input type="checkbox" class="{$custom_attribute_classes|implode(' ')}" name="{$custom_attribute}" id="{$custom_attribute_id}_source" value="{$custom_attribute_default|wash}"{if $custom_attribute_disabled} disabled="disabled"{/if} title="{$custom_attribute_title|wash}" />
+<input type="checkbox" class="{$custom_attribute_classes|implode(' ')}" name="{$custom_attribute}" id="{$custom_attribute_id}_source" value="{cond( ne( $custom_attribute_default|trim(), '' ), $custom_attribute_default|wash(), 1 )}"{if $custom_attribute_disabled} disabled="disabled"{/if} title="{$custom_attribute_title|wash}" />


### PR DESCRIPTION
JIRA issue: https://jira.ez.no/browse/EZP-22435

If a checkbox has no default value, then the custom tag is saved with an empty value.  Disabling and re-enabling the editor with a checked custom tag checkbox but with an empty value loses the "checked" property.

This fix just ensures that the value of the checkbox falls back to "1" instead of empty so that its "checked" property is preserved.
