### PR TITLE
Fix EZP-23092: incorrect error message when fetching from DFS

### DIFF
--- a/kernel/private/classes/clusterfilehandlers/dfsbackends/dfs.php
+++ b/kernel/private/classes/clusterfilehandlers/dfsbackends/dfs.php
@@ -370,7 +370,9 @@ class eZDFSFileHandlerDFSBackend implements eZDFSFileHandlerDFSBackendInterface
      */
     public function getDfsFileSize( $filePath )
     {
-        return filesize( $this->makeDFSPath( $filePath ) );
+        $dfsFilePath = $this->makeDFSPath( $filePath );
+        clearstatcache( true, $dfsFilePath );
+        return filesize( $dfsFilePath );
     }
 
     /**


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23092

If there is a mismatch between metadata size and dfs size, the error message generated by dfs fetch will be incoherent:
`'Size (100) of written data for file 'var/.../....cache123456tmp.php' does not match expected size 100'`

This fixes the message's second argument to the actual variable being checked, but also adds an additional validation of the metadata vs dfsfile size at each loop iteration.
