### PR TITLE
Fix EZP-22915: allow a list of extra directories to be deleted by eZDir::recursiveDelete()

### DIFF
--- a/config.php-RECOMMENDED
+++ b/config.php-RECOMMENDED
@@ -294,5 +294,12 @@
  */
 // define( 'CUSTOM_LOG_ROTATE_FILES', 3 );
 
+/**
+ * Extra directories eZDir is allowed to delete from (see eZDir::recursiveDelete()).
+ * By default, it is only possible to delete from inside eZ Publish root directory.
+ * Directories listed will be added as authorized directory prefixes.
+ * Values must be absolute paths, semicolon seperated.
+ */
+// define( 'EXTRA_ALLOWED_DELETION_DIRS', '/var/share/somedir/var/ini;/var/share/somedir/var/cache' );
 
 ?>

--- a/lib/ezfile/classes/ezdir.php
+++ b/lib/ezfile/classes/ezdir.php
@@ -275,6 +275,12 @@ class eZDir
         {
             // rootCheck is enabled, check if $dir is part of authorized directories
             $allowedDirs = eZINI::instance()->variable( 'FileSettings', 'AllowedDeletionDirs' );
+            if ( defined( 'EXTRA_ALLOWED_DELETION_DIRS' ) )
+            {
+                $extraAllowedDirs = explode( ';', EXTRA_ALLOWED_DELETION_DIRS );
+                $allowedDirs = array_merge( $extraAllowedDirs, $allowedDirs );
+            }
+
             // Also adding eZ Publish root dir.
             $rootDir = eZSys::rootDir() . DIRECTORY_SEPARATOR;
             array_unshift( $allowedDirs, $rootDir );

--- a/settings/site.ini
+++ b/settings/site.ini
@@ -1011,6 +1011,7 @@ LogDir=log
 # By default, it is only possible to delete from inside eZ Publish root directory.
 # Directories listed will be added as authorized directory prefixes.
 # Values must be absolute paths.
+# DEPRECATED in favor of config.ini/EXTRA_ALLOWED_DELETION_DIRS
 AllowedDeletionDirs[]
 #AllowedDeletionDirs[]=/var/share/somedir
 


### PR DESCRIPTION
Alternative solution, related to #1004.

49583e1 introduced an "egg or chicken" dilemma : when you use ezcache.php to clear the global ini cache, `eZDir::recursiveDelete()` will read the old settings from the cache, and may disallow you to clear the cache if your old settings disallow it.

https://jira.ez.no/browse/EZP-22915
PR: #981
