### PR TITLE
eZDFSFileHandlerMySQLiBackend: Small code enhancements

### DIFF
--- a/kernel/private/classes/clusterfilehandlers/dfsbackends/mysqli.php
+++ b/kernel/private/classes/clusterfilehandlers/dfsbackends/mysqli.php
@@ -375,13 +375,10 @@ class eZDFSFileHandlerMySQLiBackend implements eZClusterEventNotifier
             return 0;
         }
         // the candidate for purge are indexed in an array
-        else
+        for ( $i = 0; $i < $resultCount; $i++ )
         {
-            for ( $i = 0; $i < $resultCount; $i++ )
-            {
-                $row = mysqli_fetch_assoc( $res );
-                $files[] = $row['name'];
-            }
+            $row = mysqli_fetch_assoc( $res );
+            $files[] = $row['name'];
         }
 
         // delete query

--- a/kernel/private/classes/clusterfilehandlers/dfsbackends/mysqli.php
+++ b/kernel/private/classes/clusterfilehandlers/dfsbackends/mysqli.php
@@ -375,6 +375,7 @@ class eZDFSFileHandlerMySQLiBackend implements eZClusterEventNotifier
             return 0;
         }
         // the candidate for purge are indexed in an array
+        $files = array();
         for ( $i = 0; $i < $resultCount; $i++ )
         {
             $row = mysqli_fetch_assoc( $res );


### PR DESCRIPTION
I stumbled on this while reviewing #808, it's really minor but enhances readability and reduces code complexity (if you use such tools).
1. `0` is returned in the precedent `if` statement, so the `else` statement is not needed
2. The `$files` variable was used inside the loop without having it defined beforehand.

Cheers
:octocat: Jérôme

PS: Two commits because two issues, but I can of course merge them if you want.
