### PR TITLE
Unneeded param in window.ScrollTo call in admin interface class edit tem...

### DIFF
--- a/design/admin/templates/class/edit.tpl
+++ b/design/admin/templates/class/edit.tpl
@@ -343,7 +343,7 @@ jQuery(function( $ )//called on document.ready
 {
     var el = $('#LastChangedID input[name^=ContentAttribute_name]');
     if ( el.size() ) {
-        window.scrollTo(0, Math.max( el.offset().top - 180, 0 ));
+        window.scrollTo(0, Math.max( el.offset().top - 180 ));
         el.focus();
     }
 


### PR DESCRIPTION
...plate

This is an almost identical case to which we had in https://jira.ez.no/browse/EZP-22755 and that's the reason why i'm not adding another issue now. 

The problem is we're passing three params to window.scrollTo method but that method only accepts two. 

We already merged a smilar commit https://github.com/ezsystems/ezpublish-legacy/pull/946

Please, let me know if you still need another issue for that or is this is enough
