### PR TITLE
Removed unneeded var definition as the var is not used anymore

### DIFF
--- a/lib/ezimage/classes/ezimagemanager.php
+++ b/lib/ezimage/classes/ezimagemanager.php
@@ -785,8 +785,6 @@ class eZImageManager
      */
     function createImageAlias( $aliasName, &$existingAliasList, $parameters = array() )
     {
-        $fname = "createImageAlias( $aliasName )";
-
         // check for $aliasName validity
         $aliasList = $this->aliasList();
         if ( !isset( $aliasList[$aliasName] ) )


### PR DESCRIPTION
Found this var while debugging. that $fname is not used anymore. Don't think this is a global var or something. 

Not an issue itself so not adding noise in jira. Let me know if you prefer to do it. 
