### PR TITLE
EZP-22973: Fix test PHP warnings with postgres - 

### DIFF
--- a/tests/tests/kernel/classes/ezcollaborationitem_test.php
+++ b/tests/tests/kernel/classes/ezcollaborationitem_test.php
@@ -11,6 +11,7 @@ class eZCollaborationItemTest extends ezpDatabaseTestCase
 {
     public function setUp()
     {
+        parent::setUp();
         $participantsList = array(
             $this->createParticipantLinkPartialMock(
                 array(
@@ -37,8 +38,9 @@ class eZCollaborationItemTest extends ezpDatabaseTestCase
     /**
      * @dataProvider providerForIsParticipant
      */
-    public function testIsParticipant( $expectedResult, eZUser $user )
+    public function testIsParticipant( $expectedResult, $userId, array $groupIdArray = array() )
     {
+        $user = $this->createUserMock( $userId, $groupIdArray );
         self::assertEquals(
             $expectedResult,
             $this->getCollaborationItemPartialMock()->userIsParticipant( $user )
@@ -48,13 +50,12 @@ class eZCollaborationItemTest extends ezpDatabaseTestCase
     public function providerForIsParticipant()
     {
         return array(
+            array( true, 1 ),
+            array( false, 2 ),
 
-            array( true, $this->createUserMock( 1 ) ),
-            array( false, $this->createUserMock( 2 ) ),
-
-            array( true, $this->createUserMock( 3, array( 2 ) ) ),
-            array( true, $this->createUserMock( 3, array( 2, 3 ) ) ),
-            array( false, $this->createUserMock( 3, array( 3 ) ) ),
+            array( true, 3, array( 2 ) ),
+            array( true, 3, array( 2, 3 ) ),
+            array( false, 3, array( 3 ) ),
         );
     }
 


### PR DESCRIPTION
Related: https://jira.ez.no/browse/EZP-22973

This is a followup on #986, should "fix" the `PHP: Deprecated: mysql_escape_string()`... warning that is visible when running tests in travis with postgres.

The problem is that `eZCollaborationItemTest` extends `ezpDatabaseTestCase` but is missing `setUp()`; In addition creating a eZUser mock caused this warning because test providers are executed in first place; refactor creation to actual test function.
