### PR TITLE
Fix EZP-23211: Impossible to align multiple cells

### DIFF
--- a/extension/ezoe/design/standard/javascript/themes/ez/editor_template.js
+++ b/extension/ezoe/design/standard/javascript/themes/ez/editor_template.js
@@ -1832,7 +1832,12 @@
                 toAlign = [],
                 that = this;
 
-            if ( selectedNode === ed.getBody() ) {
+            if ( ed.dom.select('.mceSelected').length ) {
+                // the selection is inside a table,
+                // the (ez)table plugin added the mceSelected class on td or tr
+                // and we align the paragraphs inside selected cells
+                toAlign = ed.dom.select('.mceSelected p');
+            } else if ( selectedNode === ed.getBody() ) {
                 // multi element selection, building an array
                 // of the selected nodes
                 var elt = ed.selection.getStart(),


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23211
# Description

At the moment, it's impossible to align several table cells in Online Editor. This is happening because the selection is not correctly handled when the user selected several table cells. To workaround that, the table plugin (and our fork eztable) sets the `mceSelected` class on the selected cells/rows; so we just have to check that to detect the elements to align.
# Tests

manual tests
