### PR TITLE
Fix EZP-22923: ezcontentobject_link table not cleared when a relations a...

### DIFF
--- a/kernel/classes/datatypes/ezobjectrelation/ezobjectrelationtype.php
+++ b/kernel/classes/datatypes/ezobjectrelation/ezobjectrelationtype.php
@@ -393,6 +393,11 @@ class eZObjectRelationType extends eZDataType
                       'fuzzy_match' => $fuzzyMatch );
     }
 
+    function deleteNotVersionedStoredClassAttribute( eZContentClassAttribute $classAttribute )
+    {
+        eZContentObjectAttribute::removeRelationsByContentClassAttributeId( $classAttribute->attribute( 'id' ) );
+    }
+
     function customClassAttributeHTTPAction( $http, $action, $classAttribute )
     {
         switch ( $action )

--- a/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
+++ b/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
@@ -833,6 +833,11 @@ class eZObjectRelationListType extends eZDataType
         }
     }
 
+    function deleteNotVersionedStoredClassAttribute( eZContentClassAttribute $classAttribute )
+    {
+        eZContentObjectAttribute::removeRelationsByContentClassAttributeId( $classAttribute->attribute( 'id' ) );
+    }
+
     function customObjectAttributeHTTPAction( $http, $action, $contentObjectAttribute, $parameters )
     {
         $contentobjectID = false;

--- a/kernel/classes/ezcontentclassattribute.php
+++ b/kernel/classes/ezcontentclassattribute.php
@@ -523,6 +523,9 @@ class eZContentClassAttribute extends eZPersistentObject
                                            $down );
     }
 
+    /**
+     * @return eZDataType
+     */
     function dataType()
     {
         return eZDataType::create( $this->DataTypeString );

--- a/kernel/classes/ezcontentclassedithandler.php
+++ b/kernel/classes/ezcontentclassedithandler.php
@@ -27,6 +27,7 @@ class eZContentClassEditHandler
         // Delete object attributes which have been removed.
         foreach ( $oldClassAttributes as $oldClassAttribute )
         {
+            /** @var eZContentClassAttribute $oldClassAttribute */
             $attributeExists = false;
             $oldClassAttributeID = $oldClassAttribute->attribute( 'id' );
             foreach ( $class->fetchAttributes( ) as $newClassAttribute )
@@ -43,6 +44,8 @@ class eZContentClassEditHandler
                 {
                     $objectAttribute->removeThis( $objectAttribute->attribute( 'id' ) );
                 }
+
+                $oldClassAttribute->datatype()->deleteNotVersionedStoredClassAttribute( $oldClassAttribute );
             }
         }
         $class->storeDefined( $attributes );

--- a/kernel/classes/ezcontentobjectattribute.php
+++ b/kernel/classes/ezcontentobjectattribute.php
@@ -1452,6 +1452,17 @@ class eZContentObjectAttribute extends eZPersistentObject
         return false;
     }
 
+    /**
+     * Removes all links for a given Class Attribute Id.
+     * @param int $attributeId
+     */
+    public static function removeRelationsByContentClassAttributeId( $attributeId )
+    {
+        $id = (int)$attributeId;
+        $db = eZDB::instance();
+        $db->query( "DELETE FROM ezcontentobject_link WHERE contentclassattribute_id=$id" );
+    }
+
     /// Contains the value(s) submitted in HTTP form
     public $HTTPValue;
 

--- a/kernel/classes/ezdatatype.php
+++ b/kernel/classes/ezdatatype.php
@@ -942,6 +942,16 @@ class eZDataType
     }
 
     /**
+     * Clean up stored class attribute for content class that is not versioned.
+     * Note: Default implementation does nothing
+     *
+     * @param eZContentClassAttribute $classAttribute
+     */
+    function deleteNotVersionedStoredClassAttribute( eZContentClassAttribute $classAttribute )
+    {
+    }
+
+    /**
      * Return content action(s) which can be performed on object containing
      * the current datatype. Return format is array of arrays with key 'name'
      * and 'action'. 'action' can be mapped to url in datatype.ini


### PR DESCRIPTION
...ttribute is deleted from a class

Link: https://jira.ez.no/browse/EZP-22923
## Description

When removing a relation list or a relation object attribute from a content class, lines were not cleared in the ezcontentobject_link table.
## Tests

Manual test and basic sanity checks
