### PR TITLE
Fix EZP-23185: image not displayed in ezoe if alias contains quotes

### DIFF
--- a/extension/ezoe/ezxmltext/handlers/input/ezoexmlinput.php
+++ b/extension/ezoe/ezxmltext/handlers/input/ezoexmlinput.php
@@ -1218,6 +1218,7 @@ class eZOEXMLInput extends eZXMLInputHandler
                             {
                                 $imageAlias  = $content->imageAlias( $size );
                                 $srcString   = $URL . '/' . $imageAlias['url'];
+                                eZURI::transformURI( $srcString, true, null, false );
                                 $imageWidth  = $imageAlias['width'];
                                 $imageHeight = $imageAlias['height'];
                                 break;


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23185

When using urlalias_uri and an image's path contains quotes, re-editing content with an image embed will no longer display the image(s) correctly.
Additional follow-up of EZP-23086, #1019, #1035
