### PR TITLE
Fixed EZP-23132: "user/selfedit" policy requires at least one "content/c...

### DIFF
--- a/kernel/private/classes/ezpkernelweb.php
+++ b/kernel/private/classes/ezpkernelweb.php
@@ -740,6 +740,20 @@ class ezpKernelWeb implements ezpWebBasedKernelHandler
                         {
                             $accessList = $accessParams['accessList'];
                         }
+
+                        // Hardcoded check for the case where the user does not have content/edit access,
+                        // but does have access to user/selfedit, and is editing their own user object.
+                        if ( !$moduleAccessAllowed &&
+                             $functionName === 'edit' &&
+                             $this->module->attribute( 'name' ) === 'content' &&
+                             $params[0] === $currentUser->attribute( 'contentobject_id') )
+                        {
+                            $selfEditAccess = $currentUser->hasAccessTo( 'user', 'selfedit' );
+                            if ( $selfEditAccess['accessWord'] === 'yes' )
+                            {
+                                $moduleAccessAllowed = true;
+                            }
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
...reate" or one "content/edit" policy

I'm doubtful about this hardcoded hack, but the nature of the beast seems to be that one way or another it must be hardcoded. I set up the checks to minimize the performance impact for other requests than content/edit.

https://jira.ez.no/browse/EZP-23132
