### PR TITLE
Fix EZP-22685: Embed images displayed side-by-side in Online Editor

### DIFF
--- a/extension/ezoe/design/standard/stylesheets/skins/default/content.css
+++ b/extension/ezoe/design/standard/stylesheets/skins/default/content.css
@@ -201,6 +201,11 @@ span.ezoeItemNonEditable[align="left"]
     float: left;
 }
 
+img[inline="false"]
+{
+    display: block;
+}
+
 /* core.css ez layout styles for embed tags */
 
 div.ezoeItemNonEditable div.block /* Used around groups of objects which are connected in some way, and requires extra margins to the surroundings */

--- a/extension/ezoe/design/standard/stylesheets/skins/o2k7/content.css
+++ b/extension/ezoe/design/standard/stylesheets/skins/o2k7/content.css
@@ -194,6 +194,11 @@ span.ezoeItemNonEditable[align="left"]
     float: left;
 }
 
+img[inline="false"]
+{
+    display: block;
+}
+
 /* core.css ez layout styles for embed tags */
 
 div.ezoeItemNonEditable div.block /* Used around groups of objects which are connected in some way, and requires extra margins to the surroundings */


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-22685
# Description

In Online Editor, if you add some images, they are always aligned side by side even if they are not configured to be _inline_.

This patch makes sure the images are aligned depending on the inline parameter so that the editor has a better preview of how the page will be rendered.

![image-ezoe](https://cloud.githubusercontent.com/assets/305563/2942987/c1fcf34a-d9bc-11e3-93cf-fba23fa18c9f.png)
# Tests

manual tests
