### PR TITLE
Fix EZP-22896: Setup wizard: Timeout on package retrieval

### DIFF
--- a/kernel/setup/steps/ezstep_site_types.php
+++ b/kernel/setup/steps/ezstep_site_types.php
@@ -80,7 +80,7 @@ class eZStepSiteTypes extends eZStepInstaller
             curl_setopt( $ch, CURLOPT_FILE, $fp );
             curl_setopt( $ch, CURLOPT_HEADER, 0 );
             curl_setopt( $ch, CURLOPT_FAILONERROR, 1 );
-            curl_setopt( $ch, CURLOPT_CONNECTTIMEOUT, 3 );
+            curl_setopt( $ch, CURLOPT_CONNECTTIMEOUT, 30 );
             // Get proxy
             $ini = eZINI::instance();
             $proxy = $ini->hasVariable( 'ProxySettings', 'ProxyServer' ) ? $ini->variable( 'ProxySettings', 'ProxyServer' ) : false;


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-22896
## Description

On a slow connection package list retrieval can timeout. This patch changes the timeout form 3 sec to 30 sec. I am open for discussion regarding the new value :)
## Tests

Sanity checks on setup wizard.
