### PR TITLE
Fix EZP-23185: Image not displayed in editor if alias contains quotes

### DIFF
--- a/extension/ezoe/ezxmltext/handlers/input/ezoexmlinput.php
+++ b/extension/ezoe/ezxmltext/handlers/input/ezoexmlinput.php
@@ -1247,7 +1247,7 @@ class eZOEXMLInput extends eZXMLInputHandler
                         $objectAttr .= ' class="' . $className . '"';
 
                     $output .= '<img id="' . $idString . '" title="' . $objectName . '" src="' .
-                               $srcString . '" width="' . $imageWidth . '" height="' . $imageHeight .
+                               htmlspecialchars( $srcString ) . '" width="' . $imageWidth . '" height="' . $imageHeight .
                                '" ' . $objectAttr . $customAttributePart . $styleString . ' />';
                 }
                 else if ( self::embedTagIsCompatibilityMode() )


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23185
Replaces #1036 
# Description

When using the `urlalias_iri` TransformationGroup for URL, it's possible to get special characters like double quotes in the URL of images; in such condition, Online Editor might fail to display the image. This is happening because while building the HTML for editing, the URL of the images are not correctly escaped for the HTML. This patch just adds the missing `htmlspecialchars` call while building the `<img>` tag.
# Tests

manual tests
