### PR TITLE
Fix EZP-22782: wf status redirect sets bad status

### DIFF
--- a/lib/ezutils/classes/ezmoduleoperationinfo.php
+++ b/lib/ezutils/classes/ezmoduleoperationinfo.php
@@ -498,7 +498,7 @@ class eZModuleOperationInfo
 
                                 $bodyReturnValue['status'] = eZModuleOperationInfo::STATUS_HALTED;
                                 $interrupt = true;
-                            }
+                            }break;
                             case eZModuleOperationInfo::STATUS_REPEAT:
                             {
 


### PR DESCRIPTION
> Fixes http://jira.ez.no/browse/EZP-22782

A missing break in a switch/case caused the wrong workflow status to being set, preventing the object's status from being set.

Tested with a simple workflow that returns STATUS_REDIRECT as described in the issue.
