### PR TITLE
Fix EZP-23028: eZObjectRelationList not considering the selected object

### DIFF
--- a/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
+++ b/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
@@ -69,6 +69,15 @@ class eZObjectRelationListType extends eZDataType
             }
             return eZInputValidator::STATE_ACCEPTED;
         }
+        else
+        {
+            // If in browse mode and relations have been added using the search field
+            // items are stored in the post variable
+            if ( count( $http->postVariable( $postVariableName ) ) > 0  )
+            {
+                return eZInputValidator::STATE_ACCEPTED;
+            }
+        }
 
         // The following code is only there for the support of [BackwardCompatibilitySettings]/AdvancedObjectRelationList
         // which happens only when $classContent['selection_type'] == 0


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-23028
## Description

When adding an item to a relation list using the searchbox, an error message was displayed. This was happening because the validation function only checked for items in database (the way they are set in browse mode) and not in `$POST`.
This patch makes the validate method accept items from the searchbox by looking into `$POST`.
## Tests

Manual tests
