### PR TITLE
EZP-23277 REST siteaccess can be set via X-Siteaccess header

### DIFF
--- a/index_rest.php
+++ b/index_rest.php
@@ -30,11 +30,16 @@ eZExtension::activateExtensions( 'default' );
 // debug settings here
 function eZUpdateDebugSettings() {}
 
-// load siteaccess
-$access = eZSiteAccess::match( $uri,
-                      eZSys::hostname(),
-                      eZSys::serverPort(),
-                      eZSys::indexFile() );
+// set siteaccess from X-Siteaccess header if given and exists
+if ( isset( $_SERVER['HTTP_X_SITEACCESS'] ) && eZSiteAccess::exists( $_SERVER['HTTP_X_SITEACCESS'] ) )
+{
+    $access = array( 'name' => $_SERVER['HTTP_X_SITEACCESS'], 'type' => eZSiteAccess::TYPE_STATIC );
+}
+else
+{
+    $access = eZSiteAccess::match( $uri, eZSys::hostname(), eZSys::serverPort(), eZSys::indexFile() );
+}
+
 $access = eZSiteAccess::change( $access );
 
 // load siteaccess extensions

--- a/kernel/classes/ezsiteaccess.php
+++ b/kernel/classes/ezsiteaccess.php
@@ -722,4 +722,21 @@ class eZSiteAccess
         eZDebug::writeWarning("Tried to find siteaccess based on '$language' but '$sa' is not a valid RelatedSiteAccessList[]", __METHOD__ );
         return null;
     }
+
+    /**
+     * Checks if $siteAccessName matches a configured siteaccess
+     * @param $siteAccessName
+     * @return bool
+     */
+    public static function exists( $siteAccessName )
+    {
+        foreach ( eZSiteAccess::siteAccessList() as $siteaccessListItem )
+        {
+            if ( $siteaccessListItem['name'] == $siteAccessName )
+            {
+                return true;
+            }
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
Without this change, the classical siteacces matching rules applied, but the request URI wasn't changed if uri matching was used. As a consequence, uri based matching was unusable (and the rewrite rules didn't allow it by default).

This unifies how the REST API v1 behaves as compared to v2, by allowing the SA to be specified via a custom header, such as `X-Siteaccess: site_admin`.

If the header is not passed, matching will be tried as it was before.
