### PR TITLE
Fix EZP-23054: eZIE: Missing form token from Request when closing

### DIFF
--- a/extension/ezformtoken/event/ezxformtoken.php
+++ b/extension/ezformtoken/event/ezxformtoken.php
@@ -201,14 +201,19 @@ class ezxFormToken
                 $templateResult
             );
         }
-        // else fallback to hidden span inside body
-        else
+        // Fallback to hidden span inside body if any.
+        else if ( strpos( $templateResult, '<body' ) !== false )
         {
             $templateResult = preg_replace(
                 '/(<body[^>]*>)/i',
                 '\\1' . "\n<span style='display:none;' id=\"{$field}_js\" title=\"{$token}\"></span>\n",
                 $templateResult
             );
+        }
+        // No body tag, just prepend the hidden span tag to generated HTML code.
+        else
+        {
+            $templateResult = "\n<span style='display:none;' id=\"{$field}_js\" title=\"{$token}\"></span>\n" . $templateResult;
         }
 
         $templateResult = preg_replace(


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-23074

Cause of this is that when using a Twig template for the main layout and doing frontend content editing, CSRF token is not generated as a meta tag.

This patch ensures there is always a fallback (here with hidden span), so that one can grab the CSRF token in their JS.
