### PR TITLE
Revert "Fix for EZP-23249: Clear prioritized language list cache when sw...

### DIFF
--- a/kernel/classes/ezsiteaccess.php
+++ b/kernel/classes/ezsiteaccess.php
@@ -546,8 +546,6 @@ class eZSiteAccess
             }
 
             eZSys::setAccessPath( $access['uri_part'], $name );
-            
-            eZContentLanguage::clearPrioritizedLanguages();
 
             eZUpdateDebugSettings();
             eZDebugSetting::writeDebug( 'kernel-siteaccess', "Updated settings to use siteaccess '$name'", __METHOD__ );


### PR DESCRIPTION
Reverts ezsystems/ezpublish-legacy#1058

Causes fatal error during setup wizard as the call causes a fetch using non configured database settings.
