### PR TITLE
Fix EZP-23207: image alt text not modified if file is not set.

### DIFF
--- a/kernel/classes/datatypes/ezimage/ezimagetype.php
+++ b/kernel/classes/datatypes/ezimage/ezimagetype.php
@@ -178,7 +178,11 @@ class eZImageType extends eZDataType
         /** @var eZImageAliasHandler $imageHandler */
         $imageHandler = $contentObjectAttribute->attribute( 'content' );
         if ( $imageHandler )
+        {
+            $imageHandler->setAttribute( 'alternative_text', false );
             $imageHandler->removeAliases();
+            $imageHandler->store( $contentObjectAttribute );
+        }
     }
 
     /**
@@ -472,11 +476,7 @@ class eZImageType extends eZDataType
     {
         if( $action == "delete_image" )
         {
-            $content = $contentObjectAttribute->attribute( 'content' );
-            if ( $content )
-            {
-                $content->removeAliases();
-            }
+            $this->deleteStoredObjectAttribute( $contentObjectAttribute );
         }
     }
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23207

This fixes a regression in EZP-22615 , that causes an image attribute's alt text to not be updated if the file is not modified as well.
