### PR TITLE
Fix EZP-6959: eZDate and eZDateTime accept values prior to epoch

### DIFF
--- a/kernel/classes/datatypes/ezdatetime/ezdatetimetype.php
+++ b/kernel/classes/datatypes/ezdatetime/ezdatetimetype.php
@@ -147,7 +147,7 @@ class eZDateTimeType extends eZDataType
 
             if ( ( $year == '' and $month == '' and $day == '' and
                    $hour == '' and $minute == '' and ( !$useSeconds or $second == '' ) ) or
-                 !checkdate( $month, $day, $year ) or $year < 1970 )
+                 !checkdate( $month, $day, $year ) )
             {
                     $dateTime->setTimeStamp( 0 );
             }
@@ -239,7 +239,7 @@ class eZDateTimeType extends eZDataType
             $contentClassAttribute = $contentObjectAttribute->contentClassAttribute();
             if ( ( $year == '' and $month == ''and $day == '' and
                    $hour == '' and $minute == '' and ( !$useSeconds or $second == '' ) ) or
-                 !checkdate( $month, $day, $year ) or $year < 1970 )
+                 !checkdate( $month, $day, $year ) )
             {
                     $dateTime->setTimeStamp( 0 );
             }

--- a/lib/ezlocale/classes/ezdate.php
+++ b/lib/ezlocale/classes/ezdate.php
@@ -73,7 +73,7 @@ class eZDate
         }
         $this->Date = $date;
         $this->Locale = eZLocale::instance();
-        $this->IsValid = $date > 0;
+        $this->IsValid = true;
     }
 
     function attributes()
@@ -144,7 +144,7 @@ class eZDate
     function setTimeStamp( $stamp )
     {
         $this->Date = $stamp;
-        $this->IsValid = $stamp > 0;
+        $this->IsValid = true;
     }
 
     /*!

--- a/lib/ezlocale/classes/ezdatetime.php
+++ b/lib/ezlocale/classes/ezdatetime.php
@@ -85,9 +85,9 @@ class eZDateTime
             $datetime = time();
         }
 
-        $this->DateTime = $datetime;
+        $this->DateTime = intval( $datetime );
         $this->Locale = eZLocale::instance();
-        $this->IsValid = $datetime > 0;
+        $this->IsValid = true;
     }
 
     function attributes()
@@ -192,7 +192,7 @@ class eZDateTime
     function setTimeStamp( $stamp )
     {
         $this->DateTime = $stamp;
-        $this->IsValid = $stamp > 0;
+        $this->IsValid = true;
     }
 
     /*!

--- a/lib/ezutils/classes/ezdatetimevalidator.php
+++ b/lib/ezutils/classes/ezdatetimevalidator.php
@@ -28,7 +28,6 @@ class eZDateTimeValidator extends eZInputValidator
         $check = checkdate( $month, $day, $year );
         $datetime = mktime( 0, 0, 0, $month, $day, $year );
         if ( !$check or
-             $year < 1970 or
              $datetime === false )
         {
             return eZInputValidator::STATE_INVALID;
@@ -54,7 +53,6 @@ class eZDateTimeValidator extends eZInputValidator
         $check = checkdate( $month, $day, $year );
         $datetime = mktime( $hour, $minute, $second, $month, $day, $year );
         if ( !$check or
-             $year < 1970 or
              $datetime === false or
              eZDateTimeValidator::validateTime( $hour, $minute ) == eZInputValidator::STATE_INVALID )
         {


### PR DESCRIPTION
Oldie: https://jira.ez.no/browse/EZP-6959. 
I guess it is no longer necessary to keep backwards compatibility with PHP 4
