### PR TITLE
Fix EZP-16947: attribute_view_gui view=myview does not work when TemplateCompile is enabled

### DIFF
--- a/kernel/common/ezobjectforwarder.php
+++ b/kernel/common/ezobjectforwarder.php
@@ -418,7 +418,7 @@ class eZObjectForwarder
                     $newNodes = array_merge( $newNodes, $accessNodes );
                     $accessNodes = array();
                     // If $matchFile is an array we cannot create a transformation for this entry
-                    if ( is_array( $matchLookupArray ) )
+                    if ( is_array( $matchFile ) )
                         return false;
                     $newNodes[] = eZTemplateNodeTool::createResourceAcquisitionNode( '',
                                                                                      $matchLookupArray, false,


### PR DESCRIPTION
**RFC**
Now it works, but this change wasn't thoroughly tested. I need your comments, maybe you remember some parts of this code, because this is :rocket: rocket science for me.

I simply checked result on the screen and made diff between compiled templates (the old and new one).
One of the observed differences in the compiled files is they no longer contain `$tpl->processFunction( 'attribute_view_gui'` in both cases (`attribute_view_gui view=myview` and `attribute_view_gui`), and have more plain data.
