### PR TITLE
Fix EZP-22656 - PHP Notice: Undefined property: eZSOAPClient::$TimeOut i...n /var/www/html/ezpublish5/ezpublish_legacy/lib/ezsoap/classes/ezsoapclient.php on line 167

### DIFF
--- a/lib/ezsoap/classes/ezsoapclient.php
+++ b/lib/ezsoap/classes/ezsoapclient.php
@@ -164,7 +164,7 @@ class eZSOAPClient
                 $ch = curl_init ( $URL );
                 if ( $this->Timeout != 0 )
                 {
-                    curl_setopt( $ch, CURLOPT_TIMEOUT, $this->TimeOut );
+                    curl_setopt( $ch, CURLOPT_TIMEOUT, $this->Timeout );
                 }
                 $payload = $request->payload();
 


### PR DESCRIPTION
Apparently there is a typoo in the variable
