### PR TITLE
Fix EZP-22519: Number of history items regression

### DIFF
--- a/kernel/classes/ezcontentobject.php
+++ b/kernel/classes/ezcontentobject.php
@@ -1392,7 +1392,7 @@ class eZContentObject extends eZPersistentObject
         {
             $versionlimit = eZContentClass::versionHistoryLimit( $this->attribute( 'contentclass_id' ) );
             $versionCount = $this->getVersionCount();
-            if ( $versionCount >= $versionlimit )
+            if ( $versionCount > $versionlimit )
             {
                 // Remove oldest archived version
                 $params = array( 'conditions'=> array( 'status' => eZContentObjectVersion::STATUS_ARCHIVED ) );


### PR DESCRIPTION
Link : https://jira.ez.no/browse/EZP-22519

This PR fixes a small regression introduced in #922 and as you can see in comments, @andrerom was right to be worried :)
## Description

After fixing EZP-22519 the number of maximum items was not respected. It was missing one item because we are doing the check after the creation instead of before.
## Tests

Manual tests
