### PR TITLE
Fix EZP-22928: Embed inline image are always seen as inline in Online Editor

### DIFF
--- a/extension/ezoe/design/standard/stylesheets/skins/default/content.css
+++ b/extension/ezoe/design/standard/stylesheets/skins/default/content.css
@@ -206,6 +206,18 @@ img[inline="false"]
     display: block;
 }
 
+img[inline="false"][align="right"]
+{
+    float: right;
+    clear: both;
+}
+
+img[inline="false"][align="left"]
+{
+    float: left;
+    clear: both;
+}
+
 /* core.css ez layout styles for embed tags */
 
 div.ezoeItemNonEditable div.block /* Used around groups of objects which are connected in some way, and requires extra margins to the surroundings */

--- a/extension/ezoe/design/standard/stylesheets/skins/o2k7/content.css
+++ b/extension/ezoe/design/standard/stylesheets/skins/o2k7/content.css
@@ -199,6 +199,18 @@ img[inline="false"]
     display: block;
 }
 
+img[inline="false"][align="right"]
+{
+    float: right;
+    clear: both;
+}
+
+img[inline="false"][align="left"]
+{
+    float: left;
+    clear: both;
+}
+
 /* core.css ez layout styles for embed tags */
 
 div.ezoeItemNonEditable div.block /* Used around groups of objects which are connected in some way, and requires extra margins to the surroundings */


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-22928
# Description

Image put in Online Editor with the `embed-inline` view and aligned (on the right or on the left) are always seen as inline in the editor no matter if the `Inline` checkbox is checked. This is should be the case only if the inline checkbox is checked.
# Tests

manual tests
