### PR TITLE
Fix EZP-23170: swapping node with sub items with non-container node.

### DIFF
--- a/design/admin/templates/content/browse_mode_list.tpl
+++ b/design/admin/templates/content/browse_mode_list.tpl
@@ -1,3 +1,7 @@
+{if and( eq( $browse.action_name, 'SwapNode' ), is_set( $browse.persistent_data.ContentNodeID ) )}
+    {def $swap_node = fetch( 'content', 'node', hash( 'node_id', $browse.persistent_data.ContentNodeID ) )}
+{/if}
+
 <table class="list" cellspacing="0">
 <tr>
     <th class="tight">
@@ -57,7 +61,17 @@
                 <input type="{$select_type}" name="_Disabled" value="" disabled="disabled" />
             {/if}
         {else}
+            {*
+              Do not allow node selection if
+              - Action is move, copy or add node, and item is not a container
+              - Action is swap node, and node to swap has children and item is not a container, and vice versa
+            *}
             {if and( or( eq( $browse.action_name, 'MoveNode' ), eq( $browse.action_name, 'CopyNode' ), eq( $browse.action_name, 'AddNodeAssignment' ) ), $Nodes.item.object.content_class.is_container|not )}
+                <input type="{$select_type}" name="{$select_name}[]" value="{$Nodes.item[$select_attribute]}" disabled="disabled" />
+            {elseif and( eq( $browse.action_name, 'SwapNode' ),
+                         eq( get_class( $swap_node ), 'ezcontentobjecttreenode' ),
+                         or( and( $swap_node.children_count|gt(0), $Nodes.item.object.content_class.is_container|not ),
+                             and( $swap_node.is_container|not, $Nodes.item.children_count|gt(0) ) ) )}
                 <input type="{$select_type}" name="{$select_name}[]" value="{$Nodes.item[$select_attribute]}" disabled="disabled" />
             {else}
                 <input type="{$select_type}" name="{$select_name}[]" value="{$Nodes.item[$select_attribute]}" />

--- a/kernel/classes/ezsiteinstaller.php
+++ b/kernel/classes/ezsiteinstaller.php
@@ -1039,6 +1039,20 @@ class eZSiteInstaller
             return false;
         }
 
+        // verify one of the nodes contains children and the other is not a container.
+        if ( !$node->classIsContainer() && $selectedNode->childrenCount() > 0 )
+        {
+            $this->reportError( "Cannot use node $selectedNodeID as the exchanging node for $nodeID, as it contains sub items (node is not container)",
+                                'eZSiteInstaller::swapNodes' );
+            return false;
+        }
+        if ( !$selectedNode->classIsContainer() && $node->childrenCount() > 0 )
+        {
+            $this->reportError( "Cannot use node $selectedNodeID as the exchanging node for $nodeID, as it is not container (node contains sub items)",
+                                'eZSiteInstaller::swapNodes' );
+            return false;
+        }
+
         // clear cache.
         eZContentCacheManager::clearContentCacheIfNeeded( $objectID );
 

--- a/kernel/content/action.php
+++ b/kernel/content/action.php
@@ -402,13 +402,27 @@ else if ( $module->isCurrentAction( 'SwapNode' ) )
     {
         eZDebug::writeWarning( "Content node with ID $selectedNodeID does not exist, cannot use that as exchanging node for node $nodeID",
                                'content/action' );
-        return $module->redirectToView( 'view', array( 'full', 2 ) );
+        return $module->handleError( eZError::KERNEL_NOT_AVAILABLE, 'kernel', array() );
     }
     if ( !$selectedNode->canSwap() )
     {
         eZDebug::writeError( "Cannot use node $selectedNodeID as the exchanging node for $nodeID, the current user does not have edit permission for it",
                              'content/action' );
-        return $module->redirectToView( 'view', array( 'full', 2 ) );
+        return $module->handleError( eZError::KERNEL_ACCESS_DENIED, 'kernel', array() );
+    }
+
+    // verify one of the nodes contains children and the other is not a container.
+    if ( !$node->classIsContainer() && $selectedNode->childrenCount() > 0 )
+    {
+        eZDebug::writeError( "Cannot use node $selectedNodeID as the exchanging node for $nodeID, as it contains sub items (node is not container)",
+                             'content/action' );
+        return $module->handleError( eZError::KERNEL_NOT_AVAILABLE, 'kernel', array() );
+    }
+    if ( !$selectedNode->classIsContainer() && $node->childrenCount() > 0 )
+    {
+        eZDebug::writeError( "Cannot use node $selectedNodeID as the exchanging node for $nodeID, as it is not container (node contains sub items)",
+                             'content/action' );
+        return $module->handleError( eZError::KERNEL_NOT_AVAILABLE, 'kernel', array() );
     }
 
     // clear cache.


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23170

Problem: swapping a non-container node (class definition) with a node that contains children/sub items will result in an invalid state;
The new node will display the sub item count but will not list any children on the admin interface.

This PR adds an additional check in content/action that prevents the swap if any of the nodes is not a container and the other contains children.

Tests: manual.

Note: 
An improvement to this would be to add the check in the interface, before the action is executed (for example when browsing for the "destination" node.
