### PR TITLE
Fix EZP-22894: 5.3-rc7 has development settings enabled

### DIFF
--- a/settings/content.ini
+++ b/settings/content.ini
@@ -16,7 +16,7 @@
 # OBSOLETE: A list of designs the site can use
 AvailableSiteDesignList[]
 AvailableSiteDesignList[]=admin
-AvailableSiteDesignList[]=base##!
+#AvailableSiteDesignList[]=base
 
 # Define maximum versions can be managed. Use syntax
 # VersionHistoryClass[class_id]=maximum_nr to specify value for particular

--- a/settings/image.ini
+++ b/settings/image.ini
@@ -283,7 +283,7 @@ Executable=convert
 # Name of the executable for windows,
 # uncomment ExecutableMac for Mac specific converter and
 # ExecutableUnix for Unix/Linux specific converter
-ExecutableWin32=convertim##!
+#ExecutableWin32=convertim
 # ExecutableMac=convert
 # ExecutableUnix=convert
 # Parameters that must be run before the filenames and filters.

--- a/settings/site.ini
+++ b/settings/site.ini
@@ -238,8 +238,7 @@ BasketCleanupAverageFrequency=10
 # Master switch for debug, if disabled no debug will be shown
 # If enabled it's up to the DebugByIP and DebugIPList to decide what to do.
 # Use either enabled or disabled
-DebugOutput=enabled##!
-#!DebugOutput=disabled
+DebugOutput=disabled
 # Controls which debug types to always log.
 # This ensures logging even if debug output is off
 #
@@ -286,13 +285,11 @@ Debug=inline
 # Controls if redirects should be debuggable, set to enable to get a redirect
 # page with debug info.
 # This is useful for development while production sites should have it off
-DebugRedirection=enabled##!
-#!DebugRedirection=disabled
+DebugRedirection=disabled
 
 # Whether debug warnings/errors should be displayed on the page or not.
 # If not they will appear in debug log only.
-DisplayDebugWarnings=enabled##!
-#!DisplayDebugWarnings=disabled
+DisplayDebugWarnings=disabled
 
 # Whether to skip showing debug strings in the debug output.
 DebugLogOnly=disabled
@@ -676,8 +673,9 @@ URIMatchType=element
 URIMatchElement=1
 URIMatchRegexp=([^/]+)/
 URIMatchRegexpItem=1
-URIMatchSubtextPre=##!
-URIMatchSubtextPost=##!
+#URIMatchSubtextPre=
+#URIMatchSubtextPost=
+
 # Add array entries here if you chose URIMatchType=map
 # Each entry consists of the uri;accessname
 URIMatchMapItems[]
@@ -1033,8 +1031,7 @@ ShowXHTMLCode=enabled
 ShowMethodDebug=disabled
 # If enabled will add a table with templates used to render a page.
 # DebugOutput should be enabled too.
-ShowUsedTemplates=enabled##!
-#!ShowUsedTemplates=disabled
+ShowUsedTemplates=disabled
 # Determines whether the internal node tree should be cached, by enabling this the loading
 # and parsing of templates is significantly reduced.
 NodeTreeCaching=disabled
@@ -1073,8 +1070,7 @@ TemplateCompression=disabled
 # Note: Live sites should not have this enabled since it increases file access
 #       and can be slower.
 # Note: When switching this setting the template compiled files must be cleared.
-DevelopmentMode=enabled##!
-#!DevelopmentMode=disabled
+DevelopmentMode=disabled
 
 # NOTE:
 # The following settings are for template compilation development only

--- a/settings/template.ini
+++ b/settings/template.ini
@@ -26,8 +26,7 @@ AutoConvertOnSave=enabled
 # Whether warnings from the template engine should be displayed
 # on the page or not.
 # Note: Debug warnings are always shown if debug is on.
-DisplayWarnings=enabled##!
-#!DisplayWarnings=disabled
+DisplayWarnings=disabled
 # User defined parameter.
 # Ex: http://ez.no/developer/(poll_option)/5
 # will store poll_option 5 into the $view_parameters.poll_option in the template


### PR DESCRIPTION
With switch to composer based model we no longer have the option
to swap to many things in builds anymore, and hence we herby
swap the defaults in git to be same as in builds.
