### PR TITLE
Fix unit-tests with PHP >= 5.4.30

### DIFF
--- a/tests/tests/kernel/private/rest/ezprest_request_parser_regression.php
+++ b/tests/tests/kernel/private/rest/ezprest_request_parser_regression.php
@@ -66,14 +66,28 @@ class ezpRestHttpRequestParserRegression extends ezpRegressionTest
         $expectedFileName = $name . '.exp';
         if ( !file_exists( $expectedFileName ) )
         {
-            file_put_contents( $expectedFileName, var_export( $req, true ) );
+            file_put_contents( $expectedFileName, self::normalizedVarExport( $req ) );
             self::fail( 'Missing expected data file.' );
         }
         else
         {
             $expected = file_get_contents( $expectedFileName );
-            self::assertEquals( $expected, var_export( $req, true ), $expectedFileName );
+            self::assertEquals( $expected, self::normalizedVarExport( $req ), $expectedFileName );
         }
+    }
+
+    /*
+     * Since PHP 5.4.30, DateTime are not serialized the same way as previous versions.
+     * See http://php.net/ChangeLog-5.php#5.4.30 & https://bugs.php.net/bug.php?id=67308
+     */
+    private static function normalizedVarExport( $var )
+    {
+        $var = var_export( $var, true );
+        if ( PHP_VERSION_ID < 50430 )
+        {
+            $var = preg_replace( '%(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})%', '$1.000000', $var );
+        }
+        return $var;
     }
 
     public static function suite()

--- a/tests/tests/kernel/private/rest/request_parser_data/get_single_param.data.exp
+++ b/tests/tests/kernel/private/rest/request_parser_data/get_single_param.data.exp
@@ -15,7 +15,7 @@ ezpRestRequest::__set_state(array(
    'isEncrypted' => false,
    'date' => 
   DateTime::__set_state(array(
-     'date' => '2010-11-30 04:15:24',
+     'date' => '2010-11-30 04:15:24.000000',
      'timezone_type' => 1,
      'timezone' => '+00:00',
   )),

--- a/tests/tests/kernel/private/rest/request_parser_data/get_with_https.data.exp
+++ b/tests/tests/kernel/private/rest/request_parser_data/get_with_https.data.exp
@@ -14,7 +14,7 @@ ezpRestRequest::__set_state(array(
    'isEncrypted' => true,
    'date' => 
   DateTime::__set_state(array(
-     'date' => '2011-02-06 18:13:40',
+     'date' => '2011-02-06 18:13:40.000000',
      'timezone_type' => 1,
      'timezone' => '+00:00',
   )),

--- a/tests/tests/kernel/private/rest/request_parser_data/plain_request.data.exp
+++ b/tests/tests/kernel/private/rest/request_parser_data/plain_request.data.exp
@@ -14,7 +14,7 @@ ezpRestRequest::__set_state(array(
    'isEncrypted' => false,
    'date' => 
   DateTime::__set_state(array(
-     'date' => '2010-11-30 04:14:52',
+     'date' => '2010-11-30 04:14:52.000000',
      'timezone_type' => 1,
      'timezone' => '+00:00',
   )),

--- a/tests/tests/kernel/private/rest/request_parser_data/post_put.data.exp
+++ b/tests/tests/kernel/private/rest/request_parser_data/post_put.data.exp
@@ -15,7 +15,7 @@ ezpRestRequest::__set_state(array(
    'isEncrypted' => false,
    'date' => 
   DateTime::__set_state(array(
-     'date' => '2010-11-30 04:13:59',
+     'date' => '2010-11-30 04:13:59.000000',
      'timezone_type' => 1,
      'timezone' => '+00:00',
   )),

--- a/tests/tests/kernel/private/rest/request_parser_data/post_single_value.data.exp
+++ b/tests/tests/kernel/private/rest/request_parser_data/post_single_value.data.exp
@@ -15,7 +15,7 @@ ezpRestRequest::__set_state(array(
    'isEncrypted' => false,
    'date' => 
   DateTime::__set_state(array(
-     'date' => '2010-11-30 04:13:59',
+     'date' => '2010-11-30 04:13:59.000000',
      'timezone_type' => 1,
      'timezone' => '+00:00',
   )),

--- a/tests/tests/kernel/private/rest/request_parser_data/post_with_query_param.data.exp
+++ b/tests/tests/kernel/private/rest/request_parser_data/post_with_query_param.data.exp
@@ -16,7 +16,7 @@ ezpRestRequest::__set_state(array(
    'isEncrypted' => false,
    'date' => 
   DateTime::__set_state(array(
-     'date' => '2010-11-30 04:16:32',
+     'date' => '2010-11-30 04:16:32.000000',
      'timezone_type' => 1,
      'timezone' => '+00:00',
   )),


### PR DESCRIPTION
Since PHP 5.4.30, DateTime are not serialized the same way as previous versions.

See http://php.net/ChangeLog-5.php#5.4.30 & https://bugs.php.net/bug.php?id=67308

So the unit-tests relying on comparison between files containing var_export() do not work anymore.
