### PR TITLE
Fix EZP-23296: Template Block Cache has cache key collisions

### DIFF
--- a/doc/bc/5.4/changes-5.4.txt
+++ b/doc/bc/5.4/changes-5.4.txt
@@ -8,6 +8,15 @@ INI setting changes
 Change of behavior
 ------------------
 
+- EZP-23296: Template Block Cache has cache key collisions
+
+  The template cache blocks where using crc32 which has a high probability of collisions.
+  Feature has been changed to use md5 like viewcache already uses.
+
+  Note: To avoid that you have to many cache blocks take advantage of putting identical once in
+  own template so they will share cache (template and location of block is part of internal unique key).
+
+
 Removed features
 ----------------
 

--- a/lib/eztemplate/classes/eztemplatecacheblock.php
+++ b/lib/eztemplate/classes/eztemplatecacheblock.php
@@ -167,7 +167,7 @@ class eZTemplateCacheBlock
      */
     static function cachePath( $keyString, $nodeID = false )
     {
-        $filename = eZSys::ezcrc32( $keyString ) . ".cache";
+        $filename = md5( $keyString ) . ".cache";
 
         $phpDir = eZTemplateCacheBlock::templateBlockCacheDir();
         if ( is_numeric( $nodeID ) )


### PR DESCRIPTION
The template cache blocks where using crc32 which has a high probability of collisions.
Feature has been changed to use md5 like viewcache already uses.

Note: To avoid that you have to many cache blocks take advantage of putting identical once in
own templates so they will share the case (file and location of block is part of the unique key).

_WARNING: If this is back ported, cache for template block will have to be cleared!_
