### PR TITLE
Fix for EZP-22537: Community dashboard widget shows the wrong month

### DIFF
--- a/design/standard/templates/dashboard/community_activity.tpl
+++ b/design/standard/templates/dashboard/community_activity.tpl
@@ -41,7 +41,7 @@
                 //trace( $item.attr("link") );
                 html += '<li>' +
                         '<h5><a href ="' + $item.attr( "link" ) + '?utm_content=eZ+Publish+Community+Project+{/literal}{$versionString}{literal}&utm_source=eZ+Publish+Community+Project+Dashboard&utm_medium=eZ+Publish+Community+Project+Dashboard&utm_campaign=eZ+Publish+Community+Project+Dashboard' + '">' + $item.attr( "title" ) + '</a></h5> ' +
-                        '<p>' + $item.attr("author") + ' - <em>' + $date.getDate() + '/' + $date.getMonth() + '/' + $date.getFullYear() + ' ' + $date.getHours() + ':' + $date.getMinutes() + '</em></p>' +
+                        '<p>' + $item.attr("author") + ' - <em>' + $date.getDate() + '/' + ( $date.getMonth() + 1 ) + '/' + $date.getFullYear() + ' ' + $date.getHours() + ':' + $date.getMinutes() + '</em></p>' +
                     // '<p>' + $item.attr("c:date") + '</p>' +
                         '</li>';
             });


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-22537

On the dashboard, the "What's happening in the eZ Community" widget shows the wrong month for posts. This is because it uses JavaScript's date function getMonth, which is 0-indexed.
