### PR TITLE
Fix EZP-22730: /url/view/ shows wrong status for objectversions

### DIFF
--- a/design/admin/templates/url/view.tpl
+++ b/design/admin/templates/url/view.tpl
@@ -148,7 +148,7 @@
 </tr>
 {section var=Objects loop=$object_list sequence=array( bglight, bgdark )}
 
-{let object_version_status=$Objects.item.contentobject.versions[sub($Objects.item.version,1)].status}
+{let object_version_status = $Objects.item.status}
 
 {if or(or(eq($view_filter_type,''),eq($view_filter_type,'all')),and(eq($view_filter_type,'published'),eq($object_version_status,1),eq($Objects.item.contentobject.status,1)))}
 <tr class="{$Objects.sequence}">


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-22730
Fix proposed by @pbras  in issue

The current code is from 9fcace08 which is from 2006, and contains lots of changes. This particular change does not seem related to the main purpose of the commit, which is to add alphabetical navigation. 
The code assumes that `object.versions[object.version-1]` always exists, which is not the case when versions are removed, nor when the current version is 1 (the funny thing is that both cases were
previously handled, and this commit removes it). The result is that false or null is returned,
which evaluates to `STATUS_DRAFT`.
