### PR TITLE
Fix EZP-23046: kernel error overrides only work once

### DIFF
--- a/kernel/classes/eznodeviewfunctions.php
+++ b/kernel/classes/eznodeviewfunctions.php
@@ -478,6 +478,17 @@ class eZNodeviewfunctions
             {
                 if ( !isset( $Result['content_info'] ) )
                 {
+                    // set error type & number for kernel errors (see https://jira.ez.no/browse/EZP-23046)
+                    if ( isset( $Result['errorType'] ) && isset( $Result['errorNumber'] ) )
+                    {
+                        $res = eZTemplateDesignResource::instance();
+                        $res->setKeys(
+                            array(
+                                array( 'error_type', $Result['errorType'] ),
+                                array( 'error_number', $Result['errorNumber'] )
+                            )
+                        );
+                    }
                     return $Result;
                 }
                 $keyArray = array( array( 'object', $Result['content_info']['object_id'] ),
@@ -609,13 +620,14 @@ class eZNodeviewfunctions
      */
     static protected function contentViewGenerateError( eZModule $Module, $error, $store = true, array $errorParameters = array() )
     {
+        $content = $Module->handleError(
+            $error,
+            'kernel',
+            $errorParameters
+        );
+
         return array(
-            'content' =>
-                $content = $Module->handleError(
-                    $error,
-                    'kernel',
-                    $errorParameters
-                ),
+            'content' => $content,
             'scope' => 'viewcache',
             'store' => $store,
             'binarydata' => serialize( $content ),

--- a/kernel/error/view.php
+++ b/kernel/error/view.php
@@ -187,6 +187,8 @@ $Result['path'] = array( array( 'text' => ezpI18n::tr( 'kernel/error', 'Error' )
                                 'url' => false ) );
 $Result['errorCode'] = $httpErrorCode;
 $Result['errorMessage'] = $httpErrorName;
+$Result['errorType'] = $errorType;
+$Result['errorNumber'] = $errorNumber;
 
 if ( isset( $responseHeaders ) )
     $Result['responseHeaders'] = $responseHeaders;


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-23046

Kernel errors on content view wouldn't set the `error_type` and `error_number`design keys required by overrides on `error/view`.

This adds those keys to the module result of `error/view`, and makes sure that the cache retrieval method adds those to the design keys when applicable.
