### PR TITLE
Fix EZP-22426: DetectMobileDevice redirection fails for URI

### DIFF
--- a/kernel/private/classes/ezpmobiledevicedetect.php
+++ b/kernel/private/classes/ezpmobiledevicedetect.php
@@ -36,7 +36,24 @@ class ezpMobileDeviceDetect
      */
     public static function isEnabled()
     {
-        return ( eZINI::instance()->variable( 'SiteAccessSettings', 'DetectMobileDevice' ) === 'enabled' );
+        if ( eZINI::instance()->variable( 'SiteAccessSettings', 'DetectMobileDevice' ) === 'enabled' )
+        {
+            $mobileSaList = eZINI::instance()->variable( 'SiteAccessSettings', 'MobileSiteAccessList' );
+
+            if ( !empty( $mobileSaList ) )
+            {
+                return true;
+            }
+            else
+            {
+                eZDebug::writeError(
+                    "DetectMobileDevice is enabled and MobileSiteAccessList is empty, please check your site.ini configuration",
+                    __METHOD__
+                );
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/kernel/private/classes/ezpmobiledeviceregexpfilter.php
+++ b/kernel/private/classes/ezpmobiledeviceregexpfilter.php
@@ -118,7 +118,24 @@ class ezpMobileDeviceRegexpFilter implements ezpMobileDeviceDetectFilterInterfac
         if ( !isset( $_COOKIE['eZMobileDeviceDetect'] )
                 && !in_array( $currentSiteAccess['name'], eZINI::instance()->variable( 'SiteAccessSettings', 'MobileSiteAccessList'  ) ) )
         {
-            $http->redirect( eZINI::instance()->variable( 'SiteAccessSettings', 'MobileSiteAccessURL' ) . eZSys::serverVariable(  'REQUEST_URI' ) );
+            $currentUrl = eZSys::serverURL() . eZSys::requestURI();
+            $redirectUrl = eZINI::instance()->variable( 'SiteAccessSettings', 'MobileSiteAccessURL' );
+
+            // Do not redirect if already on the redirect url
+            if ( strpos( $currentUrl, $redirectUrl ) !== 0 )
+            {
+                // Default siteaccess name needs to be removed from the uri when redirecting
+                $uri = explode( '/', ltrim( eZSys::requestURI(), '/' ) );
+
+                if ( array_shift( $uri ) == $currentSiteAccess['name'] )
+                {
+                    $http->redirect( $redirectUrl . '/' . implode( '/', $uri ) );
+                }
+                else
+                {
+                    $http->redirect( $redirectUrl . eZSys::requestURI() );
+                }
+            }
 
             eZExecution::cleanExit();
         }

--- a/tests/tests/kernel/private/ezpmobiledevicedetect_test.php
+++ b/tests/tests/kernel/private/ezpmobiledevicedetect_test.php
@@ -21,6 +21,7 @@ class ezpMobileDeviceDetectTest extends ezpTestCase
 
         // Enable mobile device detection
         ezpINIHelper::setINISetting( 'site.ini', 'SiteAccessSettings', 'DetectMobileDevice', 'enabled' );
+        ezpINIHelper::setINISetting( 'site.ini', 'SiteAccessSettings', 'MobileSiteAccessList', array( 'eng' ) );
 
         $this->mobileDeviceDetect = $this->getMock( 'ezpMobileDeviceDetect', null, array( $this->getMock( 'ezpMobileDeviceRegexpFilter', null ) ) );
     }
@@ -41,6 +42,17 @@ class ezpMobileDeviceDetectTest extends ezpTestCase
     public function testIsEnabled()
     {
         $this->assertTrue( $this->mobileDeviceDetect->isEnabled() );
+    }
+
+    /**
+     * Tests if mobile device detection is enabled but MobileSiteAccessList is not provided
+     *
+     */
+    public function testIsEnabledBadSetting()
+    {
+        ezpINIHelper::setINISetting( 'site.ini', 'SiteAccessSettings', 'MobileSiteAccessList', '' );
+
+        $this->assertFalse( $this->mobileDeviceDetect->isEnabled() );
     }
 
     /**


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-22426
## Description

When using an URI in `MobileSiteAccessURL` the feature would not work as expected.

Examples of expected behaviors:

| URL entered | URL redirected |
| --- | --- |
| http://ez4.local | http://ez4.local/iphone |
| http://ez4.local/eng | http://ez4.local/iphone/ |
| http://ez4.local/blog | http://ez4.local/iphone/blog |
| http://ez4.local/eng/blog | http://ez4.local/iphone/blog |
## Test

Manual test using firefox user agent switcher
