### PR TITLE
Fix EZP-23086: Image thumbnail not shown

### DIFF
--- a/design/admin/javascript/ezajaxsubitems_datatable.js
+++ b/design/admin/javascript/ezajaxsubitems_datatable.js
@@ -60,9 +60,9 @@ var sortableSubitems = function () {
         }
 
         var thumbView = function(cell, record, column, data) {
-            var url = record.getData('thumbnail_url');
+            var url = encodeURI(record.getData('thumbnail_url'));
             if (url) {
-                var thBack = 'background: url(' + url + ') no-repeat;';
+                var thBack = 'background: url(\'' + url.replace("'", "\\'") + '\') no-repeat;';
                 var thWidth = ' width: ' + record.getData('thumbnail_width') + 'px;';
                 var thHeight = ' height: ' + record.getData('thumbnail_height') + 'px;';
                 cell.innerHTML = '<div class="thumbview"><div id="thumbfield" class="thumbfield"></div><span><div style="' + thBack + thWidth + thHeight + '"></div></span></div>';

--- a/extension/ezjscore/classes/ezjscajaxcontent.php
+++ b/extension/ezjscore/classes/ezjscajaxcontent.php
@@ -313,7 +313,9 @@ class ezjscAjaxContent
                     $thumbHeight = isset( $imageAlias['height'] ) ? (int) $imageAlias['height'] : 0;
 
                     if ( $thumbUrl !== '' )
-                        eZURI::transformURI( $thumbUrl, true );
+                    {
+                        eZURI::transformURI( $thumbUrl, true, null, false );
+                    }
 
                     break;
                 }

--- a/lib/ezutils/classes/ezuri.php
+++ b/lib/ezutils/classes/ezuri.php
@@ -591,9 +591,10 @@ class eZURI
      * @param string &$href
      * @param boolean $ignoreIndexDir
      * @param string $serverURL full|relative
+     * @param boolean $htmlEscape true to html escape the result for HTML
      * @return string the link to use
      */
-    public static function transformURI( &$href, $ignoreIndexDir = false, $serverURL = null )
+    public static function transformURI( &$href, $ignoreIndexDir = false, $serverURL = null, $htmlEscape = true )
     {
         // When using ezroot, immediately stop if the linked element is external
         if ( $ignoreIndexDir )
@@ -604,7 +605,7 @@ class eZURI
             $modifiedHref = eZClusterFileHandler::instance()->applyServerUri( $trimmedHref );
             if ( $modifiedHref != $trimmedHref )
             {
-                $href = str_replace( '&amp;amp;', '&amp;', htmlspecialchars( $modifiedHref ) );
+                $href = $htmlEscape ? self::escapeHtmlTransformUri( $href ) : $href;
                 return true;
             }
             unset( $modifiedHref );
@@ -622,7 +623,7 @@ class eZURI
             $href = '/';
         else if ( $href[0] == '#' )
         {
-            $href = htmlspecialchars( $href );
+            $href = $htmlEscape ? htmlspecialchars( $href ) : $href;
             return true;
         }
         else if ( $href[0] != '/' )
@@ -639,12 +640,25 @@ class eZURI
             $href = preg_replace( "#^(//)#", "/", $href );
             $href = preg_replace( "#(^.*)(/+)$#", "\$1", $href );
         }
-        $href = str_replace( '&amp;amp;', '&amp;', htmlspecialchars( $href ) );
+        $href = $htmlEscape ? self::escapeHtmlTransformUri( $href ) : $href;
 
         if ( $href == "" )
             $href = "/";
 
         return true;
+    }
+
+    /**
+     * Encoding cleanup used by transformURI.
+     * Extracted in a private method to avoid duplicated code.
+     *
+     * @param string $href
+     *
+     * @return string
+     */
+    private static function escapeHtmlTransformUri( $href )
+    {
+        return str_replace( '&amp;amp;', '&amp;', htmlspecialchars( $href ) );
     }
 
     /**


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-23086
## Description

Thumbnails are not shown when using urlalias_uria and quotes. See link for description.

Based on @dpobel remarks on #1011
This patch adds a parameter to  `eZURI::transformURI` in order to be able to get results without html encoding. This is useful when the result needs to be used in javascript. Result is then escaped (for JS code) in the javascript code.
## Tests

Manual tests
