### PR TITLE
EZP-22455: Do not cache ezscript_load and ezcss_load call

### DIFF
--- a/design/admin/templates/pagelayout.tpl
+++ b/design/admin/templates/pagelayout.tpl
@@ -42,14 +42,14 @@ div#maincolumn {ldelim} padding-right: 20px; padding-left: 50px; {rdelim}
 </style>
 {/if}
 
+{include uri='design:page_head_style.tpl'}
+{include uri='design:page_head_script.tpl'}
+
 {* Pr uri header cache
  Need navigation part for cases like content/browse where node id is taken from caller params *}
 {cache-block keys=array( $module_result.uri, $user_hash, $admin_theme, $access_type, first_set( $module_result.navigation_part, $navigation_part.identifier ), $search_hash ) ignore_content_expiry}
 
 {include uri='design:page_head.tpl'}
-
-{include uri='design:page_head_style.tpl'}
-{include uri='design:page_head_script.tpl'}
 
 </head>
 <body>


### PR DESCRIPTION
Caching ezscript_load and ezcss_load in pagelayout will cause problems in modules that uses ezscript_require and ezcss_require. I have tested a case where we were using ezscript_require in the left menu. The first we load the page the tag is generated at the correct place, but after some cache files expires and we call again ezscript_require it won't generate the tag because it will pass the files to be generated in the ezscript_load call.

Please check the ezscript_load definition:

Works like ezscript(), except that the optional $script parameter is prepended to the list of script files already saved with ezscript_require() before they are packed and the script tag is generated.

Now the ezscript_require definition:

Like ezscript(), but stores script files to be loaded using the persistent_variable.js_files template variable\* instead of generating the script tag unless ezscript_load() is already called.

So, when developing ez publish admin interface extension we can't use ezscript_require because it will fail later because ez publish will cache the ezscript_load call, making ezscript_require think ezpublish_load hasn't been called.

Also it isn't necessary to cache page_head_style.tpl page_head_script.tpl because it doesn't contain any code that should be cache anyways. I do understand caching page_header because sometimes it will call tons of mysql queries, but that isn't the case for page_head_style.tpl and page_head_script.tpl.
