### PR TITLE
Fix EZP-23299: ezpm: adding a subtree with nodeId misses children

### DIFF
--- a/kernel/classes/packagehandlers/ezcontentobject/ezcontentobjectpackagehandler.php
+++ b/kernel/classes/packagehandlers/ezcontentobject/ezcontentobjectpackagehandler.php
@@ -1567,7 +1567,6 @@ class eZContentObjectPackageHandler extends eZPackageHandler
             else
             {
                 $nodeID = false;
-                $subtree = false;
                 if ( is_numeric( $argument ) )
                 {
                     $nodeID = (int)$argument;
@@ -1585,7 +1584,6 @@ class eZContentObjectPackageHandler extends eZPackageHandler
                     if ( preg_match( "#(.+)/\*$#", $path, $matches ) )
                     {
                         $path = $matches[1];
-                        $subtree = true;
                     }
                     $node = eZContentObjectTreeNode::fetchByURLPath( $path );
                     if ( is_object( $node ) )
@@ -1601,7 +1599,7 @@ class eZContentObjectPackageHandler extends eZPackageHandler
                 if ( $nodeID )
                 {
                     $nodeItem['node-id-list'][] = array( 'id' => $nodeID,
-                                                         'subtree' => $subtree,
+                                                         'subtree' => true,
                                                          'node' => &$node );
                 }
                 if ( $error )


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-23299
## Description

The behavior was not the same when exporting content objects. When passing its path has parameter, it would get the whole subtree, and when passing its nodeId it would only get the children.

This patch makes both type of parameter retrieve the same content, meaning the whole subtree.
## Tests

Manual tests
