### PR TITLE
Fix EZP-22860: Moving WF event fails if user is not valid

### DIFF
--- a/kernel/workflow/edit.php
+++ b/kernel/workflow/edit.php
@@ -19,9 +19,19 @@ case "down":
         {
             if ( isset( $Params["EventID"] ) )
             {
-                $event = eZWorkflowEvent::fetch( $Params["EventID"], true, 1,
-                                                 array( "workflow_id", "version", "placement" ) );
-                $event->move( $Params["FunctionName"] == "up" ? false : true );
+                /** @var eZWorkflowEvent $event */
+                $event = eZWorkflowEvent::fetch(
+                    $Params["EventID"],
+                    true,
+                    1,
+                    array( "workflow_id", "version", "placement" )
+                );
+
+                if ( $event instanceof eZWorkflowEvent )
+                {
+                    $event->move( $Params["FunctionName"] == "up" ? false : true );
+                }
+
                 $Module->redirectTo( $Module->functionURI( 'edit' ) . '/' . $WorkflowID );
                 return;
             }


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-22860
## Description

If you remove the user of a validation Workflow (making the WF edit form not valid) and try to move events up or down, you get a fatal error. This fix ensure the events has been retrieved (which is not the case when invalid) before trying to move it.
## Tests

Manual tests
