### PR TITLE
Fixed EZP-23042: Urlalias history removed for an existing translation wh...

### DIFF
--- a/kernel/classes/ezurlaliasml.php
+++ b/kernel/classes/ezurlaliasml.php
@@ -675,6 +675,7 @@ class eZURLAliasML extends eZPersistentObject
             // 0. Check if the entry to be updated represents multiple languages:
             // IF YES:
             //  1. "Downgrade" existing entry, by removing the active translation's language id from the language_mask.
+            //  2. Create a new history entry, for the active translation only, by copying from the existing entry.
             // IF NO:
             //  1. Mark entry as a history entry
 
@@ -687,6 +688,21 @@ class eZURLAliasML extends eZPersistentObject
                     $currentEntry = new eZURLAliasML( $toBeUpdated[0] );
                     $currentEntry->LangMask = (int)$currentEntry->LangMask & ~$languageID;
                     $currentEntry->store();
+
+                    // Create new history entry
+                    $newRow = array( 'id'              => $currentEntry->attribute( 'id' ),
+                                     'text'            => $currentEntry->attribute( 'text' ),
+                                     'text_md5'        => $currentEntry->attribute( 'text_md5' ),
+                                     'parent'          => $currentEntry->attribute( 'parent' ),
+                                     'action'          => $currentEntry->attribute( 'action' ),
+                                     'action_type'     => $currentEntry->attribute( 'action_type' ),
+                                     'link'            => $currentEntry->attribute( 'link' ),
+                                     'is_alias'        => $currentEntry->attribute( 'is_alias' ),
+                                     'alias_redirects' => $currentEntry->attribute( 'alias_redirects' ),
+                                     'lang_mask'       => $languageMask,
+                                     'is_original'     => 0 );
+                    $newEntry = new eZURLAliasML( $newRow );
+                    $newEntry->store();
                 }
                 else
                 {


### PR DESCRIPTION
...en updating content

Fixed by creating a new history entry, which records the old urlalias for the active translation. Caveat: Here be dragons.

https://jira.ez.no/browse/EZP-23042
