### PR TITLE
Fix EZP-22793: Incorrect kernel error when accessing hidden node.

### DIFF
--- a/kernel/classes/eznodeviewfunctions.php
+++ b/kernel/classes/eznodeviewfunctions.php
@@ -563,7 +563,7 @@ class eZNodeviewfunctions
 
         if ( $node->attribute( 'is_invisible' ) && !eZContentObjectTreeNode::showInvisibleNodes() )
         {
-            return self::contentViewGenerateError( $Module, eZError::KERNEL_ACCESS_DENIED );
+            return self::contentViewGenerateError( $Module, eZError::KERNEL_NOT_AVAILABLE );
         }
 
         if ( !$node->canRead() )


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-22793

Because access to hidden nodes is not controlled by user permissions or limitations (but rather `ShowHiddenNodes` ini setting ), the generated error should not be `KERNEL_ACCESS_DENIED`.

This PR modifies it to `KERNEL_NOT_AVAILABLE` instead (which is kernel error 3, or HTTP Error 404 by default)
