### PR TITLE
EZP-23235: Improve eZOE's UrlObjectLink handling performance.

### DIFF
--- a/extension/ezoe/ezxmltext/handlers/input/ezoexmlinput.php
+++ b/extension/ezoe/ezxmltext/handlers/input/ezoexmlinput.php
@@ -532,15 +532,22 @@ class eZOEXMLInput extends eZXMLInputHandler
         $objectAttributeID = $contentObjectAttribute->attribute( 'id' );
         $objectAttributeVersion = $contentObjectAttribute->attribute('version');
 
-        foreach( $urlIDArray as $urlID )
+        $existingUrlIDs = eZURLObjectLink::fetchLinkObjectList( $objectAttributeID, $objectAttributeVersion, false );
+        foreach ( $existingUrlIDs as &$urlRow )
         {
-            $linkObjectLink = eZURLObjectLink::fetch( $urlID, $objectAttributeID, $objectAttributeVersion );
-            if ( $linkObjectLink == null )
-            {
-                $linkObjectLink = eZURLObjectLink::create( $urlID, $objectAttributeID, $objectAttributeVersion );
-                $linkObjectLink->store();
-            }
+            $urlRow = $urlRow['url_id'];
         }
+
+        $urlsToInsert = array_diff( $urlIDArray, $existingUrlIDs );
+
+        $db = eZDB::instance();
+        $db->begin();
+        foreach( $urlsToInsert as $urlID )
+        {
+            $linkObjectLink = eZURLObjectLink::create( $urlID, $objectAttributeID, $objectAttributeVersion );
+            $linkObjectLink->store();
+        }
+        $db->commit();
     }
 
      /**


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23235

Problem: on content with many xml attributes, each with many links, there is the potential for hundreds or thousands of select/insert queries dealing with ezurl_object_link.

This replaces the 'N' selects with a single query, and calculates the difference of urls to insert vs existing ones.
A transaction is also added, for performance reasons.
