### PR TITLE
Fix EZP-22615: Not possible to remove an image from an object

### DIFF
--- a/kernel/classes/datatypes/ezimage/ezimagetype.php
+++ b/kernel/classes/datatypes/ezimage/ezimagetype.php
@@ -298,11 +298,9 @@ class eZImageType extends eZDataType
 
         }
 
-        if ( $content )
+        if ( $result && $hasImageAltText )
         {
-            if ( $hasImageAltText )
-                $content->setAttribute( 'alternative_text', $imageAltText );
-            $result = true;
+            $content->setAttribute( 'alternative_text', $imageAltText );
         }
 
         return $result;


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-22615
## Description

When an image is removed:
- aliases are deleted
- contentobject's data_text is updated with a a xml with no images.

The problem was that the list of attribute was loaded in the beginning of attribute_edit.php:
https://github.com/ezsystems/ezpublish-legacy/blob/master/kernel/content/attribute_edit.php#L55

Then attributes are fetched:
https://github.com/ezsystems/ezpublish-legacy/blob/master/kernel/content/attribute_edit.php#L288

During the fetch, when we are deleting, objectattribute's content is modified:
https://github.com/ezsystems/ezpublish-legacy/blob/master/kernel/classes/datatypes/ezimage/ezimagetype.php#L478

This ends up triggering the method updated by this patch to know if the attribute needs to be stored. This method was always returning true making the attribute being stored with it's old value.
## Test

Manual tests
## TODO
- [x] See what travis thinks about it
