### PR TITLE
EZP-22835: Fixed ezjscore cache clearing error

### DIFF
--- a/extension/ezjscore/classes/ezjsccachemanager.php
+++ b/extension/ezjscore/classes/ezjsccachemanager.php
@@ -15,6 +15,9 @@ class ezjscCacheManager
      */
     public static function clearCache( array $cacheItem )
     {
-        eZClusterFileHandler::instance()->fileDeleteByDirList( array( $cacheItem['path'] ), eZSys::cacheDirectory(), '' );
+        eZClusterFileHandler::instance()->fileDeleteByDirList(
+            array( 'javascript', 'stylesheets' ),
+            eZSys::cacheDirectory() . '/' . $cacheItem['path'], ''
+        );
     }
 }


### PR DESCRIPTION
> Fixes http://jira.ez.no/browse/EZP-22835

Plain old wrong PEBKAC: wrong usage of `fileDeleteByDirList()` :-)
