### PR TITLE
Extracted eZDFSFileHandlerDFSBackendInterface

### DIFF
--- a/autoload/ezp_kernel.php
+++ b/autoload/ezp_kernel.php
@@ -120,7 +120,10 @@ return array(
       'eZDBSchemaInterface'                                => 'lib/ezdbschema/classes/ezdbschemainterface.php',
       'eZDBTool'                                           => 'lib/ezdb/classes/ezdbtool.php',
       'eZDFSFileHandler'                                   => 'kernel/private/classes/clusterfilehandlers/ezdfsfilehandler.php',
+      'eZDFSFileHandlerBackendException'                   => 'kernel/private/classes/clusterfilehandlers/dfsbackends/ezdfsfilehandlerbackendexception.php',
       'eZDFSFileHandlerDFSBackend'                         => 'kernel/private/classes/clusterfilehandlers/dfsbackends/dfs.php',
+      'eZDFSFileHandlerDFSBackendFilterIterator'           => 'kernel/private/classes/clusterfilehandlers/dfsbackends/dfs_filter_iterator.php',
+      'eZDFSFileHandlerDFSBackendInterface'                => 'kernel/private/classes/clusterfilehandlers/dfsbackends/ezdfsfilehandlerdfsbackendinterface.php',
       'eZDFSFileHandlerMySQLiBackend'                      => 'kernel/private/classes/clusterfilehandlers/dfsbackends/mysqli.php',
       'eZDFSFileHandlerNFSMountPointNotFoundException'     => 'kernel/private/classes/exceptions/cluster/mount_point_not_found.php',
       'eZDFSFileHandlerNFSMountPointNotWriteableException' => 'kernel/private/classes/exceptions/cluster/mount_point_not_writeable.php',
@@ -590,7 +593,6 @@ return array(
       'ezpContentSortingCriteria'                          => 'kernel/private/api/content/criteria/sorting.php',
       'ezpContentXHTMLRenderer'                            => 'kernel/private/rest/classes/renderers/xhtml_content_renderer.php',
       'ezpDatabaseBasedClusterFileHandler'                 => 'kernel/private/interfaces/ezpdatabasebasedclusterfilehandler.php',
-      'ezpDbMySQLiClusterGateway'                          => 'kernel/clustering/dbmysqli.php',
       'ezpDfsMySQLiClusterGateway'                         => 'kernel/clustering/dfsmysqli.php',
       'ezpEvent'                                           => 'kernel/private/classes/ezpevent.php',
       'ezpExtension'                                       => 'kernel/private/classes/ezpextension.php',
@@ -709,7 +711,7 @@ return array(
       'ezpTopologicalSortNode'                             => 'kernel/private/classes/ezptopologicalsortnode.php',
       'ezpUpdatedContent'                                  => 'kernel/private/rest/classes/sync/updates.php',
       'ezpUserNotFoundException'                           => 'kernel/private/rest/classes/exceptions/user_not_found.php',
-      'ezpWebBasedKernelHandler'                          => 'kernel/private/interfaces/ezpwebbasedkernelhandler.php',
+      'ezpWebBasedKernelHandler'                           => 'kernel/private/interfaces/ezpwebbasedkernelhandler.php',
     );
 
 ?>

--- a/kernel/private/classes/clusterfilehandlers/dfsbackends/dfs.php
+++ b/kernel/private/classes/clusterfilehandlers/dfsbackends/dfs.php
@@ -8,7 +8,7 @@
  * @package kernel
  */
 
-class eZDFSFileHandlerDFSBackend
+class eZDFSFileHandlerDFSBackend implements eZDFSFileHandlerDFSBackendInterface
 {
     public function __construct()
     {
@@ -33,6 +33,8 @@ class eZDFSFileHandlerDFSBackend
      *
      * @param string $srcFilePath Local source file path
      * @param string $dstFilePath Local destination file path
+     *
+     * @return bool
      */
     public function copyFromDFSToDFS( $srcFilePath, $dstFilePath )
     {
@@ -269,7 +271,20 @@ class eZDFSFileHandlerDFSBackend
      */
     public function existsOnDFS( $filePath )
     {
-        return file_exists( $this->makeDFSPath( $filePath ) );
+        if ( file_exists( $this->makeDFSPath( $filePath ) ) )
+        {
+            return true;
+        }
+
+        // Verify that mount point is still there
+        $filePathDir = substr( $filePath, 0, strpos( $filePath, '/' ) + 1 );
+        $path = realpath( $this->getMountPoint() ). '/' . $filePathDir;
+        if ( !file_exists( $path ) || !is_dir( $path ) )
+        {
+            throw new eZDFSFileHandlerBackendException( "NFS mount root $path not found" );
+        }
+
+        return false;
     }
 
     /**
@@ -277,7 +292,7 @@ class eZDFSFileHandlerDFSBackend
      *
      * @return string
      */
-    public function getMountPoint()
+    protected function getMountPoint()
     {
         return $this->mountPointPath;
     }
@@ -348,6 +363,27 @@ class eZDFSFileHandlerDFSBackend
     public function getDfsFileSize( $filePath )
     {
         return filesize( $this->makeDFSPath( $filePath ) );
+    }
+
+    /**
+     * Returns an iterator over the files within $basePath on the backend
+     *
+     * @param string $basePath a path relative to the mount point
+     *
+     * @return Iterator An iterator that returns a DFS File pathname as the value
+     */
+    public function getFilesList( $basePath )
+    {
+        // The custom iterator filters out the file path in order to get a relative one
+        return new eZDFSFileHandlerDFSBackendFilterIterator(
+            new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator(
+                    $this->mountPointPath . '/' . $basePath,
+                    FilesystemIterator::SKIP_DOTS|FilesystemIterator::UNIX_PATHS
+                )
+            ),
+            $this->mountPointPath
+        );
     }
 
     /**

--- a/kernel/private/classes/clusterfilehandlers/dfsbackends/dfs_filter_iterator.php
+++ b/kernel/private/classes/clusterfilehandlers/dfsbackends/dfs_filter_iterator.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * This file is part of the eZ Publish Legacy package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributd with this source code.
+ * @version //autogentag//
+ */
+
+/**
+ * A filter iterator used by eZDFSFileHandlerDFSBackend.
+ * It filters directories out, and converts the current() return value to a relative path to the file.
+ */
+class eZDFSFileHandlerDFSBackendFilterIterator extends FilterIterator
+{
+    /**
+     * @var string
+     */
+    private $prefix;
+
+    public function __construct( Iterator $iterator, $prefix )
+    {
+        parent::__construct( $iterator );
+        $this->prefix = $prefix;
+    }
+
+    /**
+     * Filters directories out
+     */
+    public function accept()
+    {
+        return $this->getInnerIterator()->current()->isFile();
+    }
+
+    /**
+     * Transforms the SplFileInfo in a simple relative path
+     *
+     * @return string The relative path to the current file
+     */
+    public function current()
+    {
+        /** @var SplFileInfo $file */
+        $file = $this->getInnerIterator()->current();
+        $filePathName = $file->getPathname();
+
+        // Trim prefix + 1 for leading /
+        return substr( $filePathName, strlen( $this->prefix ) + 1 );
+    }
+}

--- a/kernel/private/classes/clusterfilehandlers/dfsbackends/ezdfsfilehandlerbackendexception.php
+++ b/kernel/private/classes/clusterfilehandlers/dfsbackends/ezdfsfilehandlerbackendexception.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * This file is part of the eZ Publish Legacy package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributd with this source code.
+ * @version //autogentag//
+ */
+class eZDFSFileHandlerBackendException extends Exception
+{
+
+}

--- a/kernel/private/classes/clusterfilehandlers/dfsbackends/ezdfsfilehandlerdfsbackendinterface.php
+++ b/kernel/private/classes/clusterfilehandlers/dfsbackends/ezdfsfilehandlerdfsbackendinterface.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * This file is part of the eZ Publish Legacy package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+/**
+ * Interface for a DFS FS handler, that offers CRUD support for binary files.
+ *
+ * Implementations of this interface can be used by DFS database backends, such as eZDFSFileHandlerMySQLiBackend,
+ * to read/write to a binary file storage medium.
+ */
+interface eZDFSFileHandlerDFSBackendInterface
+{
+    /**
+     * Creates a copy of $srcFilePath from DFS to $dstFilePath on DFS
+     *
+     * @param string $srcFilePath Local source file path
+     * @param string $dstFilePath Local destination file path
+     *
+     * @return bool
+     */
+    public function copyFromDFSToDFS( $srcFilePath, $dstFilePath );
+
+    /**
+     * Copies the DFS file $srcFilePath to FS
+     *
+     * @param string $srcFilePath Source file path (on DFS)
+     * @param string $dstFilePath Destination file path (on FS). If not specified, $srcFilePath is used
+     *
+     * @return bool
+     */
+    public function copyFromDFS( $srcFilePath, $dstFilePath = false );
+
+    /**
+     * Copies the local file $filePath to DFS under the same name, or a new name
+     * if specified
+     *
+     * @param string $srcFilePath Local file path to copy from
+     * @param bool|string $dstFilePath Optional path to copy to. If not specified, $srcFilePath is used on DFS as well.
+     *
+     * @return bool
+     */
+    public function copyToDFS( $srcFilePath, $dstFilePath = false );
+
+    /**
+     * Deletes one or more files
+     *
+     * @param string|array $filePath Single local filename, or array of local filenames
+     *
+     * @return bool true if deletion was successful, false otherwise
+     * @todo Improve error handling using exceptions
+     */
+    public function delete( $filePath );
+
+    /**
+     * Sends the contents of $filePath to default output
+     *
+     * @param string $filePath File path
+     * @param int $startOffset Starting offset
+     * @param bool|int $length Length to transmit, false means everything
+     *
+     * @return bool true, or false if operation failed
+     */
+    public function passthrough( $filePath, $startOffset = 0, $length = false );
+
+    /**
+     * Returns the content of $filePath
+     *
+     * @param string $filePath file path
+     *
+     * @return string|bool file's content, or false
+     * @todo Handle errors using exceptions
+     */
+    public function getContents( $filePath );
+
+    /**
+     * Creates $filePath with $contents
+     *
+     * @param string $filePath
+     * @param string $contents
+     *
+     * @return bool
+     */
+    public function createFileOnDFS( $filePath, $contents );
+
+    /**
+     * Renames $oldPath to $newPath
+     *
+     * @param string $oldPath
+     * @param string $newPath
+     *
+     * @return bool
+     */
+    public function renameOnDFS( $oldPath, $newPath );
+
+    /**
+     * Checks if a file exists on the DFS
+     *
+     * @param string $filePath
+     *
+     * @return bool
+     */
+    public function existsOnDFS( $filePath );
+
+    /**
+     * Returns the size in bytes of $filePath
+     *
+     * @param string $filePath
+     *
+     * @return int
+     */
+    public function getDfsFileSize( $filePath );
+
+    /**
+     * Returns an iterator over the files within $basePath on the backend
+     *
+     * @param string $basePath a path relative to the mount point
+     *
+     * @return Iterator An iterator that returns a DFS File pathname as the value
+     */
+    public function getFilesList( $basePath );
+}

--- a/kernel/private/classes/clusterfilehandlers/dfsbackends/mysqli.php
+++ b/kernel/private/classes/clusterfilehandlers/dfsbackends/mysqli.php
@@ -1961,7 +1961,7 @@ class eZDFSFileHandlerMySQLiBackend implements eZClusterEventNotifier
 
     /**
      * Distributed filesystem backend
-     * @var eZDFSFileHandlerDFSBackend
+     * @var eZDFSFileHandlerDFSBackendInterface
      */
     protected $dfsbackend = null;
 


### PR DESCRIPTION
> Implements [EZP-22966](https://jira.ez.no/browse/EZP-22966)

Adds an `eZDFSFileHandlerDFSBackendInterface`, implemented by the existing `eZDFSFileHandlerDFSBackend`.

Also changed `dfscleanup.php` so that it is backend independent!
- added a new `getFilesList()` method that lists files from a backend
- moved DFS sanity check within the backend, and use exception handling to detect that NFS isn't available anymore
