### PR TITLE
FIX EZP-22472: Incorrect handling of dfs cache error

### DIFF
--- a/kernel/content/view.php
+++ b/kernel/content/view.php
@@ -188,7 +188,8 @@ else
                 $args
             );
 
-        if ( isset( $result['responseHeaders'] ) )
+        // check if $result is an array (could also be eZClusterFileFailure) and contains responseHeaders
+        if ( is_array( $result ) && !empty( $result['responseHeaders'] ) )
         {
             foreach ( $result['responseHeaders'] as $header )
             {


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-22472

After the fix for https://jira.ez.no/browse/EZP-21547 (see https://github.com/ezsystems/ezpublish-legacy/commit/57171cd9), there is the possibility that `eZClusterFileHandler::processCache()` will result in a `eZClusterFileFailure` instance.

The next lines are using the result as an array, which (in case of error) will not be valid PHP.
This fix simply adds a check before using `$result` as an `array`.
