### PR TITLE
Fix EZP-22915: do not use eZINI when checking path in eZDir::recursiveDelete()

### DIFF
--- a/config.php-RECOMMENDED
+++ b/config.php-RECOMMENDED
@@ -295,4 +295,13 @@
 // define( 'CUSTOM_LOG_ROTATE_FILES', 3 );
 
 
+/**
+ * Directory that eZDir is allowed to delete from (see eZDir::recursiveDelete()).
+ * By default, it is only possible to delete from inside eZ Publish root directory.
+ * Directory listed will be added as authorized directory prefix.
+ * Value must be an absolute path.
+ */
+// define( 'ALLOWED_DELETION_DIR', '/var/share/somedir' );
+
+
 ?>

--- a/lib/ezfile/classes/ezdir.php
+++ b/lib/ezfile/classes/ezdir.php
@@ -274,7 +274,11 @@ class eZDir
         if ( $rootCheck )
         {
             // rootCheck is enabled, check if $dir is part of authorized directories
-            $allowedDirs = eZINI::instance()->variable( 'FileSettings', 'AllowedDeletionDirs' );
+            $allowedDirs = array();
+            if ( defined( 'ALLOWED_DELETION_DIR' ) && ALLOWED_DELETION_DIR !== '' )
+            {
+                $allowedDirs = array( ALLOWED_DELETION_DIR );
+            }
             // Also adding eZ Publish root dir.
             $rootDir = eZSys::rootDir() . DIRECTORY_SEPARATOR;
             array_unshift( $allowedDirs, $rootDir );

--- a/settings/site.ini
+++ b/settings/site.ini
@@ -1004,12 +1004,6 @@ VarDir=var
 CacheDir=cache
 # The name of the log dir, it's a subdir of VarDir
 LogDir=log
-# Directories eZDir is allowed to delete from (see eZDir::recursiveDelete()).
-# By default, it is only possible to delete from inside eZ Publish root directory.
-# Directories listed will be added as authorized directory prefixes.
-# Values must be absolute paths.
-AllowedDeletionDirs[]
-#AllowedDeletionDirs[]=/var/share/somedir
 
 
 [TemplateSettings]


### PR DESCRIPTION
This avoid depending on global ini cache when trying to clear it.
The config parameter needs to be known before eZINI is loaded, so it is
defines in config.php

Downside : you can now define only one allowed dir.

https://jira.ez.no/browse/EZP-22915

See PR #1006 :
49583e1 introduced an "egg or chicken" dilemma : when you use ezcache.php to clear the global ini cache, eZDir::recursiveDelete() will read the old settings from the cache, and may disallow you to clear the cache if your old settings disallow it.
