### PR TITLE
Fixed EZP-22974: When I create a new Image I get Error: eZDir::recursive...

### DIFF
--- a/kernel/classes/ezcache.php
+++ b/kernel/classes/ezcache.php
@@ -514,6 +514,11 @@ class eZCache
                 return;
             }
 
+            if ( !file_exists( $cachePath ) )
+            {
+                return;
+            }
+
             if ( is_file( $cachePath ) )
             {
                 $handler = eZFileHandler::instance( false );


### PR DESCRIPTION
...Delete

The error occurs when clearing cache that does not exist (has not been generated). I have not removed the call to clearing cache, since I don't know for sure if there are cases where cache does exist. Instead the cache clearing code is improved so that it doesn't attempt to delete non-existing directories.

Now it silently ignores such calls. I don't see any need to log them - it is perfectly normal that this happens. It does however log an error if the cache path is neither a file nor a directory, which can theoretically happen if you mess around with symlinks in your cache dir.

https://jira.ez.no/browse/EZP-22974

EDIT: This actually fixes https://jira.ez.no/browse/EZP-23146, not the above.
