### PR TITLE
Fix EZP-23254: DFS - tmp files left if the file size is not identical to...

### DIFF
--- a/kernel/private/classes/clusterfilehandlers/dfsbackends/mysqli.php
+++ b/kernel/private/classes/clusterfilehandlers/dfsbackends/mysqli.php
@@ -713,6 +713,11 @@ class eZDFSFileHandlerMySQLiBackend implements eZClusterEventNotifier
             {
                 return $filePath;
             }
+            // Sizes might have been corrupted by FS problems. Enforcing temp file removal.
+            else if ( file_exists( $tmpFilePath ) )
+            {
+                unlink( $tmpFilePath );
+            }
 
             usleep( self::TIME_UNTIL_RETRY );
             ++$loopCount;


### PR DESCRIPTION
... the original one

Link: https://jira.ez.no/browse/EZP-23254
## Decription

This is a follow up of #808. Temp files could still be left out if a corrupted filesystem returned invalid size values.
## Tests

Manual tests
