### PR TITLE
Fix for EZP-23249: Clear prioritized language list cache when switching siteaccesses

### DIFF
--- a/kernel/classes/ezsiteaccess.php
+++ b/kernel/classes/ezsiteaccess.php
@@ -550,6 +550,8 @@ class eZSiteAccess
             eZUpdateDebugSettings();
             eZDebugSetting::writeDebug( 'kernel-siteaccess', "Updated settings to use siteaccess '$name'", __METHOD__ );
         }
+        
+        eZContentLanguage::clearPrioritizedLanguages();
 
         return $access;
     }
@@ -623,6 +625,8 @@ class eZSiteAccess
             $moduleRepositories = eZModule::activeModuleRepositories();
             eZModule::setGlobalPathList( $moduleRepositories );
         }
+        
+        eZContentLanguage::clearPrioritizedLanguages();
 
         return $access;
     }


### PR DESCRIPTION
If you need to loop through several siteaccess to access content, the prioritized language list is not updated.
For example, this code will always return the "UK" name for every siteaccess:

```
$siteAccesses = array( 'uk', 'us', 'de' );
foreach( $siteAccesses as $siteAccessName )
{
    $cli->output( $siteAccessName );

    $access = array( 'name' => $siteAccessName, 'type' => eZSiteAccess::TYPE_STATIC );
    eZSiteAccess::load( $access );

    $node = eZFunctionHandler::execute( 'content', 'node', array( 'node_id' => 60 ) );
    $cli->output( $node->attribute( 'object' )->attribute( 'name' ) );
}
```
