### PR TITLE
EZP-22643: "Missing form token from Request " when creating an object after clearing cache

### DIFF
--- a/extension/ezformtoken/event/ezxformtoken.php
+++ b/extension/ezformtoken/event/ezxformtoken.php
@@ -256,6 +256,11 @@ class ezxFormToken
         self::$isEnabled = (bool)$isEnabled;
     }
 
+    static public function isEnabled()
+    {
+        return (bool)self::$isEnabled;
+    }
+
     /**
      * Figures out if current user should be protected or not
      * based on if (s)he has a session and is logged in.


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-22643

This patch adds a `ezxFormToken::isEnabled()`, to be used in
https://github.com/ezsystems/ezpublish-kernel/pull/858
