### PR TITLE
*** TEMPORARY DO NOT MERGE *** Workaround a bug in travis TIMEZONE* vari...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ before_script:
  # Detecting timezone issues by testing on random timezone
  - declare -a TIMEZONES=("America/New_York" "Asia/Calcutta" "UTC")
  - declare -a TIMEZONE=${TIMEZONES["`shuf -i 0-2 -n 1`"]}
+ - export TIMEZONE=UTC
 
 
 script:


### PR DESCRIPTION
...ables handling

**THIS PR IS NOT TO BE MERGED**

There is ATM a problem with the way travis handles TIMEZONE\* variables. TIMEZONE ends up empty.

I tried some stuff with no success.
