### PR TITLE
Fix EZP-23086: image thumbnail with special chars and urlalias_iri

### DIFF
--- a/design/admin/javascript/ezajaxsubitems_datatable.js
+++ b/design/admin/javascript/ezajaxsubitems_datatable.js
@@ -61,6 +61,8 @@ var sortableSubitems = function () {
 
         var thumbView = function(cell, record, column, data) {
             var url = record.getData('thumbnail_url');
+            // thumbnail_url is html-encoded, revert and escape url
+            url = encodeURI( $('<span/>').html( url ).text() );
             if (url) {
                 var thBack = 'background: url(' + url + ') no-repeat;';
                 var thWidth = ' width: ' + record.getData('thumbnail_width') + 'px;';


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23086

When using urlalias_iri transformation group urls may contain some special chars (eg `/folder"with"quotes/`)
In this situation, the thumbnail preview on admin ui fails.

Problem: ajax / ezjscore request filters uris with htmlentities, which won't work for applying in css styles.

Fix: Revert htmlentities and re-encode uri in afftected js.

This looks hackish, but:
- It is impractical/unpretictable to modify `eZURI::transformURI()`
- Problems with using different transformation ( f.e. transformUrl will not take root/indexdir into account)
