### PR TITLE
EZP-23074: ezjscore - cleanup and move jquery plugin code into template.

### DIFF
--- a/extension/ezjscore/classes/ezjscserverfunctionsjs.php
+++ b/extension/ezjscore/classes/ezjscserverfunctionsjs.php
@@ -154,102 +154,9 @@ class ezjscServerFunctionsJs extends ezjscServerFunctions
     public static function yui3io( $args )
     {
         $rootUrl = self::getIndexDir();
-        return "
-YUI( YUI3_config ).add('io-ez', function( Y )
-{
-    var _rootUrl = '$rootUrl', _serverUrl = _rootUrl + 'ezjscore/', _seperator = '@SEPERATOR$', _configBak,
-        _prefUrl = _rootUrl + 'user/preferences';
-
-    // (static) Y.io.ez() uses Y.io()
-    //
-    // @param string callArgs
-    // @param object|undefined c Same format as second parameter of Y.io()
-    function _ez( callArgs, c )
-    {
-        callArgs = callArgs.join !== undefined ? callArgs.join( _seperator ) : callArgs;
-        var url = _serverUrl + 'call/';
-
-        // Merge configuration object
-        if ( c === undefined )
-            c = {on:{}, data: '', headers: {}, method: 'POST'};
-        else
-            c = Y.merge( {on:{}, data: '', headers: {}, method: 'POST'}, c );
-
-        var _token = '', _tokenNode = document.getElementById('ezxform_token_js');
-        if ( _tokenNode ) _token = '&ezxform_token=' + _tokenNode.getAttribute('title');
-
-        // Append function arguments as post param if method is POST
-        if ( c.method === 'POST' )
-            c.data += ( c.data ? '&' : '' ) + 'ezjscServer_function_arguments=' + callArgs + _token;
-        else
-            url += encodeURIComponent( callArgs );
-
-        // force json transport
-        c.headers.Accept = 'application/json,text/javascript,*/*';
-
-        // backup user success call
-        if ( c.on.success !== undefined )
-            c.on.successCallback = c.on.success;
-
-        c.on.success = _ioezSuccess;
-        _configBak = c;
-
-        return Y.io( url, c );
-    }
-
-    function _ioezSuccess( id, o )
-    {
-        if ( o.responseJSON === undefined )
-        {
-            // create new object to avoid error in ie6 (and do not use Y.merge since it fails in ff)
-            var returnObject = {'responseJSON': Y.JSON.parse( o.responseText ),
-                                'readyState': o.readyState,
-                                'responseText': o.responseText,
-                                'responseXML': o.responseXML,
-                                'status': o.status,
-                                'statusText': o.statusText
-            };
-        }
-        else
-        {
-            var returnObject = o;
-        }
-
-        var c = _configBak;
-        if ( c.on.successCallback !== undefined )
-        {
-            if ( c.arguments !== undefined )
-                c.on.successCallback( id, returnObject, c.arguments );
-            else
-                c.on.successCallback( id, returnObject, null );
-        }
-        else if ( window.console !== undefined )
-        {
-            if ( returnObject.responseJSON.error_text )
-                window.console.error( 'Y.ez(): ' + returnObject.responseJSON.error_text );
-            else
-                window.console.log( 'Y.ez(): ' + returnObject.responseJSON.content );
-        }
-        _configBak.on.success = _configBak.on.successCallback;
-        _configBak.on.successCallback = undefined;
-    }
-
-    _ez.url = _serverUrl;
-    _ez.root_url = _rootUrl;
-    _ez.seperator = _seperator;
-    Y.io.ez = _ez;
-    Y.io.ez.setPreference = function( name, value )
-    {
-        var c = {on:{}, data:'', headers: {}, method: 'POST'},
-            _tokenNode = document.getElementById( 'ezxform_token_js' );
-
-        c.data = 'Function=set_and_exit&Key=' + encodeURIComponent( name ) + '&Value=' + encodeURIComponent( value );
-        if ( _tokenNode )
-            c.data += '&ezxform_token=' + _tokenNode.getAttribute( 'title' );
-        return Y.io( _prefUrl, c );
-    }
-}, '3.0.0' ,{requires:['io-base', 'json-parse']});
-        ";
+        $tpl = eZTemplate::factory();
+        $tpl->setVariable( 'rootUrl', $rootUrl );
+        return $tpl->fetch( 'design:ezjscore/ezjsc_yui.tpl' );
     }
 
     /**
@@ -307,80 +214,9 @@ YUI( YUI3_config ).add('io-ez', function( Y )
     public static function jqueryio( $args )
     {
         $rootUrl = self::getIndexDir();
-        return "
-(function($) {
-    var _rootUrl = '$rootUrl', _serverUrl = _rootUrl + 'ezjscore/', _seperator = '@SEPERATOR$',
-        _prefUrl = _rootUrl + 'user/preferences';
-
-    // FIX: Ajax is broken on IE8 / IE7 on jQuery 1.4.x as it's trying to use the broken window.XMLHttpRequest object
-    if ( window.XMLHttpRequest && window.ActiveXObject )
-        $.ajaxSettings.xhr = function() { try { return new window.ActiveXObject('Microsoft.XMLHTTP'); } catch(e) {} };
-
-    // (static) jQuery.ez() uses jQuery.post() (Or jQuery.get() if post paramer is false)
-    //
-    // @param string callArgs
-    // @param object|array|string|false post Optional post values, uses get request if false or undefined
-    // @param function Optional callBack
-    function _ez( callArgs, post, callBack )
-    {
-        callArgs = callArgs.join !== undefined ? callArgs.join( _seperator ) : callArgs;
-        var url = _serverUrl + 'call/';
-        if ( post )
-        {
-            var _token = '', _tokenNode = document.getElementById('ezxform_token_js');
-            if ( _tokenNode ) _token = _tokenNode.getAttribute('title');
-            if ( post.join !== undefined )// support serializeArray() format
-            {
-                post.push( { 'name': 'ezjscServer_function_arguments', 'value': callArgs } );
-                post.push( { 'name': 'ezxform_token', 'value': _token } );
-            }
-            else if ( typeof(post) === 'string' )// string
-            {
-                post += ( post ? '&' : '' ) + 'ezjscServer_function_arguments=' + callArgs + '&ezxform_token=' + _token;
-            }
-            else // object
-            {
-                post['ezjscServer_function_arguments'] = callArgs;
-                post['ezxform_token'] = _token;
-            }
-            return $.post( url, post, callBack, 'json' );
-        }
-        return $.get( url + encodeURIComponent( callArgs ), {}, callBack, 'json' );
-    };
-    _ez.url = _serverUrl;
-    _ez.root_url = _rootUrl;
-    _ez.seperator = _seperator;
-    $.ez = _ez;
-
-    $.ez.setPreference = function( name, value )
-    {
-        var param = {'Function': 'set_and_exit', 'Key': name, 'Value': value};
-            _tokenNode = document.getElementById( 'ezxform_token_js' );
-        if ( _tokenNode )
-            param.ezxform_token = _tokenNode.getAttribute( 'title' );
-
-        return $.post( _prefUrl, param );
-    };
-
-    // Method version, for loading response into elements
-    // NB: Does not use json (not possible with .load), so ezjscore/call will return string
-    function _ezLoad( callArgs, post, selector, callBack )
-    {
-        callArgs = callArgs.join !== undefined ? callArgs.join( _seperator ) : callArgs;
-        var url = _serverUrl + 'call/';
-        if ( post )
-        {
-            post['ezjscServer_function_arguments'] = callArgs;
-            post['ezxform_token'] = jQuery('#ezxform_token_js').attr('title');
-        }
-        else
-            url += encodeURIComponent( callArgs );
-
-        return this.load( url + ( selector ? ' ' + selector : '' ), post, callBack );
-    };
-    $.fn.ez = _ezLoad;
-})(jQuery);
-        ";
+        $tpl = eZTemplate::factory();
+        $tpl->setVariable( 'rootUrl', $rootUrl );
+        return $tpl->fetch( 'design:ezjscore/ezjsc_jquery.tpl' );
     }
 
     /**

--- a/extension/ezjscore/design/standard/templates/ezjscore/ezjsc_jquery.tpl
+++ b/extension/ezjscore/design/standard/templates/ezjscore/ezjsc_jquery.tpl
@@ -1,0 +1,79 @@
+{literal}
+(function($) {
+    var _rootUrl = '{/literal}{$rootUrl}{literal}',
+        _serverUrl = _rootUrl + 'ezjscore/',
+        _seperator = '@SEPERATOR$',
+        _prefUrl = _rootUrl + 'user/preferences',
+        _formToken = $('#ezxform_token_js').attr('title') || '';
+
+    // FIX: Ajax is broken on IE8 / IE7 on jQuery 1.4.x as it's trying to use the broken window.XMLHttpRequest object
+    if ( window.XMLHttpRequest && window.ActiveXObject )
+        $.ajaxSettings.xhr = function() { try { return new window.ActiveXObject('Microsoft.XMLHTTP'); } catch(e) {} };
+
+    // (static) jQuery.ez() uses jQuery.post() (Or jQuery.get() if post paramer is false)
+    //
+    // @param string callArgs
+    // @param object|array|string|false post Optional post values, uses get request if false or undefined
+    // @param function Optional callBack
+    function _ez( callArgs, post, callBack )
+    {
+        callArgs = callArgs.join !== undefined ? callArgs.join( _seperator ) : callArgs;
+        var url = _serverUrl + 'call/';
+        if ( post )
+        {
+            if ( post.join !== undefined )// support serializeArray() format
+            {
+                post.push( { 'name': 'ezjscServer_function_arguments', 'value': callArgs } );
+                if ( _formToken )
+                    post.push( { 'name': 'ezxform_token', 'value': _formToken } );
+            }
+            else if ( typeof(post) === 'string' )// string
+            {
+                post += ( post ? '&' : '' ) + 'ezjscServer_function_arguments=' + callArgs;
+                if ( _formToken)
+                    post += '&ezxform_token=' + _formToken;
+            }
+            else // object
+            {
+                post['ezjscServer_function_arguments'] = callArgs;
+                if ( _formToken )
+                    post['ezxform_token'] = _formToken;
+            }
+            return $.post( url, post, callBack, 'json' );
+        }
+        return $.get( url + encodeURIComponent( callArgs ), {}, callBack, 'json' );
+    };
+    _ez.url = _serverUrl;
+    _ez.root_url = _rootUrl;
+    _ez.seperator = _seperator;
+    $.ez = _ez;
+
+    $.ez.setPreference = function( name, value )
+    {
+        var param = {'Function': 'set_and_exit', 'Key': name, 'Value': value};
+        if ( _formToken )
+            param.ezxform_token = _formToken;
+
+        return $.post( _prefUrl, param );
+    };
+
+    // Method version, for loading response into elements
+    // NB: Does not use json (not possible with .load), so ezjscore/call will return string
+    function _ezLoad( callArgs, post, selector, callBack )
+    {
+        callArgs = callArgs.join !== undefined ? callArgs.join( _seperator ) : callArgs;
+        var url = _serverUrl + 'call/';
+        if ( post )
+        {
+            post['ezjscServer_function_arguments'] = callArgs;
+            if ( _formToken )
+                post['ezxform_token'] = _formToken;
+        }
+        else
+            url += encodeURIComponent( callArgs );
+
+        return this.load( url + ( selector ? ' ' + selector : '' ), post, callBack );
+    };
+    $.fn.ez = _ezLoad;
+})(jQuery);
+{/literal}

--- a/extension/ezjscore/design/standard/templates/ezjscore/ezjsc_yui.tpl
+++ b/extension/ezjscore/design/standard/templates/ezjscore/ezjsc_yui.tpl
@@ -1,0 +1,98 @@
+{literal}
+YUI( YUI3_config ).add('io-ez', function( Y )
+{
+    var _rootUrl = '{/literal}{$rootUrl}{literal}',
+        _serverUrl = _rootUrl + 'ezjscore/',
+        _seperator = '@SEPERATOR$',
+        _configBak, _prefUrl = _rootUrl + 'user/preferences';
+
+    // (static) Y.io.ez() uses Y.io()
+    //
+    // @param string callArgs
+    // @param object|undefined c Same format as second parameter of Y.io()
+    function _ez( callArgs, c )
+    {
+        callArgs = callArgs.join !== undefined ? callArgs.join( _seperator ) : callArgs;
+        var url = _serverUrl + 'call/';
+
+        // Merge configuration object
+        if ( c === undefined )
+            c = {on:{}, data: '', headers: {}, method: 'POST'};
+        else
+            c = Y.merge( {on:{}, data: '', headers: {}, method: 'POST'}, c );
+
+        var _token = '', _tokenNode = document.getElementById('ezxform_token_js');
+        if ( _tokenNode ) _token = '&ezxform_token=' + _tokenNode.getAttribute('title');
+
+        // Append function arguments as post param if method is POST
+        if ( c.method === 'POST' )
+            c.data += ( c.data ? '&' : '' ) + 'ezjscServer_function_arguments=' + callArgs + _token;
+        else
+            url += encodeURIComponent( callArgs );
+
+        // force json transport
+        c.headers.Accept = 'application/json,text/javascript,*/*';
+
+        // backup user success call
+        if ( c.on.success !== undefined )
+            c.on.successCallback = c.on.success;
+
+        c.on.success = _ioezSuccess;
+        _configBak = c;
+
+        return Y.io( url, c );
+    }
+
+    function _ioezSuccess( id, o )
+    {
+        if ( o.responseJSON === undefined )
+        {
+            // create new object to avoid error in ie6 (and do not use Y.merge since it fails in ff)
+            var returnObject = {'responseJSON': Y.JSON.parse( o.responseText ),
+                                'readyState': o.readyState,
+                                'responseText': o.responseText,
+                                'responseXML': o.responseXML,
+                                'status': o.status,
+                                'statusText': o.statusText
+            };
+        }
+        else
+        {
+            var returnObject = o;
+        }
+
+        var c = _configBak;
+        if ( c.on.successCallback !== undefined )
+        {
+            if ( c.arguments !== undefined )
+                c.on.successCallback( id, returnObject, c.arguments );
+            else
+                c.on.successCallback( id, returnObject, null );
+        }
+        else if ( window.console !== undefined )
+        {
+            if ( returnObject.responseJSON.error_text )
+                window.console.error( 'Y.ez(): ' + returnObject.responseJSON.error_text );
+            else
+                window.console.log( 'Y.ez(): ' + returnObject.responseJSON.content );
+        }
+        _configBak.on.success = _configBak.on.successCallback;
+        _configBak.on.successCallback = undefined;
+    }
+
+    _ez.url = _serverUrl;
+    _ez.root_url = _rootUrl;
+    _ez.seperator = _seperator;
+    Y.io.ez = _ez;
+    Y.io.ez.setPreference = function( name, value )
+    {
+        var c = {on:{}, data:'', headers: {}, method: 'POST'},
+            _tokenNode = document.getElementById( 'ezxform_token_js' );
+
+        c.data = 'Function=set_and_exit&Key=' + encodeURIComponent( name ) + '&Value=' + encodeURIComponent( value );
+        if ( _tokenNode )
+            c.data += '&ezxform_token=' + _tokenNode.getAttribute( 'title' );
+        return Y.io( _prefUrl, c );
+    }
+}, '3.0.0' ,{requires:['io-base', 'json-parse']});
+{/literal}


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23074

Not strictly needed, but this moves ezjsc jquery and yui plugin code into its own template template and cleans up formtoken related vars/code a bit.
