### PR TITLE
Fix EZP-22664: View cache not cleared properly if the node count is above the threshold

### DIFF
--- a/kernel/classes/ezcontentcachemanager.php
+++ b/kernel/classes/ezcontentcachemanager.php
@@ -787,18 +787,18 @@ class eZContentCacheManager
 
         eZDebug::accumulatorStart( 'node_cleanup', '', 'Node cleanup' );
 
-        $nodeList = ezpEvent::getInstance()->filter( 'content/cache', $nodeList );
-
         eZContentObject::expireComplexViewModeCache();
         $cleanupValue = eZContentCache::calculateCleanupValue( count( $nodeList ) );
 
         if ( eZContentCache::inCleanupThresholdRange( $cleanupValue ) )
         {
+            $nodeList = ezpEvent::getInstance()->filter( 'content/cache', $nodeList );
             eZContentCache::cleanup( $nodeList );
         }
         else
         {
             eZDebug::writeDebug( "Expiring all view cache since list of nodes({$cleanupValue}) exceeds site.ini\[ContentSettings]\CacheThreshold", __METHOD__ );
+            ezpEvent::getInstance()->notify( 'content/cache/all' );
             eZContentObject::expireAllViewCache();
         }
 
@@ -1006,7 +1006,7 @@ class eZContentCacheManager
             $ini = eZINI::instance();
             $useURLAlias =& $GLOBALS['eZContentObjectTreeNodeUseURLAlias'];
             $pathPrefix = $ini->variable( 'SiteAccessSettings', 'PathPrefix' );
-            
+
             // get staticCacheHandler instance
             $optionArray = array( 'iniFile'      => 'site.ini',
                                   'iniSection'   => 'ContentSettings',


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-22664

This makes sure that the `'content/cache/all'` event is triggered (and not `'content/cache', $nodeList`) 
when clearing view cache, if the node count is above the cleanup threshold.
