### PR TITLE
Fix EZP-22446: redirect fails due to port eZSys::hostname()

### DIFF
--- a/kernel/private/classes/ezpkernelweb.php
+++ b/kernel/private/classes/ezpkernelweb.php
@@ -270,7 +270,7 @@ class ezpKernelWeb implements ezpWebBasedKernelHandler
             $this->settings['siteaccess'] :
             eZSiteAccess::match(
                 eZURI::instance( eZSys::requestURI() ),
-                eZSys::hostname(),
+                eZSys::hostname( false ),
                 eZSys::serverPort(),
                 eZSys::indexFile()
             )

--- a/lib/ezutils/classes/ezhttptool.php
+++ b/lib/ezutils/classes/ezhttptool.php
@@ -540,7 +540,10 @@ class eZHTTPTool
         if ( $parameters['override_port'] )
             $port = $parameters['override_port'];
         if ( !is_string( $host ) )
-            $host = eZSys::hostname();
+        {
+            $hasPort = is_string( $port );
+            $host = eZSys::hostname( !$hasPort );
+        }
         if ( !is_string( $protocol ) )
         {
             $protocol = eZSys::serverProtocol();

--- a/lib/ezutils/classes/ezmodule.php
+++ b/lib/ezutils/classes/ezmodule.php
@@ -954,7 +954,7 @@ class eZModule
             $uri = '/';
 
         $urlComponents = parse_url( $uri );
-        if ( isset( $urlComponents['host'] ) && $urlComponents['host'] !== eZSys::hostname() )
+        if ( isset( $urlComponents['host'] ) && $urlComponents['host'] !== eZSys::hostname( false ) )
         {
             $allowedHosts = $this->getAllowedRedirectHosts();
             if ( !isset( $allowedHosts[$urlComponents['host']] ) )


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-22446

When using port in url, the host check by AllowedRedirectHosts will fail as the port is included in eZSys::hostname()

The fix makes it possible to return only the actual hostname in eZSys with a new optional parameter `$withPort`.
`eZModule::redirectTo()` uses this new parameter to make a strict host name comparison.
