### PR TITLE
Fix EZP-22974: When I create a new Image I get Error: eZDir::recursiveDelete

### DIFF
--- a/lib/ezfile/classes/ezdir.php
+++ b/lib/ezfile/classes/ezdir.php
@@ -267,7 +267,6 @@ class eZDir
         // $dir is not a directory
         if ( !is_dir( $dir ) )
         {
-            eZDebug::writeError( "The path: $dir is not a folder" , __METHOD__ );
             return false;
         }
 


### PR DESCRIPTION
Possible fix for
#### EZP-22974 - 22974: When I create a new Image I get Error: eZDir::recursiveDelete

If you create a new image, with page redirect enabled, you'll get the following error

```
Error: eZDir::recursiveDelete   Jun 02 2014 15:13:44
The path: var/ezwebin_site/cache/template-block/subtree/1/cache is not a folder
```
