### PR TITLE
Fix EZP-22313: HTML pasted into literal ends up outside literal tag

### DIFF
--- a/extension/ezoe/design/standard/javascript/ezoe/popup_utils.js
+++ b/extension/ezoe/design/standard/javascript/ezoe/popup_utils.js
@@ -230,7 +230,7 @@ var eZOEPopupUtils = {
             }
             else if ( eZOEPopupUtils.xmlToXhtmlHash[s.tagName] )
             {
-                s.editorElement = eZOEPopupUtils.insertTagCleanly( ed, eZOEPopupUtils.xmlToXhtmlHash[s.tagName], '&nbsp;' );
+                s.editorElement = eZOEPopupUtils.insertTagCleanly( ed, eZOEPopupUtils.xmlToXhtmlHash[s.tagName], tinymce.isIE ? '&nbsp;' : '<br data-mce-bogus="1" />' );
             }
             if ( s.onTagGenerated )
             {

--- a/extension/ezoe/design/standard/javascript/themes/ez/editor_template.js
+++ b/extension/ezoe/design/standard/javascript/themes/ez/editor_template.js
@@ -378,6 +378,15 @@
                 });
             });
 
+            // eZ: make sure we are pasting as plain text inside literal tag
+            ed.onNodeChange.add(function (ed, cm, e) {
+                if ( e.tagName.toLowerCase() === 'pre' || e.parentNode.tagName.toLowerCase() === 'pre' ) {
+                    ed.pasteAsPlainText = true;
+                } else {
+                    ed.pasteAsPlainText = false;
+                }
+            });
+
             // eZ: regularly update the textarea
             ed.onChange.add(function(ed) {
                 tinymce.triggerSave();


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-22313
# Description

With Chrome, when trying to paste some code inside a literal, the code is pasted outside of the literal area. This happens because the paste mode is not set to _plain text_, so the serializer creates some paragraphs and tries to fix the code.

The patch makes sure that the paste mode is set to _plain text_ when the caret is inside a literal tag. The fix in popup_utils.js is also needed, without it, if the user does not remove the generated non breaking space, the literal area is split in several areas.
# Tests

manual tests in IE9, IE10, Firefox and Chrome
