### PR TITLE
Fix EZP-23088: Image information still displayed after removal

### DIFF
--- a/kernel/content/attribute_edit.php
+++ b/kernel/content/attribute_edit.php
@@ -325,6 +325,10 @@ if ( $storingAllowed && $hasObjectInput)
     $db->begin();
     $object->setName( $class->contentObjectName( $object, $version->attribute( 'version' ), $EditLanguage ), $version->attribute( 'version' ), $EditLanguage );
     $db->commit();
+
+    // While being fetched, attributes might have been modified.
+    // The list needs to be refreshed so it is accurately displayed.
+    $contentObjectAttributes = $version->contentObjectAttributes( $EditLanguage );
 }
 elseif ( $storingAllowed )
 {


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-23088
## Description

This follows #1001 were deletion of images has been fixed (see description for context for this PR).
`contentObjectAttributes` are modified during the fetch (it is were deletion is done):
https://github.com/ezsystems/ezpublish-legacy/blob/master/kernel/content/attribute_edit.php#L288

but the variable is not updated.

This patch refreshes the variable, this way updated content is displayed on the edit page.
## Tests

Manual tets
