### PR TITLE
Fix EZP-23176: Sessions are always started for anonymous user

### DIFF
--- a/kernel/classes/datatypes/ezuser/ezuser.php
+++ b/kernel/classes/datatypes/ezuser/ezuser.php
@@ -988,8 +988,11 @@ WHERE user_id = '" . $userID . "' AND
         if ( !( $flags & self::NO_SESSION_REGENERATE) )
             eZSession::regenerate();
 
-        eZSession::set( 'eZUserLoggedInID', $userID );
-        self::cleanup();
+        if ( $userID != self::anonymousId() || eZSession::hasStarted() )
+        {
+            eZSession::set( 'eZUserLoggedInID', $userID );
+            self::cleanup();
+        }
     }
 
     /*!


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23176

`eZUser::setCurrentlyLoggedInUser()` always starts a session, even for anonymous.

Replaces ezsystems/ezpublish-kernel#932

Essentially this will not start a new session if the (new) current user is anonymous.

If a previously user was set, and setCurrentlyLoggedInUser() is for anonymous, a session should already exist, so it will still update the user ID.
