### PR TITLE
Fix EZP-23073: blank screen given when you select an option in the browse list of objects

### DIFF
--- a/extension/ezoe/design/standard/templates/ezoe/customattributes/link.tpl
+++ b/extension/ezoe/design/standard/templates/ezoe/customattributes/link.tpl
@@ -197,6 +197,7 @@ var ezoeLinkAttribute = {
         jQuery('div.panel').hide();
         jQuery('div.link-dialog').show();
         jQuery('div.link-dialog input[type=text]:first').focus();
+        jQuery('div.panel.current').show();
     }
 };
 


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-23073

There is a problem using the customtag functionality.

Steps to reproduce:
1. Create a new customtag that has "link" attribute.
2. Click on the folder to browse for the  object to link to.
3. Select a node clicking the radio button.
4. ERROR: you get a blank screen.

This pull request fixes blank screen given when you select an option in the browse list.
