### PR TITLE
Enabled asynchronous publishing from preview

### DIFF
--- a/kernel/content/versionviewframe.php
+++ b/kernel/content/versionviewframe.php
@@ -94,6 +94,11 @@ if ( $Module->isCurrentAction( 'Publish' ) and
         return $Result;
     }
 
+    $behaviour = new ezpContentPublishingBehaviour();
+    $behaviour->isTemporary = true;
+    $behaviour->disableAsynchronousPublishing = false;
+    ezpContentPublishingBehaviour::setBehaviour( $behaviour );
+
     $operationResult = eZOperationHandler::execute( 'content', 'publish', array( 'object_id' => $ObjectID,
                                                                                  'version' => $EditVersion ) );
     $object = eZContentObject::fetch( $ObjectID );


### PR DESCRIPTION
> Fixes http://jira.ez.no/browse/EZP-22640

If the feature is enabled in content.ini, Publish from the versionview page will go through async publishing as well.
There is a minor feature loss though: without async publishing, versionview redirects to the published node ID. Since the object is  published asynchronously, the redirection will be made to the published object's parent location.

Should this indeed be done by default ? Does anyone see a need for an option there ?
