### PR TITLE
Fix EZP-22838: Tests: provider* functions use the default db parameters ...

### DIFF
--- a/tests/tests/kernel/classes/ezcollaborationitem_test.php
+++ b/tests/tests/kernel/classes/ezcollaborationitem_test.php
@@ -7,7 +7,7 @@
  * @version //autogentag//
  */
 
-class eZCollaborationItemTest extends ezpTestCase
+class eZCollaborationItemTest extends ezpDatabaseTestCase
 {
     public function setUp()
     {


### PR DESCRIPTION
...and not the provided dsn

From a fresh clone @96e86693, if you run :
php tests/runtests.php --dsn mysqli://non_root_user:random_passwd@localhost/eztests

you end up with such a trace :

0: eZMySQLiDB::connect()
1: eZMySQLiDB::eZMySQLiDB()
2: ReflectionClass::newInstanceArgs()
3: eZExtension::getHandlerClass()
4: eZDB::instance()
5: eZPersistentObject::fetchObjectList()
6: eZPersistentObject::fetchObject()
7: eZUser::fetch()
8: eZPersistentObject::eZPersistentObject()
9: eZUser::eZUser()
10: ReflectionClass::newInstanceArgs()
11: PHPUnit_Framework_MockObject_Generator::getObject()
12: PHPUnit_Framework_MockObject_Generator::getMock()
13: PHPUnit_Framework_TestCase::getMock()
14: PHPUnit_Framework_MockObject_MockBuilder::getMock()
15: eZCollaborationItemTest::createUserMock()
16: eZCollaborationItemTest::providerForIsParticipant()
17: ReflectionMethod::invoke()
18: PHPUnit_Util_Test::getProvidedData()
19: PHPUnit_Framework_TestSuite::createTest()
20: PHPUnit_Framework_TestSuite::addTestMethod()
21: PHPUnit_Framework_TestSuite::__construct()
22: PHPUnit_Framework_TestSuite::addTestSuite()
23: eZKernelTestSuite::__construct()
24: eZKernelTestSuite::suite()
25: ReflectionMethod::invoke()
26: PHPUnit_Framework_TestSuite::addTestSuite()
27: eZTestSuite::__construct()
28: ezpTestRunner::prepareTests()
29: ezpTestRunner::handleCustomTestSuite()
30: PHPUnit_TextUI_Command::handleArguments()
31: ezpTestRunner::handleArguments()
32: PHPUnit_TextUI_Command::run()

You see that the tests introduced in dd136d9b, eZCollaborationItemTest::providerForIsParticipant() do createUserMock().
This runs the eZ Publish framework, but with the default database, (db://root:@localhost/nextgen).
