### PR TITLE
Fix EZP-22974: When I create a new Image I get Error: eZDir::recursiveDelete

### DIFF
--- a/kernel/classes/clusterfilehandlers/ezfsfilehandler.php
+++ b/kernel/classes/clusterfilehandlers/ezfsfilehandler.php
@@ -671,9 +671,13 @@ class eZFSFileHandler implements eZClusterFileHandlerInterface
                 if ( file_exists( $path ) )
                     eZDebug::writeError( "File still exists after removal: '$path'", __METHOD__ );
             }
-            else
+            else if ( is_dir( $path ) )
             {
                 eZDir::recursiveDelete( $path );
+            }
+            else
+            {
+                continue;
             }
         }
 


### PR DESCRIPTION
Possible fix for
#### EZP-22974 - 22974: When I create a new Image I get Error: eZDir::recursiveDelete

If you create a new image, with page redirect enabled, you'll get the following error

```
Error: eZDir::recursiveDelete   Jun 02 2014 15:13:44
The path: var/ezwebin_site/cache/template-block/subtree/1/cache is not a folder
```
