### PR TITLE
Fix EZP-22886: Adding WF event breaks positions if user is not valid

### DIFF
--- a/kernel/workflow/edit.php
+++ b/kernel/workflow/edit.php
@@ -309,19 +309,19 @@ else if ( $http->hasPostVariable( "DeleteButton" ) )
 // Add new workflow event
 else if ( $http->hasPostVariable( "NewButton" ) )
 {
-    $new_event = eZWorkflowEvent::create( $WorkflowID, $cur_type );
-    $new_event_type = $new_event->eventType();
-    $db = eZDB::instance();
-    $db->begin();
+    if ( $canStore )
+    {
+        $new_event = eZWorkflowEvent::create( $WorkflowID, $cur_type );
+        $new_event_type = $new_event->eventType();
+        $db = eZDB::instance();
+        $db->begin();
 
-    if ($canStore)
-        $workflow->store( $event_list );
+        $new_event_type->initializeEvent( $new_event );
+        $new_event->store();
 
-    $new_event_type->initializeEvent( $new_event );
-    $new_event->store();
-
-    $db->commit();
-    $event_list[] = $new_event;
+        $db->commit();
+        $event_list[] = $new_event;
+    }
 }
 else if ( $canStore )
 {


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-22886
## Description

If you remove the user of a validation Workflow (making the WF edit form not valid) and add a new WF event, this event order are messed up. This fix disables the possibility to add new events when you have existing invalid ones.
## Tests

Manual tests
