### PR TITLE
EZP-22982: Allow $phpSelf to be identical to $index

### DIFF
--- a/lib/ezutils/classes/ezsys.php
+++ b/lib/ezutils/classes/ezsys.php
@@ -1214,7 +1214,7 @@ class eZSys
             return null;
 
         // optimize '/index.php' pattern
-        if ( $phpSelf === "/{$index}" )
+        if ( $phpSelf === $index || $phpSelf === "/{$index}" )
             return '';
 
         $phpSelfParts = explode( $index, $phpSelf );


### PR DESCRIPTION
With display_errors set to `E_ALL` and nginx, the content tree menu isn't shown in the backend (only the "Internal error" message).

Calling the requested url directly (/content/treemenu/2/....) reveals a JSON encoded PHP notice:

```
Warning: strpos(): Empty needle in /var/www/ezpublish/ezpublish_legacy/lib/ezutils/classes/ezsys.php line 1231"
```

This is a very simple patch - I first worked with a regular expression but didn't want to overcomplicate the code as it is more readable like this.

Cheers
:octocat: Jérôme
