### PR TITLE
Fix EZP-22519: Duplicating a content version results in an empty draft i...

### DIFF
--- a/kernel/classes/ezcontentobject.php
+++ b/kernel/classes/ezcontentobject.php
@@ -1330,33 +1330,6 @@ class eZContentObject extends eZPersistentObject
     {
         $db = eZDB::instance();
         $db->begin();
-        // Check if we have enough space in version list
-        if ( $versionCheck )
-        {
-            $versionlimit = eZContentClass::versionHistoryLimit( $this->attribute( 'contentclass_id' ) );
-            $versionCount = $this->getVersionCount();
-            if ( $versionCount >= $versionlimit )
-            {
-                // Remove oldest archived version
-                $params = array( 'conditions'=> array( 'status' => eZContentObjectVersion::STATUS_ARCHIVED ) );
-                $versions = $this->versions( true, $params );
-                if ( count( $versions ) > 0 )
-                {
-                    $modified = $versions[0]->attribute( 'modified' );
-                    $removeVersion = $versions[0];
-                    foreach ( $versions as $version )
-                    {
-                        $currentModified = $version->attribute( 'modified' );
-                        if ( $currentModified < $modified )
-                        {
-                            $modified = $currentModified;
-                            $removeVersion = $version;
-                        }
-                    }
-                    $removeVersion->removeThis();
-                }
-            }
-        }
 
         // get the next available version number
         $nextVersionNumber = $this->nextVersion();
@@ -1412,6 +1385,34 @@ class eZContentObject extends eZPersistentObject
             // Reset execution bit
             $newNodeAssignment->setAttribute( 'op_code', $newNodeAssignment->attribute( 'op_code' ) & ~1 );
             $newNodeAssignment->store();
+        }
+
+        // Removing last item if we don't have enough space in version list
+        if ( $versionCheck )
+        {
+            $versionlimit = eZContentClass::versionHistoryLimit( $this->attribute( 'contentclass_id' ) );
+            $versionCount = $this->getVersionCount();
+            if ( $versionCount >= $versionlimit )
+            {
+                // Remove oldest archived version
+                $params = array( 'conditions'=> array( 'status' => eZContentObjectVersion::STATUS_ARCHIVED ) );
+                $versions = $this->versions( true, $params );
+                if ( count( $versions ) > 0 )
+                {
+                    $modified = $versions[0]->attribute( 'modified' );
+                    $removeVersion = $versions[0];
+                    foreach ( $versions as $version )
+                    {
+                        $currentModified = $version->attribute( 'modified' );
+                        if ( $currentModified < $modified )
+                        {
+                            $modified = $currentModified;
+                            $removeVersion = $version;
+                        }
+                    }
+                    $removeVersion->removeThis();
+                }
+            }
         }
 
         $db->commit();


### PR DESCRIPTION
...f maximum versions is reached

Link: https://jira.ez.no/browse/EZP-22519
## Description

When copying  the oldest version of a content, if the maximum number of items was reached it would create an empty draft.
It was happening because the code would first erase the first version, then try to copy it. This patch makes the copy first and then erases the last verion.

The second problem is that this operation was done twice in the code. The first time in the history module and then in `eZContentObject createNewVersion()`. I removed it from the history module.
## Tests

Manuel tests
