### PR TITLE
Fix EZP-22487: paragraph drops its class when alignment is applied in ezoe

### DIFF
--- a/extension/ezoe/design/standard/javascript/themes/ez/editor_template.js
+++ b/extension/ezoe/design/standard/javascript/themes/ez/editor_template.js
@@ -449,6 +449,14 @@
                         node.firstChild.replaceData( 0, 1, ' ' );
                 });
 
+                // replaces ezoeAlign* class so that the PHP parser does not ignore
+                // an other class see https://jira.ez.no/browse/EZP-22487
+                $f.find('.ezoeAligncenter, .ezoeAlignjustify, .ezoeAlignleft, .ezoeAlignright').each(function (i, node) {
+                    var $node = jQuery(node);
+
+                    $node.removeClass('ezoeAlign' + $node.attr('align'));
+                });
+
                 o.content = $f.html();
             });
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-22487
# Description

See this screencast: https://mugo.viewscreencasts.com/1b9932098b8c4b0fb5c7bf8cf77aa0a2 Basically, if an element has both a custom class and one of the `ezoeAlign*` class, the PHP parser will drop the complete class attribute. This patch makes sure the `ezoeAlign*` classes are removed before being handled server side.
# Tests

manual test
