### PR TITLE
Fix EZP-22414: Session is lost when redirecting from a legacy module

### DIFF
--- a/autoload/ezp_kernel.php
+++ b/autoload/ezp_kernel.php
@@ -599,6 +599,7 @@ return array(
       'ezpI18n'                                            => 'kernel/common/ezpi18n.php',
       'ezpKernel'                                          => 'kernel/private/classes/ezpkernel.php',
       'ezpKernelHandler'                                   => 'kernel/private/interfaces/ezpkernelhandler.php',
+      'ezpKernelRedirect'                                  => 'kernel/private/classes/ezpkernelredirect.php',
       'ezpKernelResult'                                    => 'kernel/private/classes/ezpkernelresult.php',
       'ezpKernelTreeMenu'                                  => 'kernel/private/classes/ezpkerneltreemenu.php',
       'ezpKernelWeb'                                       => 'kernel/private/classes/ezpkernelweb.php',

--- a/kernel/private/classes/ezpkernelredirect.php
+++ b/kernel/private/classes/ezpkernelredirect.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * File containing the ezpKernelRedirect class.
+ *
+ * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+/**
+ * Struct containing information on HTTP redirection.
+ */
+class ezpKernelRedirect extends ezpKernelResult
+{
+    /**
+     * Target URL to redirect to.
+     *
+     * @var string
+     */
+    private $targetUrl;
+
+    /**
+     * Redirection status code (e.g. 302).
+     *
+     * @var int
+     */
+    private $statusCode;
+
+    public function __construct( $url, $redirectStatus = null, $content = null )
+    {
+        $this->targetUrl = $url ?: '/';
+        $this->statusCode = $redirectStatus ? (int)substr( $redirectStatus, 0, 3 ) : 302;
+        parent::__construct( $content, array( 'status' => $redirectStatus ) );
+    }
+
+    /**
+     * @return int
+     */
+    public function getStatusCode()
+    {
+        return $this->statusCode;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTargetUrl()
+    {
+        return $this->targetUrl;
+    }
+}

--- a/kernel/private/classes/ezpkernelweb.php
+++ b/kernel/private/classes/ezpkernelweb.php
@@ -367,7 +367,8 @@ class ezpKernelWeb implements ezpWebBasedKernelHandler
 
         if ( $this->module->exitStatus() == eZModule::STATUS_REDIRECT )
         {
-            $this->redirect();
+            $this->shutdown();
+            return $this->redirect();
         }
 
         $uiContextName = $this->module->uiContextName();
@@ -966,11 +967,7 @@ class ezpKernelWeb implements ezpWebBasedKernelHandler
 
         eZDB::checkTransactionCounter();
 
-        if ( $automaticRedirect )
-        {
-            eZHTTPTool::redirect( $redirectURI, array(), $this->module->redirectStatus() );
-        }
-        else
+        if ( !$automaticRedirect )
         {
             // Make sure any errors or warnings are reported
             if ( $ini->variable( 'DebugSettings', 'DisplayDebugWarnings' ) === 'enabled' )
@@ -1014,10 +1011,12 @@ class ezpKernelWeb implements ezpWebBasedKernelHandler
 
             eZDebug::addTimingPoint( "Script end" );
 
+            ob_start();
             eZDisplayResult( $templateResult );
+            return new ezpKernelResult( ob_get_clean() );
         }
 
-        eZExecution::cleanExit();
+        return eZHTTPTool::redirect( $redirectURI, array(), $this->module->redirectStatus(), true, true );
     }
 
     /**

--- a/lib/ezsession/classes/ezpsessionhandlersymfony.php
+++ b/lib/ezsession/classes/ezpsessionhandlersymfony.php
@@ -18,7 +18,10 @@
  */
 class ezpSessionHandlerSymfony extends ezpSessionHandler
 {
-    protected $storage = null;
+    /**
+     * @var \Symfony\Component\HttpFoundation\Session\Storage\SessionStorageInterface
+     */
+    protected $storage;
 
     /**
      * reimp. Does not do anything to let Symfony manage the session handling
@@ -113,7 +116,7 @@ class ezpSessionHandlerSymfony extends ezpSessionHandler
     /**
      * Set the storage handler defined in Symfony.
      *
-     * @param Symfony\Component\HttpFoundation\Session\Storage\SessionStorageInterface $storage
+     * @param \Symfony\Component\HttpFoundation\Session\Storage\SessionStorageInterface $storage
      */
     public function setStorage( $storage )
     {
@@ -127,6 +130,11 @@ class ezpSessionHandlerSymfony extends ezpSessionHandler
      */
     public function sessionStart()
     {
+        if ( $this->storage && !$this->storage->isStarted() )
+        {
+            $this->storage->start();
+        }
+
         return true;
     }
 }

--- a/lib/ezutils/classes/ezhttptool.php
+++ b/lib/ezutils/classes/ezhttptool.php
@@ -574,17 +574,19 @@ class eZHTTPTool
     }
 
     /**
-     * \static
      * Performs an HTTP redirect.
      *
-     * \param  $path  The path to redirect
-     * \param  $parameters  \see createRedirectUrl()
-     * \param  $status  The HTTP status code as a string
-     * \param  $encodeURL  Encode the URL. This should normally be true, but
-     * may be set to false to avoid double encoding when redirect() is called
-     * twice.
+     * @param string $path The path to redirect to
+     * @param array $parameters See createRedirectUrl(). Defaults to empty array.
+     * @param bool $status The HTTP status code as a string (code + text, e.g. "302 Found"). Defaults to false.
+     * @param bool $encodeURL Encodes the URL.
+     *                        This should normally be true, but may be set to false to avoid double encoding when redirect() is called twice.
+     *                        Defaults to true
+     * @param bool $returnRedirectObject If true, will return an ezpKernelRedirect object.
+     *
+     * @return null|ezpKernelRedirect
      */
-    static function redirect( $path, $parameters = array(), $status = false, $encodeURL = true )
+    static function redirect( $path, $parameters = array(), $status = false, $encodeURL = true, $returnRedirectObject = false )
     {
         $url = eZHTTPTool::createRedirectUrl( $path, $parameters );
         if ( strlen( $status ) > 0 )
@@ -599,12 +601,21 @@ class eZHTTPTool
         }
 
         eZHTTPTool::headerVariable( 'Location', $url );
-
         /* Fix for redirecting using workflows and apache 2 */
-        echo '<HTML><HEAD>';
-        echo '<META HTTP-EQUIV="Refresh" Content="0;URL='. htmlspecialchars( $url ) .'">';
-        echo '<META HTTP-EQUIV="Location" Content="'. htmlspecialchars( $url ) .'">';
-        echo '</HEAD><BODY></BODY></HTML>';
+        $escapedUrl = htmlspecialchars( $url );
+        $content = <<<EOT
+<HTML><HEAD>
+<META HTTP-EQUIV="Refresh" Content="0;URL=$escapedUrl">
+<META HTTP-EQUIV="Location" Content="$escapedUrl">
+</HEAD><BODY></BODY></HTML>
+EOT;
+
+        if ( $returnRedirectObject )
+        {
+            return new ezpKernelRedirect( $url, $status ?: null, $content );
+        }
+
+        echo $content;
     }
 
     /*!


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-22414

**This only occurs when using Symfony stack, with legacy fallback**.
## Description

In a legacy module, when you set a session variable and then perform a redirection (e.g. using `$Module->redirectTo( '/' )`) to a page managed by Symfony stack, created session will be lost during the redirection process.

There were 2 issues:
- Redirection process was still _brutal_, with an `eZExecution::cleanExit()`, preventing Symfony to correctly handle the redirect response, with the appropriate `Set-Cookie` header.
- Since we got lazy sessions back, when the session needed to be started from legacy, it just didn't happen, and we lost the newly created session variable. 

> Note: It seems that `PreAuthenticatedToken` we used before merging full Symfony authentication has been fixed regarding systematic session start. Hence this patch would also help for 5.2 installation.
## Tests

Manual tests, both through Symfony stack and pure legacy stack
