### PR TITLE
Fix EZP-22915: do not use $rootCheck when clearing global ini cache

### DIFF
--- a/kernel/classes/ezcache.php
+++ b/kernel/classes/ezcache.php
@@ -720,7 +720,7 @@ class eZCache
      */
     static function clearGlobalINICache( $cacheItem )
     {
-        eZDir::recursiveDelete( $cacheItem['path'] );
+        eZDir::recursiveDelete( $cacheItem['path'], false );
     }
 
     /**


### PR DESCRIPTION
49583e15 introduced an "egg or chicken" dilemma : when you use ezcache.php to clear the global ini cache, eZDir::recursiveDelete() will read the old settings from the cache, and may disallow you to clear the cache if your old settings disallow it.

https://jira.ez.no/browse/EZP-22915
PR: #981
