### PR TITLE
Fix EZP-23316: AdvancedObjectRelationList: content not saved

### DIFF
--- a/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
+++ b/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
@@ -69,7 +69,7 @@ class eZObjectRelationListType extends eZDataType
             }
             return eZInputValidator::STATE_ACCEPTED;
         }
-        else
+        else if ( eZINI::instance()->variable( 'BackwardCompatibilitySettings', 'AdvancedObjectRelationList' ) == "disabled" )
         {
             // If in browse mode and relations have been added using the search field
             // items are stored in the post variable


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-23316
## Description

Since #1003 there is the regression when using `AdvancedObjectRelationList` the `else` statement added then would avoid the `AdvancedObjectRelationList` code to be executed.
## Tests

Manual test with and without `AdvancedObjectRelationList` enabled
