### PR TITLE
Fix EZP-22433: check for empty image when trashing ezimage attribute

### DIFF
--- a/kernel/classes/datatypes/ezimage/ezimagetype.php
+++ b/kernel/classes/datatypes/ezimage/ezimagetype.php
@@ -46,6 +46,13 @@ class eZImageType extends eZDataType
     {
         $imageHandler = $contentObjectAttribute->attribute( "content" );
         $originalAlias = $imageHandler->imageAlias( "original" );
+
+        // check if there is an actual image, 'is_valid' says if there is an image or not
+        if ( $originalAlias['is_valid'] != '1' && empty( $originalAlias['filename'] ) )
+        {
+            return;
+        }
+
         $basenameHashed = md5( $originalAlias["basename"] );
         $trashedFolder = "{$originalAlias["dirpath"]}/trashed";
         $imageHandler->updateAliasPath( $trashedFolder, $basenameHashed );


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23066

also
- https://jira.ez.no/browse/EZP-22628
- https://jira.ez.no/browse/EZP-22433

This PR checks that an image exists when sending an ezimage attribute to trash, which prevents generating inconsistent data when no actual image exists. 
