### PR TITLE
Fix EZP-22749: wrong working directory

### DIFF
--- a/doc/bc/5.3/changes-5.3.txt
+++ b/doc/bc/5.3/changes-5.3.txt
@@ -44,3 +44,7 @@ Removed globals
 
 Deprecated
 ----------
+- eZExpiryHandler::registerShutdownFunction() is deprecated (EZP-22749)
+
+  The method isn't removed, but it won't register anything anymore. eZExpiryHandler::shutdown() will be called instead
+  upon kernel shutdown. The register call can be removed, but not doing so won't have any negative effect.

--- a/kernel/classes/datatypes/ezuser/ezuser.php
+++ b/kernel/classes/datatypes/ezuser/ezuser.php
@@ -1915,7 +1915,6 @@ WHERE user_id = '" . $userID . "' AND
     static protected function userInfoExpiry()
     {
         /* Figure out when the last update was done */
-        eZExpiryHandler::registerShutdownFunction();
         $handler = eZExpiryHandler::instance();
         if ( $handler->hasTimestamp( 'user-info-cache' ) )
         {
@@ -2698,7 +2697,6 @@ WHERE user_id = '" . $userID . "' AND
      */
     static function cleanupCache()
     {
-        eZExpiryHandler::registerShutdownFunction();
         $handler = eZExpiryHandler::instance();
         $handler->setTimestamp( 'user-info-cache', time() );
         $handler->store();

--- a/kernel/classes/ezcache.php
+++ b/kernel/classes/ezcache.php
@@ -460,7 +460,6 @@ class eZCache
         if ( isset( $cacheItem['expiry-key'] ) )
         {
             $key = $cacheItem['expiry-key'];
-            eZExpiryHandler::registerShutdownFunction();
             $expiryHandler = eZExpiryHandler::instance();
             $keyValue = $expiryHandler->getTimestamp( $key );
             if ( $keyValue !== false )
@@ -533,7 +532,6 @@ class eZCache
      */
     static function clearImageAlias( $cacheItem )
     {
-        eZExpiryHandler::registerShutdownFunction();
         $expiryHandler = eZExpiryHandler::instance();
         $expiryHandler->setTimestamp( 'image-manager-alias', time() );
         $expiryHandler->store();
@@ -642,7 +640,6 @@ class eZCache
      */
     static function clearContentTreeMenu( $cacheItem )
     {
-        eZExpiryHandler::registerShutdownFunction();
         $expiryHandler = eZExpiryHandler::instance();
         $expiryHandler->setTimestamp( 'content-tree-menu', time() );
         $expiryHandler->store();
@@ -653,7 +650,6 @@ class eZCache
      */
     static function clearTemplateBlockCache( $cacheItem )
     {
-        eZExpiryHandler::registerShutdownFunction();
         $expiryHandler = eZExpiryHandler::instance();
         $expiryHandler->setTimestamp( 'global-template-block-cache', time() );
         $expiryHandler->store();
@@ -702,7 +698,6 @@ class eZCache
      */
     static function clearUserInfoCache( $cacheItem )
     {
-        eZExpiryHandler::registerShutdownFunction();
         $handler = eZExpiryHandler::instance();
         $handler->setTimestamp( 'user-info-cache', time() );
         $handler->store();
@@ -714,7 +709,6 @@ class eZCache
      */
     static function clearContentCache( $cacheItem )
     {
-        eZExpiryHandler::registerShutdownFunction();
         $handler = eZExpiryHandler::instance();
         $handler->setTimestamp( 'content-view-cache', time() );
         $handler->store();
@@ -772,8 +766,6 @@ class eZCache
      */
     static function clearActiveExtensions( $cacheItem )
     {
-        eZExpiryHandler::registerShutdownFunction();
-
         $handler = eZExpiryHandler::instance();
         $handler->setTimestamp( $cacheItem['expiry-key'], time() );
         $handler->store();

--- a/kernel/classes/ezcontentclass.php
+++ b/kernel/classes/ezcontentclass.php
@@ -390,7 +390,6 @@ class eZContentClass extends eZPersistentObject
         if ( $enableCaching )
         {
             $http = eZHTTPTool::instance();
-            eZExpiryHandler::registerShutdownFunction();
             $handler = eZExpiryHandler::instance();
             $expiredTimeStamp = 0;
             if ( $handler->hasTimestamp( 'user-class-cache' ) )
@@ -911,7 +910,6 @@ You will need to change the class of the node by using the swap functionality.' 
            }
         }
 
-        eZExpiryHandler::registerShutdownFunction();
         $handler = eZExpiryHandler::instance();
         $handler->setTimestamp( 'user-class-cache', time() );
         $handler->store();
@@ -1031,7 +1029,6 @@ You will need to change the class of the node by using the swap functionality.' 
         }
         eZContentClassClassGroup::removeClassMembers( $this->ID, $previousVersion );
 
-        eZExpiryHandler::registerShutdownFunction();
         $handler = eZExpiryHandler::instance();
         $time = time();
         $handler->setTimestamp( 'user-class-cache', $time );
@@ -1832,7 +1829,6 @@ You will need to change the class of the node by using the swap functionality.' 
                                           '',
                                           array( 'clustering' => 'classidentifiers' ) );
 
-            eZExpiryHandler::registerShutdownFunction();
             $handler = eZExpiryHandler::instance();
             $expiryTime = 0;
             if ( $handler->hasTimestamp( 'class-identifier-cache' ) )

--- a/kernel/classes/ezcontentclassattribute.php
+++ b/kernel/classes/ezcontentclassattribute.php
@@ -590,8 +590,6 @@ class eZContentClassAttribute extends eZPersistentObject
 
     static function cachedInfo()
     {
-        eZExpiryHandler::registerShutdownFunction();
-
         $info = array();
         $db = eZDB::instance();
         $dbName = md5( $db->DB );
@@ -913,7 +911,6 @@ class eZContentClassAttribute extends eZPersistentObject
                                           '',
                                           array( 'clustering' => 'classattridentifiers' ) );
 
-            eZExpiryHandler::registerShutdownFunction();
             $handler = eZExpiryHandler::instance();
             $expiryTime = 0;
             if ( $handler->hasTimestamp( 'class-identifier-cache' ) )

--- a/kernel/classes/ezcontentobject.php
+++ b/kernel/classes/ezcontentobject.php
@@ -5824,7 +5824,6 @@ class eZContentObject extends eZPersistentObject
      */
     static function expireAllViewCache()
     {
-        eZExpiryHandler::registerShutdownFunction();
         $handler = eZExpiryHandler::instance();
         $handler->setTimestamp( 'content-view-cache', time() );
         $handler->store();
@@ -5840,7 +5839,6 @@ class eZContentObject extends eZPersistentObject
      */
     static function expireAllCache()
     {
-        eZExpiryHandler::registerShutdownFunction();
         $handler = eZExpiryHandler::instance();
         $handler->setTimestamp( 'content-view-cache', time() );
         $handler->setTimestamp( 'template-block-cache', time() );
@@ -5856,7 +5854,6 @@ class eZContentObject extends eZPersistentObject
      */
     static function expireTemplateBlockCache()
     {
-        eZExpiryHandler::registerShutdownFunction();
         $handler = eZExpiryHandler::instance();
         $handler->setTimestamp( 'template-block-cache', time() );
         $handler->store();
@@ -5870,7 +5867,6 @@ class eZContentObject extends eZPersistentObject
      */
     static function expireComplexViewModeCache()
     {
-        eZExpiryHandler::registerShutdownFunction();
         $handler = eZExpiryHandler::instance();
         $handler->setTimestamp( 'content-complex-viewmode-cache', time() );
         $handler->store();
@@ -5884,7 +5880,6 @@ class eZContentObject extends eZPersistentObject
      */
     static function isCacheExpired( $timestamp )
     {
-        eZExpiryHandler::registerShutdownFunction();
         $handler = eZExpiryHandler::instance();
         if ( !$handler->hasTimestamp( 'content-view-cache' ) )
             return false;
@@ -5918,7 +5913,6 @@ class eZContentObject extends eZPersistentObject
     {
         if ( !eZContentObject::isComplexViewMode( $viewMode ) )
             return false;
-        eZExpiryHandler::registerShutdownFunction();
         $handler = eZExpiryHandler::instance();
         if ( !$handler->hasTimestamp( 'content-complex-viewmode-cache' ) )
             return false;

--- a/kernel/classes/ezrole.php
+++ b/kernel/classes/ezrole.php
@@ -262,7 +262,6 @@ class eZRole extends eZPersistentObject
         $db->commit();
 
         // Expire role cache
-        eZExpiryHandler::registerShutdownFunction();
         $handler = eZExpiryHandler::instance();
         $handler->setTimestamp( 'user-info-cache', time() );
         $handler->setTimestamp( 'user-class-cache', time() );

--- a/kernel/classes/ezscript.php
+++ b/kernel/classes/ezscript.php
@@ -402,6 +402,7 @@ class eZScript
 
         eZExecution::cleanup();
         eZExecution::setCleanExit();
+        eZExpiryHandler::shutdown();
         $this->setIsInitialized( false );
         if ( $exitCode !== false )
             $this->ExitCode = $exitCode;

--- a/kernel/classes/ezuserdiscountrule.php
+++ b/kernel/classes/ezuserdiscountrule.php
@@ -62,7 +62,6 @@ class eZUserDiscountRule extends eZPersistentObject
         }
         else
         {
-            eZExpiryHandler::registerShutdownFunction();
             $handler = eZExpiryHandler::instance();
             $handler->setTimestamp( 'user-discountrules-cache', time() );
             $handler->store();
@@ -100,7 +99,6 @@ class eZUserDiscountRule extends eZPersistentObject
         {
             $http = eZHTTPTool::instance();
 
-            eZExpiryHandler::registerShutdownFunction();
             $handler = eZExpiryHandler::instance();
             $expiredTimeStamp = 0;
             if ( $handler->hasTimestamp( 'user-discountrules-cache' ) )

--- a/kernel/content/ezcontentfunctioncollection.php
+++ b/kernel/content/ezcontentfunctioncollection.php
@@ -1526,8 +1526,6 @@ class eZContentFunctionCollection
 
     static public function fetchContentTreeMenuExpiry()
     {
-        eZExpiryHandler::registerShutdownFunction();
-
         $expiryHandler = eZExpiryHandler::instance();
 
         if ( !$expiryHandler->hasTimestamp( 'content-tree-menu' ) )

--- a/kernel/content/treemenu.php
+++ b/kernel/content/treemenu.php
@@ -6,8 +6,6 @@
  * @package kernel
  */
 
-eZExpiryHandler::registerShutdownFunction();
-
 if ( !defined( 'MAX_AGE' ) )
 {
     define( 'MAX_AGE', 86400 );

--- a/kernel/private/classes/ezcontentobjectstategroup.php
+++ b/kernel/private/classes/ezcontentobjectstategroup.php
@@ -354,7 +354,6 @@ class eZContentObjectStateGroup extends eZPersistentObject
             }
         }
 
-        eZExpiryHandler::registerShutdownFunction();
         $handler = eZExpiryHandler::instance();
         $handler->setTimestamp( 'state-limitations', time() );
 
@@ -691,7 +690,6 @@ class eZContentObjectStateGroup extends eZPersistentObject
 
             if ( $storedTimeStamp === false )
             {
-                eZExpiryHandler::registerShutdownFunction();
                 $handler->setTimestamp( 'state-limitations', time() );
             }
         }

--- a/kernel/private/classes/ezpkerneltreemenu.php
+++ b/kernel/private/classes/ezpkerneltreemenu.php
@@ -308,6 +308,7 @@ class ezpKernelTreeMenu implements ezpKernelHandler
     {
         eZExecution::cleanup();
         eZExecution::setCleanExit();
+        eZExpiryHandler::shutdown();
         if ( $reInitialize )
             $this->isInitialized = false;
     }

--- a/kernel/private/classes/ezpkernelweb.php
+++ b/kernel/private/classes/ezpkernelweb.php
@@ -1226,6 +1226,7 @@ class ezpKernelWeb implements ezpWebBasedKernelHandler
     {
         eZExecution::cleanup();
         eZExecution::setCleanExit();
+        eZExpiryHandler::shutdown();
         if ( $reInitialize )
             $this->isInitialized = false;
     }

--- a/kernel/private/rest/classes/cache/apc.php
+++ b/kernel/private/rest/classes/cache/apc.php
@@ -23,7 +23,6 @@ class ezpRestCacheStorageApcCluster extends ezcCacheStorageApcPlain
 
     public function __construct( $location = null, array $options = array() )
     {
-        eZExpiryHandler::registerShutdownFunction();
         $this->expiryHandler = eZExpiryHandler::instance();
 
         parent::__construct( $location, $options );

--- a/lib/ezi18n/classes/eztstranslator.php
+++ b/lib/ezi18n/classes/eztstranslator.php
@@ -732,8 +732,6 @@ class eZTSTranslator extends eZTranslatorHandler
      */
     public static function expireCache( $timestamp = false, $locale = null )
     {
-        eZExpiryHandler::registerShutdownFunction();
-
         if ( $timestamp === false )
             $timestamp = time();
 

--- a/lib/ezimage/classes/ezimagemanager.php
+++ b/lib/ezimage/classes/ezimagemanager.php
@@ -275,7 +275,6 @@ class eZImageManager
     */
     function isImageTimestampValid( $timestamp )
     {
-        eZExpiryHandler::registerShutdownFunction();
         $expiryHandler = eZExpiryHandler::instance();
         if ( $expiryHandler->hasTimestamp( 'image-manager-alias' ) )
         {

--- a/lib/eztemplate/classes/eztemplatecacheblock.php
+++ b/lib/eztemplate/classes/eztemplatecacheblock.php
@@ -88,7 +88,6 @@ class eZTemplateCacheBlock
     static function handle( $cachePath, $nodeID, $ttl, $useGlobalExpiry = true )
     {
         $globalExpiryTime = -1;
-        eZExpiryHandler::registerShutdownFunction();
         if ( $useGlobalExpiry )
         {
             $globalExpiryTime = eZExpiryHandler::getTimestamp( 'template-block-cache', -1 );

--- a/lib/eztemplate/classes/eztemplatecachefunction.php
+++ b/lib/eztemplate/classes/eztemplatecachefunction.php
@@ -262,7 +262,6 @@ class eZTemplateCacheFunction
         }
 
         $globalExpiryTime = -1;
-        eZExpiryHandler::registerShutdownFunction();
         if ( $ignoreContentExpiry == false )
         {
             $globalExpiryTime = eZExpiryHandler::getTimestamp( 'template-block-cache', -1 );

--- a/lib/ezutils/classes/ezexpiryhandler.php
+++ b/lib/ezutils/classes/ezexpiryhandler.php
@@ -167,19 +167,11 @@ class eZExpiryHandler
     /**
      * Registers the shutdown function.
      * @see eZExpiryHandler::shutdown()
+     * @deprecated See EZP-22749
      */
     public static function registerShutdownFunction(){
-        if ( !eZExpiryHandler::$isShutdownFunctionRegistered ) {
-            register_shutdown_function( array('eZExpiryHandler', 'shutdown') );
-            eZExpiryHandler::$isShutdownFunctionRegistered = true;
-        }
+        eZDebug::writeStrict( __METHOD__ . " is deprecated. See EZP-22749.", __METHOD__ . " is deprecated" );
     }
-
-    /**
-     * Indicates if thre shutdown function has been registered
-     * @var bool
-     */
-    private static $isShutdownFunctionRegistered = false;
 
     /**
      * Holds the expiry timestamps array

--- a/tests/tests/lib/ezutils/ezphpcreator_regression.php
+++ b/tests/tests/lib/ezutils/ezphpcreator_regression.php
@@ -63,7 +63,6 @@ class eZPHPCreatorRegression extends ezpDatabaseTestCase
                                       '',
                                       array( 'clustering' => 'classidentifiers' ) );
 
-        eZExpiryHandler::registerShutdownFunction();
         $handler = eZExpiryHandler::instance();
         $expiryTime = 0;
         if ( $handler->hasTimestamp( 'class-identifier-cache' ) )


### PR DESCRIPTION
> Fixes https://jira.ez.no/browse/EZP-22749
> Status: read for review
### Actual bug

The issue affects all shutdown handlers on apache. As said on the [`register_shutdown_function()`](http://fr2.php.net/manual/en/function.register-shutdown-function.php) doc:

> Working directory of the script can change inside the shutdown function under some web servers, e.g. Apache.

In my case, with apache, the working directory is set to "/". Some shutdown functions don't care as they don't rely on the filesystem, but others do, like eZExpiryHandler, that may write the updated expiry handler cache to FS upon shutdown.
### Fix

This patch only fixes the `eZExpiryHandler` case.

`eZExpiryHandler::registerShutdownFunction()` isn't used anymore, and Expiry cache is explicitly stored after the kernel is done excuting, be it through runCallback, run or pure legacy mode.
### BC

This deprecates registerShutdownFunction(). It should not be used at all, and must be changed to have no effect.
