### PR TITLE
Fix EZP-22792: consecutive calls to trashNode::originalParent() return null

### DIFF
--- a/kernel/classes/ezcontentobjecttrashnode.php
+++ b/kernel/classes/ezcontentobjecttrashnode.php
@@ -348,8 +348,8 @@ class eZContentObjectTrashNode extends eZContentObjectTreeNode
             $realParentPathArray = $this->originalNodeParent->attribute( 'path_array' );
             $realParentPath = implode( '/', $realParentPathArray );
 
-            array_pop( $this->pathArray );
-            $thisParentPath = implode( '/', $this->pathArray );
+            $thisParentPathArray = array_slice( $this->pathArray, 0, -1 );
+            $thisParentPath = implode( '/', $thisParentPathArray );
 
             if ( $thisParentPath == $realParentPath )
             {


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-22792

The `originalParent()` function was saved `pathArray` property after the first call, but used `array_pop()` on every consecutive call.
This caused all the function to always return `null` on consecutive calls, as `$thisParentPath` would keep getting smaller.
