### PR TITLE
EZP-22546: Fixing file uploads with the ezpRelationListAjaxUploader

### DIFF
--- a/kernel/classes/ezcontentupload.php
+++ b/kernel/classes/ezcontentupload.php
@@ -425,6 +425,17 @@ class eZContentUpload
         if ( $storeResult['require_storage'] )
             $dataMap[$nameAttribute]->store();
 
+        if ( is_array( $parentNodes ) )
+        {
+            foreach ( $parentNodes as $parentNode )
+            {
+                $object->createNodeAssignment(
+                    $parentNode,
+                    $parentNode == $parentMainNode
+                );
+            }
+        }
+
         return $this->publishObject( $result, $result['errors'], $result['notices'],
                                      $object, $publishVersion, $class, $parentNodes, $parentMainNode );
     }


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-22546

With [EZP-22480](https://jira.ez.no/browse/EZP-22480)/https://github.com/ezsystems/ezpublish-legacy/commit/b6f895ed1b790039f623d1476c8ffaecc6961080, the creation of node assignments between an uploaded file and the parent node has been extracted from the `publishObject` method to the `handleUpload()` method.

In the same class, the `handleLocalFile()` method also calls the `publishObject()` method, but doesn't add the node assignments part. This causes the relation list Uploader to break when uploading a file directly in to an object relation list from a node.

With the patch proposed in this PR, the node assignments parts is added to the `handleLocalFile()` method, similarly to the `handleUpload()` method.

Cheers
:octocat: Jérôme
