### PR TITLE
Fix for EZP-23249: Clear prioritized language list cache when switching siteaccesses

### DIFF
--- a/kernel/classes/ezsiteaccess.php
+++ b/kernel/classes/ezsiteaccess.php
@@ -547,6 +547,8 @@ class eZSiteAccess
 
             eZSys::setAccessPath( $access['uri_part'], $name );
 
+            eZContentLanguage::clearPrioritizedLanguages();
+
             eZUpdateDebugSettings();
             eZDebugSetting::writeDebug( 'kernel-siteaccess', "Updated settings to use siteaccess '$name'", __METHOD__ );
         }
@@ -622,6 +624,8 @@ class eZSiteAccess
         {
             $moduleRepositories = eZModule::activeModuleRepositories();
             eZModule::setGlobalPathList( $moduleRepositories );
+
+            eZContentLanguage::clearPrioritizedLanguages();
         }
 
         return $access;


### PR DESCRIPTION
Note: this replaces https://github.com/ezsystems/ezpublish-legacy/pull/1054

If you need to loop through several siteaccess to access content, the prioritized language list is not updated.
For example, this code will always return the "UK" name for every siteaccess:

```
$siteAccesses = array( 'uk', 'us', 'de' );
foreach( $siteAccesses as $siteAccessName )
{
    $cli->output( $siteAccessName );

    $access = array( 'name' => $siteAccessName, 'type' => eZSiteAccess::TYPE_STATIC );
    eZSiteAccess::load( $access );

    $node = eZFunctionHandler::execute( 'content', 'node', array( 'node_id' => 60 ) );
    $cli->output( $node->attribute( 'object' )->attribute( 'name' ) );
}
```
