### PR TITLE
Fix EZP-11741: Missing articles after unpublished via cronjobs

### DIFF
--- a/kernel/classes/ezcontentobject.php
+++ b/kernel/classes/ezcontentobject.php
@@ -1963,7 +1963,7 @@ class eZContentObject extends eZPersistentObject
                 {
                     $db = eZDB::instance();
                     $db->begin();
-                    foreach ( $additionalNodes as $additionalNode )
+                    foreach ( $nodes as $additionalNode )
                     {
                         if ( $additionalNode->attribute( 'node_id' ) != $node->attribute( 'main_node_id' ) )
                         {


### PR DESCRIPTION
In 5651fb9c, $additionalNodes is never set.
According to the file attached to the EZP-11741 issue [1], the patch was not correctly applied.

https://jira.ez.no/browse/EZP-11741

[1] https://jira.ez.no/secure/attachment/12199/12199_11741.patch
