### PR TITLE
Fix EZP-23255: Show correct error on createObject

### DIFF
--- a/extension/ezjscore/classes/ajaxuploader/ezprelationlistajaxuploader.php
+++ b/extension/ezjscore/classes/ajaxuploader/ezprelationlistajaxuploader.php
@@ -195,7 +195,7 @@ class ezpRelationListAjaxUploader implements ezpAjaxUploaderHandlerInterface
                 ezpI18n::tr(
                     'extension/ezjscore/ajaxuploader',
                     'Unable to create the content object to add to the relation: %detail',
-                    null, array( '%detail', $result['errors'][0]['description'] )
+                    null, array( '%detail' => $result['errors'][0]['description'] )
                 )
             );
         }


### PR DESCRIPTION
the `%detail` parameter was never replaced because of a typo in the function call

https://jira.ez.no/browse/EZP-23255
