### PR TITLE
Removed obsolete deprecated method eZExpiryHandler::registerShutdownFunction();

### DIFF
--- a/templates/classcreatelist.ctpl
+++ b/templates/classcreatelist.ctpl
@@ -82,7 +82,6 @@
         if ( $enableCaching )
         {
             $http = eZHTTPTool::instance();
-            eZExpiryHandler::registerShutdownFunction();
             $handler = eZExpiryHandler::instance();
             $expiredTimeStamp = 0;
             if ( $handler->hasTimestamp( 'user-class-cache' ) )


### PR DESCRIPTION
I don't even know if the ctpl files are still used, but: [deprecated and obsolete](https://github.com/ezsystems/ezpublish-legacy/pull/955) is deprecated and obsolete :).

Cheers
:octocat: Jérôme
