### PR TITLE
Fix EZP-23071: duplicate jquery inclusions break jquery plugins

### DIFF
--- a/extension/ezjscore/autoloads/ezjscpackertemplatefunctions.php
+++ b/extension/ezjscore/autoloads/ezjscpackertemplatefunctions.php
@@ -205,7 +205,7 @@ class ezjscPackerTemplateFunctions
             {
                 if ( !isset( self::$loaded['js_files'] ) )
                 {
-                    self::setPersistentArray( 'js_files', self::flattenArray( $namedParameters['script_array'] ), $tpl, true );
+                    self::setPersistentArray( 'js_files', self::flattenArray( $namedParameters['script_array'] ), $tpl, true, true );
                     break;
                 }// let 'ezscript' handle loaded calls
                 elseif ( $operatorName === 'ezscript_require' )


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-23071

When f.e. a page using ezie edit attribute is rendered, there are multiple jquery inclusions, one of them at the bottom of the javascript list.
This causes the jquery plugin (that extends `$.fn` with new function(s)) to be ignored.

Fix by making sure there are no duplicate scripts in ezjscore's javascript tag output.
