### PR TITLE
Fixed EZP-21959: Security: Siteaccess matching is loose, in legacy stack

### DIFF
--- a/kernel/classes/ezsiteaccess.php
+++ b/kernel/classes/ezsiteaccess.php
@@ -375,9 +375,7 @@ class eZSiteAccess
 
             if ( isset( $name ) && $name != '' )
             {
-                $name = preg_replace( array( '/[^a-zA-Z0-9]+/', '/_+/', '/^_/', '/_$/' ),
-                                      array( '_', '_', '', '' ),
-                                      $name );
+                $name = self::washName( $name );
 
                 if ( in_array( $name, $siteAccessList ) )
                 {
@@ -524,6 +522,11 @@ class eZSiteAccess
                 else
                     $access['uri_part'] = array();
             }
+            else
+            {
+                $access['uri_part'] = self::washName( $access['uri_part'] );
+            }
+
             eZSys::setAccessPath( $access['uri_part'], $name );
 
             eZUpdateDebugSettings();
@@ -531,6 +534,27 @@ class eZSiteAccess
         }
 
         return $access;
+    }
+
+    /**
+     * Washes site access name
+     *
+     * Allowed characters are [a-z], [A-Z] and [0-9], and the "_" (underscore). The washing rules are:
+     * - Characters not in the previous list (alphanumerical and underscore) are replaced by an "_" (underscore);
+     * - Multiple consecutive "_" (underscores) are replaced by a single underscore;
+     * - Leading and trailing "_" are removed.
+     *
+     * @since 5.3
+     * @param string $name The site access name, as received from the browser
+     * @return string The washed name
+     */
+    private static function washName( $name )
+    {
+        return preg_replace(
+            array( '/[^a-zA-Z0-9]+/', '/_+/', '/^_/', '/_$/' ),
+            array( '_', '_', '', '' ),
+            $name
+        );
     }
 
     /**

--- a/tests/tests/kernel/classes/ezsiteaccessmatchhosturi_test.php
+++ b/tests/tests/kernel/classes/ezsiteaccessmatchhosturi_test.php
@@ -86,4 +86,38 @@ class eZSiteAccessMatchHostUriTest extends ezpTestCase
             array( "abcdefg/foo/abc", "abcdefg_foo", eZSiteAccess::TYPE_HTTP_HOST_URI, array( "abcdefg", "foo" ) ),
         );
     }
+
+    /**
+     * Test for eZSiteAccess::change(), washing non-latin1 chars from the site access.
+     * @dataProvider providerForTestChange
+     */
+    public function testChange( $name, $type, $dirtyUriPart, $washedUriPart )
+    {
+        $this->assertEquals(
+            array(
+                'name' => $name,
+                'type' => $type,
+                'uri_part' => array( $washedUriPart )
+            ),
+            eZSiteAccess::change(
+                array(
+                    'name' => $name,
+                    'type' => $type,
+                    'uri_part' => array( $dirtyUriPart )
+                )
+            )
+        );
+    }
+
+    public function providerForTestChange()
+    {
+        return array(
+            array( 'eng', eZSiteAccess::TYPE_HTTP_HOST_URI, 'eng', 'eng' ),
+            array( 'eng', eZSiteAccess::TYPE_HTTP_HOST_URI, 'engæ', 'eng' ),
+            array( 'eng', eZSiteAccess::TYPE_HTTP_HOST_URI, 'engæøå', 'eng' ),
+            array( 'eng', eZSiteAccess::TYPE_HTTP_HOST_URI, 'engæøåÆØÅ', 'eng' ),
+            array( 'eng', eZSiteAccess::TYPE_HTTP_HOST_URI, '€eng$', 'eng' ),
+            array( 'eng', eZSiteAccess::TYPE_HTTP_HOST_URI, '€åeng$ø', 'eng' ),
+        );
+    }
 }


### PR DESCRIPTION
Based on https://github.com/ezsystems/ezpublish-legacy/pull/907
Working on my fork since I don't have access on ezsystems.
Fixed CS nitpick: indentation.
