### PR TITLE
Fix EZP-22569: Removed Location still shows on frontend until http cache expires

### DIFF
--- a/kernel/content/ezcontentoperationcollection.php
+++ b/kernel/content/ezcontentoperationcollection.php
@@ -899,6 +899,8 @@ class eZContentOperationCollection
             }
         }
 
+        // Triggering content/cache filter for Http cache purge
+        ezpEvent::getInstance()->filter( 'content/cache', $removeNodeIdList );
         // we don't clear template block cache here since it's cleared in eZContentObjectTreeNode::removeNode()
 
         return array( 'status' => true );


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-22569

`eZContentCacheManager` was called to delete view cache (and then trigger Http cache purge), but after the locations have been removed, hence with no effect.
This patch adds `content/cache` filter in `eZContentOperationCollection::removeNodes()`.

Open question: Should the filter occur in `eZContentOperationCollection` or in `eZContentObjectTreeNode::removeThis()` ? In term of responsibility, I'd bet for current implementation :octocat: 
