### PR TITLE
Fix for EZP-23122: Add support for custom tag names

### DIFF
--- a/extension/ezoe/settings/content.ini.append.php
+++ b/extension/ezoe/settings/content.ini.append.php
@@ -10,6 +10,8 @@
 #[CustomTagSettings]
 #AvailableCustomTags[]=pagebreak
 #AvailableCustomTags[]=underline
+## Add a more user-friendly name to the dropdown list of custom tags
+#CustomTagsDescription[pagebreak]=Page break
 #IsInline[underline]=true
 ## Displays the custom tag as an image so you cannot create sub content.
 ## Will use custom image if there is a custom attribute on the tag named 'image_url'


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-23122

Add some inline documentation for a long-time feature that has been hidden: instead of just showing custom tag identifiers in the dropdown list, allow user-friendly names to be shown.
