### PR TITLE
Fix EZP-22937: Unable to get the width of a table pasted from Excel

### DIFF
--- a/extension/ezoe/design/standard/javascript/ezoe/popup_utils.js
+++ b/extension/ezoe/design/standard/javascript/ezoe/popup_utils.js
@@ -603,12 +603,16 @@ var eZOEPopupUtils = {
         };
         jQuery( '#' + node + ' input,#' + node + ' select' ).each(function( i, el )
         {
-            var o = jQuery( el ), name = el.name;
+            var o = jQuery( el ), name = el.name, v;
             if ( o.hasClass('mceItemSkip') ) return;
             if ( name === 'class' )
-                var v = jQuery.trim( cssReplace( editorElement.className ) );
-            else 
-                var v = tinyMCEPopup.editor.dom.getAttrib( editorElement, name );//editorElement.getAttribute( name );
+                v = jQuery.trim( cssReplace( editorElement.className ) );
+            else {
+                v = tinyMCEPopup.editor.dom.getAttrib( editorElement, name );
+                if ( !v && tinymce.DOM.getAttrib(editorElement, 'style') && editorElement.style[name.toLowerCase()]  ) {
+                    v = editorElement.style[name.toLowerCase()];
+                }
+            }
             if ( v !== false && v !== null && v !== undefined )
             {
                 if ( handler[el.id] !== undefined && handler[el.id].call !== undefined )


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-22937
# Description

The width of a table pasted from Excel is not correctly retrieved when the editor wants to edit the property of the table. This is happening because in this case the width is set with a CSS rule in the style attribute of the table while the popup_utils.js code only reads the `width` attribute.

This patch changes popup_utils.js so that the style rules in the `style` attribute are also taken into account.
# Tests

manual test
