### PR TITLE
Fix EZP-22554: Email error when registering a user

### DIFF
--- a/kernel/classes/datatypes/ezuser/ezusertype.php
+++ b/kernel/classes/datatypes/ezuser/ezusertype.php
@@ -250,6 +250,13 @@ class eZUserType extends eZDataType
         }
         else
         {
+            // No "draft" for version 1 to avoid regression for existing code creating new users.
+            if ( $contentObjectAttribute->attribute( 'version' ) == '1' )
+            {
+                $user->store();
+                $contentObjectAttribute->setContent( $user );
+            }
+
             // saving information in the object attribute data_text field to simulate a draft
             $contentObjectAttribute->setAttribute( 'data_text', $this->serializeDraft( $user ) );
         }


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-22554
## Description

In https://jira.ez.no/browse/EZP-21966 we introduced a way to have a single "draft" for ezusers (they were none before that). With this fix, ezusers were not filled up with login information until they are published. Sometimes, existing code, like the user/register, needs to access these information before the ezuser has been published.
In order to fix that, this patch disables the "draft" feature for the first version of the user.
##  Tests

Test on user register and sanity checks on user edit.
