### PR TITLE
Fix EZP-22628: Children containing ezuser can not be trashed

### DIFF
--- a/design/admin/templates/node/removeobject.tpl
+++ b/design/admin/templates/node/removeobject.tpl
@@ -107,10 +107,23 @@
 
 <div class="block">
 {if and( $remove_info.can_remove_all, eq( $delete_items_exist,true() ), not( $remove_info.has_pending_object ) )}
+
     {if $move_to_trash_allowed}
-    <input type="hidden" name="SupportsMoveToTrash" value="1" />
-    <p><input type="checkbox" name="MoveToTrash" value="1" {if $move_to_trash}checked="checked" {/if}title="{'If "Move to trash" is checked, the items will be moved to the trash instead of being permanently deleted.'|i18n( 'design/admin/node/removeobject' )|wash}" />{'Move to trash'|i18n('design/admin/node/removeobject')}</p>
+        <input type="hidden" name="SupportsMoveToTrash" value="1" />
     {/if}
+
+    <p>
+        <input type="checkbox" name="MoveToTrash" value="1"
+               {if and($move_to_trash, $move_to_trash_allowed) }checked="checked" {/if}
+               {if not($move_to_trash_allowed)}disabled="disabled" {/if}
+               title="{'If "Move to trash" is checked, the items will be moved to the trash instead of being permanently deleted.'|i18n( 'design/admin/node/removeobject' )|wash}"
+        />
+        {'Move to trash'|i18n('design/admin/node/removeobject')}
+        {if not($move_to_trash_allowed)}
+            - {'Objects containing ezuser attributes can not be sent to trash'|i18n('design/admin/node/removeobject')}
+        {/if}
+    </p>
+
 {/if}
 </div>
 


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-22628
## Description

Object containing ezuser attribute can not be sent to trash. It has been the case for a while (and for 10 years for the user class).
If you delete the parent of one of these object (and the parent don't have an ezuser field) ezpublish will try to send it to trash and this will trigger side effects. A quick example is to delete a user_group containing users.

This patch modifies slightly the behavior:
- The "move to trash" checkbox will always be present. If a subtree item contains an ezuser attribute, it will be deactivated and an explanation message will be present (only if needed).
- Children will also be checked to decide if a tree can be sent to trash. If one wants to trash a tree containing ezusers, they will need to go delete them first.
## Screenshot

![delete_user](https://cloud.githubusercontent.com/assets/4035241/2732234/bffd03d4-c637-11e3-92f9-18dba6417a7f.png)
## Tests

Manual sanity check on content deletion.
## TODO
- [ ] Translations ?
