### PR TITLE
Fix EZP-22915: Clearing caches fail if cache folder is symlinked

### DIFF
--- a/lib/ezfile/classes/ezdir.php
+++ b/lib/ezfile/classes/ezdir.php
@@ -268,9 +268,33 @@ class eZDir
         if ( !is_dir( $dir ) )
             return false;
 
-        // rootCheck is enabled and $dir is not part of the root directory
-        if ( $rootCheck && strpos( dirname( realpath( $dir ) ) . DIRECTORY_SEPARATOR, realpath( eZSys::rootDir() ) . DIRECTORY_SEPARATOR ) === false )
-            return false;
+        if ( $rootCheck )
+        {
+            // rootCheck is enabled, check if $dir is part of authorized directories
+            $allowedDirs = eZINI::instance()->variable( 'FileSettings', 'AllowedDeletionDirs' );
+            // Also adding eZ Publish root dir.
+            $rootDir = eZSys::rootDir() . DIRECTORY_SEPARATOR;
+            array_unshift( $allowedDirs, $rootDir );
+
+            $dirRealPath = dirname( realpath( $dir ) ) . DIRECTORY_SEPARATOR;
+            $canDelete = false;
+            foreach ( $allowedDirs as $allowedDir )
+            {
+                if ( strpos( $dirRealPath, realpath( $allowedDir ) ) === 0 )
+                {
+                    $canDelete = true;
+                    break;
+                }
+            }
+
+            if ( !$canDelete )
+            {
+                eZDebug::writeError(
+                    "Recursive delete denied for '$dir' as its realpath '$dirRealPath' is outside eZ Publish root and not registered in AllowedDeletionDirs."
+                );
+                return false;
+            }
+        }
 
         // the directory cannot be opened
         if ( ! ( $handle = @opendir( $dir ) ) )

--- a/settings/site.ini
+++ b/settings/site.ini
@@ -1004,6 +1004,12 @@ VarDir=var
 CacheDir=cache
 # The name of the log dir, it's a subdir of VarDir
 LogDir=log
+# Directories eZDir is allowed to delete from (see eZDir::recursiveDelete()).
+# By default, it is only possible to delete from inside eZ Publish root directory.
+# Directories listed will be added as authorized directory prefixes.
+# Values must be absolute paths.
+AllowedDeletionDirs[]
+#AllowedDeletionDirs[]=/var/share/somedir
 
 
 [TemplateSettings]


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-22915

In `eZDir::recursiveDelete()`, root check was added in c6c384545548a90c85f25d16352b06f2925f9a40 in order to fix [EZP-15823](https://jira.ez.no/browse/EZP-15823).
To be less restrictive, I added a new setting in `site.ini` allowing to specify which directory _outside_ eZ Publish root dir can be considered as a valid _path prefix_ for recursive deletion.
