### PR TITLE
EZP-23031: allow large file sizes on DFS without memory limitation.

### DIFF
--- a/kernel/private/classes/clusterfilehandlers/dfsbackends/dfs.php
+++ b/kernel/private/classes/clusterfilehandlers/dfsbackends/dfs.php
@@ -58,7 +58,7 @@ class eZDFSFileHandlerDFSBackend implements eZDFSFileHandlerDFSBackendInterface
         }
         else
         {
-            $ret = $this->createFile( $dstFilePath, file_get_contents( $srcFilePath ), false );
+            $ret = $this->createFile( $dstFilePath, fopen( $srcFilePath, 'rb' ), false );
         }
 
         $this->accumulatorStop();
@@ -92,7 +92,7 @@ class eZDFSFileHandlerDFSBackend implements eZDFSFileHandlerDFSBackendInterface
         }
         else
         {
-            $ret = $this->createFile( $dstFilePath, file_get_contents( $srcFilePath ) );
+            $ret = $this->createFile( $dstFilePath, fopen( $srcFilePath, 'rb' ) );
         }
 
         if ( $ret )
@@ -118,8 +118,9 @@ class eZDFSFileHandlerDFSBackend implements eZDFSFileHandlerDFSBackendInterface
     {
         $this->accumulatorStart();
 
-        $srcFileContents = file_get_contents( $srcFilePath );
-        if ( $srcFileContents === false )
+        $srcFileSize = filesize( $srcFilePath );
+        $srcFileHandle = fopen( $srcFilePath, 'rb' );
+        if ( $srcFileHandle === false )
         {
             $this->accumulatorStop();
             eZDebug::writeError( "Error getting contents of file 'FS://$srcFilePath'.", __METHOD__ );
@@ -132,17 +133,16 @@ class eZDFSFileHandlerDFSBackend implements eZDFSFileHandlerDFSBackendInterface
         }
 
         $dstFilePath = $this->makeDFSPath( $dstFilePath );
-        $ret = $this->createFile( $dstFilePath, $srcFileContents, true );
+        $ret = $this->createFile( $dstFilePath, $srcFileHandle, true );
         if ( $ret )
         {
             // Double checking if the file has been correctly created
-            $srcFileSize = strlen( $srcFileContents );
             clearstatcache( true, $dstFilePath );
             $dstFileSize = filesize( $dstFilePath );
             if ( $dstFileSize != $srcFileSize )
             {
                 eZDebug::writeError( "Size ($dstFileSize) of written data for file FS://$dstFilePath does not match expected size of original DFS file ($srcFileSize)", __METHOD__ );
-                return false;
+                $ret = false;
             }
         }
 

--- a/lib/ezfile/classes/ezfile.php
+++ b/lib/ezfile/classes/ezfile.php
@@ -66,7 +66,19 @@ class eZFile
         {
 //             eZDebugSetting::writeNotice( 'ezfile-create', "Created file $filepath", 'eZFile::create' );
             if ( $data )
-                fwrite( $file, $data );
+            {
+                if ( is_resource( $data ) )
+                {
+                    // block-copy source $data to new $file in 1MB chunks
+                    while ( !feof( $data ) )
+                    {
+                        fwrite( $file, fread( $data, 1048576 ) );
+                    }
+                    fclose( $data );
+                }
+                else
+                    fwrite( $file, $data );
+            }
             fclose( $file );
 
             if ( $atomic )


### PR DESCRIPTION
This updates `eZFile::createFile()` so it can accept either a string or file resource as `$data` parameter.
dfs.php is updated accordingly, creating a handle using fopen() instead of passing the whole content with `file_get_contents()`.

The validity check for `$contents` in `createFile()` also applies to the handle in the same way.