### PR TITLE
Fix EZP-23218: password in not stored when a user draft is saved

### DIFF
--- a/kernel/classes/datatypes/ezuser/ezuser.php
+++ b/kernel/classes/datatypes/ezuser/ezuser.php
@@ -232,7 +232,26 @@ class eZUser extends eZPersistentObject
         $contentObjectID = $this->attribute( 'contentobject_id' );
         $sql = "SELECT * FROM ezuser WHERE contentobject_id='$contentObjectID' AND LENGTH( login ) > 0";
         $rows = $db->arrayQuery( $sql );
-        return !empty( $rows );
+        if ( !empty( $rows ) )
+        {
+            return true;
+        }
+
+        // If there are no stored logins, we look for a "draft" login before we give up
+        $userObject = eZContentObject::fetch( $contentObjectID );
+        if ( $userObject instanceof eZContentObject )
+        {
+            foreach ( $userObject->attribute( 'contentobject_attributes' ) as $contentObjectAttribute )
+            {
+                if ( $contentObjectAttribute->attribute( 'data_type_string' ) === 'ezuser' )
+                {
+                    $serializedDraft = $contentObjectAttribute->attribute( 'data_text' );
+                    return !empty( $serializedDraft );
+                }
+            }
+        }
+
+        return false;
     }
 
     /*!


### PR DESCRIPTION
Ensure that the new login draft feature introduced in EZP-21966 is used on "store draft and exit"
