### PR TITLE
Fix EZP-22854: updatesearchindex not committing at each iteration.

### DIFF
--- a/bin/php/updatesearchindex.php
+++ b/bin/php/updatesearchindex.php
@@ -145,11 +145,11 @@ do
         $script->iterate( $cli, true );
     }
 
+    $searchEngine->commit();
+
     $limit['offset'] += $length;
 
 } while ( count( $objects ) == $length );
-
-$searchEngine->commit();
 
 $cli->output();
 $cli->output( "done" );


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-22854

The updatesearchindex.php should commit changes at each iteration and not at the end of the operation (much like the index cronjob and other scripts).
