### PR TITLE
Fixed EZP-22466 advanced object relation list editing

### DIFF
--- a/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
+++ b/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
@@ -281,39 +281,19 @@ class eZObjectRelationListType extends eZDataType
             {
                 $subObjectID = $relationItem['contentobject_id'];
                 $attributeBase = $base . '_ezorl_edit_object_' . $subObjectID;
-
-                if ( !isset( $content['temp'][$subObjectID] ) )
-                {
-                    if ( !$object = eZContentObject::fetch( $subObjectID ) )
-                    {
-                        continue;
-                    }
-                    $attributes = $object->contentObjectAttributes(
-                        true,
-                        $relationItem['contentobject_version'],
-                        $contentObjectAttribute->attribute( 'language_code' )
-                    );
-                    $content['temp'][$subObjectID] = array(
-                        'require-fixup' => false,
-                        'attributes' => $attributes,
-                        'object' => $object,
-                    );
-                }
-
                 $object = $content['temp'][$subObjectID]['object'];
-                if ( !$object )
+                if ( $object )
                 {
-                    continue;
-                }
-                $attributes = $content['temp'][$subObjectID]['attributes'];
+                    $attributes = $content['temp'][$subObjectID]['attributes'];
 
-                $customActionAttributeArray = array();
-                $fetchResult = $object->fetchInput( $attributes, $attributeBase,
-                                                    $customActionAttributeArray,
-                                                    $contentObjectAttribute->inputParameters() );
-                $content['temp'][$subObjectID]['attribute-input-map'] = $fetchResult['attribute-input-map'];
-                $content['temp'][$subObjectID]['attributes'] = $attributes;
-                $content['temp'][$subObjectID]['object'] = $object;
+                    $customActionAttributeArray = array();
+                    $fetchResult = $object->fetchInput( $attributes, $attributeBase,
+                                                        $customActionAttributeArray,
+                                                        $contentObjectAttribute->inputParameters() );
+                    $content['temp'][$subObjectID]['attribute-input-map'] = $fetchResult['attribute-input-map'];
+                    $content['temp'][$subObjectID]['attributes'] = $attributes;
+                    $content['temp'][$subObjectID]['object'] = $object;
+                }
             }
             $relationItem['priority'] = $prioritiesByContentObjectId[$relationItem['contentobject_id']];
         }


### PR DESCRIPTION
> Replaces #913 
> Fixes http://jira.ez.no/browse/EZP-22466

Fixes the condition at the top of `eZObjectRelationList::validateObjetAttributeHTTPInput()`.
It should now only skip validation if the attribute isn't required AND doesn't contain any relation.

The issue was a regression from https://jira.ez.no/browse/EZP-18790. The bug fixed in this issue
was tested, and no regression was found.
