### PR TITLE
Fixed: EZP-23251 Javascript error trying to paste an iframe html in a li...

### DIFF
--- a/extension/ezoe/design/standard/templates/content/datatype/edit/ezxmltext_ezoe.tpl
+++ b/extension/ezoe/design/standard/templates/content/datatype/edit/ezxmltext_ezoe.tpl
@@ -169,6 +169,7 @@
             if (
                 pl.editor.pasteAsPlainText
                 && o.node.childNodes.length === 1
+                && o.node.firstChild.tagName
                 && o.node.firstChild.tagName.toLowerCase() === 'pre'
             ) {
                 o.node.innerHTML = o.node.firstChild.innerHTML.replace(/\n/g, "<br />");


### PR DESCRIPTION
...teral html tag

Fixes https://jira.ez.no/browse/EZP-23251

Description there says it all. I was getting a javascript error when trying to paste an iframe inside a literal tag with html class

Here is my approach. But to be honest, looks more like a workaround than a proper fix... Thoughts?
