### PR TITLE
Fix EZP-23322: validate if required object relation list is empty

### DIFF
--- a/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
+++ b/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
@@ -73,7 +73,10 @@ class eZObjectRelationListType extends eZDataType
         {
             // If in browse mode and relations have been added using the search field
             // items are stored in the post variable
-            if ( count( $http->postVariable( $postVariableName ) ) > 0  )
+            if (
+                $http->postVariable( $postVariableName ) != array( "no_relation" )
+                && count( $http->postVariable( $postVariableName ) ) > 0
+            )
             {
                 return eZInputValidator::STATE_ACCEPTED;
             }


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23322

This fixes a regression introduced in EZP-23028, causing a required objectrelationlist attribute to be accepted.
