### PR TITLE
Fix EZP-23107: Custom headers break if header value contains semicolons

### DIFF
--- a/kernel/classes/ezhttpheader.php
+++ b/kernel/classes/ezhttpheader.php
@@ -113,7 +113,10 @@ class eZHTTPHeader
 
                 if ( strpos( $uriString, $path ) === 0 )
                 {
-                    @list( $headerValue, $depth, $level ) = explode( ';', $value );
+                    $config = eZStringUtils::explodeStr( $value, ';' );
+                    $headerValue = $config[0];
+                    $depth = isset( $config[1] ) ? $config[1] : null;
+                    $level = isset( $config[2] ) ? $config[2] : null;
 
                     if ( $header == 'Expires' )
                     {

--- a/settings/site.ini
+++ b/settings/site.ini
@@ -1482,6 +1482,7 @@ HeaderList[]=Expires
 # Default Cache-Control header
 # HTTP Headers are specified using the following format :
 # <HTTP header>[<eZ Publish path|module{/view}>]=<value>{;<depth>{;<level>}}
+# Note: to use a semicolon in the value, you need to escape it with a backslash.
 #
 # Example :
 # # Set Pragma HTTP header to no-cache for whole site, except /news, and 2 levels below news.


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23107
# Description

This patch makes sure it's possible to configure eZ Publish to send a custom header value with a semicolon. This issue comes from the fact that the semicolon is a separator in the custom HTTP header settings (to optionally set the depth and level) and the case where the custom HTTP value would contain a semicolon was not taken into account.
# Tests

manual tests
