### PR TITLE
Followup EZP-22917: make eZFSFileHandler::fileDelete() less verbose

### DIFF
--- a/kernel/classes/clusterfilehandlers/ezfsfilehandler.php
+++ b/kernel/classes/clusterfilehandlers/ezfsfilehandler.php
@@ -671,7 +671,7 @@ class eZFSFileHandler implements eZClusterFileHandlerInterface
                 if ( file_exists( $path ) )
                     eZDebug::writeError( "File still exists after removal: '$path'", __METHOD__ );
             }
-            else
+            elseif ( is_dir( $path ) )
             {
                 eZDir::recursiveDelete( $path );
             }


### PR DESCRIPTION
After e9bfd8cea8, `eZDir::recursiveDelete()` has been made verbose, and
clearing all caches results in such error message:

> [ Jul 04 2014 16:33:47 ] [] eZDir::recursiveDelete:
> The path: var/cache/ini is not a folder

Mimic what is done in `eZFSFileHandler::delete()` by checking if the path
given to `eZDir::recursiveDelete()` is a directory.
