### PR TITLE
Implemented: EZP-23045: In the admin interface: make it possible to sort by visibility

### DIFF
--- a/design/admin/javascript/ezajaxsubitems_datatable.js
+++ b/design/admin/javascript/ezajaxsubitems_datatable.js
@@ -110,7 +110,7 @@ var sortableSubitems = function () {
             {key:"crank", label:"", sortable:false, formatter:customMenu, resizeable:false},
             {key:"thumbnail", label:labelsObj.DATA_TABLE_COLS.thumbnail, sortable:false, formatter:thumbView, resizeable:false},
             {key:"name", label:labelsObj.DATA_TABLE_COLS.name, sortable:true, resizeable:true, formatter:formatName},
-            {key:"hidden_status_string", label: labelsObj.DATA_TABLE_COLS.visibility, sortable:false, resizeable:true},
+            {key:"hidden_status_string", label: labelsObj.DATA_TABLE_COLS.visibility, sortable:true, resizeable:true},
             {key:"class_name", label:labelsObj.DATA_TABLE_COLS.type, sortable:true, resizeable:true},
             {key:"creator", label:labelsObj.DATA_TABLE_COLS.modifier, sortable:false, resizeable:true},
             {key:"modified_date", label:labelsObj.DATA_TABLE_COLS.modified, sortable:true, resizeable:true},

--- a/extension/ezjscore/classes/ezjscserverfunctionsnode.php
+++ b/extension/ezjscore/classes/ezjscserverfunctionsnode.php
@@ -234,6 +234,9 @@ class ezjscServerFunctionsNode extends ezjscServerFunctions
             case 'published_date':
                 $sortKey = 'published';
                 break;
+            case 'hidden_status_string':
+                $sortKey = 'visibility';
+                break;
             default:
                 $sortKey = $sort;
         }

--- a/kernel/classes/ezcontentobjecttreenode.php
+++ b/kernel/classes/ezcontentobjecttreenode.php
@@ -27,6 +27,7 @@ class eZContentObjectTreeNode extends eZPersistentObject
     const SORT_FIELD_MODIFIED_SUBNODE = 10;
     const SORT_FIELD_NODE_ID = 11;
     const SORT_FIELD_CONTENTOBJECT_ID = 12;
+    const SORT_FIELD_VISIBILITY = 13;
 
     const SORT_ORDER_DESC = 0;
     const SORT_ORDER_ASC = 1;
@@ -642,6 +643,10 @@ class eZContentObjectTreeNode extends eZPersistentObject
                         case 'priority':
                         {
                             $sortingFields .= $treeTableName . '.priority';
+                        } break;
+                        case 'visibility':
+                        {
+                            $sortingFields .= $treeTableName . '.is_invisible';
                         } break;
                         case 'name':
                         {
@@ -2718,6 +2723,8 @@ class eZContentObjectTreeNode extends eZPersistentObject
                 return 'node_id';
             case self::SORT_FIELD_CONTENTOBJECT_ID:
                 return 'contentobject_id';
+            case self::SORT_FIELD_VISIBILITY:
+                return 'is_invisible';
         }
     }
 
@@ -2755,6 +2762,8 @@ class eZContentObjectTreeNode extends eZPersistentObject
                 return self::SORT_FIELD_NODE_ID;
             case 'contentobject_id':
                 return self::SORT_FIELD_CONTENTOBJECT_ID;
+            case 'is_invisible':
+                return self::SORT_FIELD_VISIBILITY;
         }
     }
 


### PR DESCRIPTION
Issue link: https://jira.ez.no/browse/EZP-23045

When there is a lot of children under a specific content (object), not being able to sort by visibility makes it a bit difficult to quickly see which one are hidden for example, or perform bulk operations (like remove) on those: one has to click on every page from the google-like navigator to discover them.
With visibility sorting, it makes it a bit easier.
