### PR TITLE
Update ezhttptool.php [Fix for the linkcheck.php validation]

### DIFF
--- a/lib/ezutils/classes/ezhttptool.php
+++ b/lib/ezutils/classes/ezhttptool.php
@@ -750,6 +750,9 @@ EOT;
                 curl_setopt( $ch, CURLOPT_TIMEOUT, 15 );
                 curl_setopt( $ch, CURLOPT_FAILONERROR, 1 );
                 curl_setopt( $ch, CURLOPT_NOBODY, 1 );
+                // Force Get request because CURLOPT_NOBODY sets 
+                // the request method to HEAD which is restricted on most servers
+                curl_setopt( $ch, CURLOPT_CUSTOMREQUEST, 'GET');
             }
 
             if ( $userAgent )


### PR DESCRIPTION
Added "CURLOPT_CUSTOMREQUEST" to the curl_setopt because most servers have restricted Head request method which is generated with the "CURLOPT_NOBODY" option. With this addition, the linkcheck.php cronjob will validate links properly.
