### PR TITLE
Fix EZP-23341: incorrect subtree limitation check in section/assign

### DIFF
--- a/kernel/classes/datatypes/ezuser/ezuser.php
+++ b/kernel/classes/datatypes/ezuser/ezuser.php
@@ -2007,6 +2007,7 @@ WHERE user_id = '" . $userID . "' AND
             $classID = $contentObject->attribute( 'contentclass_id' );
             $ownerID = $contentObject->attribute( 'owner_id' );
             $sectionID = $contentObject->attribute( 'section_id' );
+            $nodePath = $contentObject->mainNode()->PathString;
 
             foreach ( $access['policies'] as $policy )
             {
@@ -2015,6 +2016,22 @@ WHERE user_id = '" . $userID . "' AND
                      ( isset( $policy['Section'] ) and !in_array( $sectionID, $policy['Section'] ) ) )
                 {
                     continue;
+                }
+                if ( isset( $policy['User_Subtree'] ) )
+                {
+                    $subtreeLimitationResult = false;
+                    foreach ( $policy['User_Subtree'] as $path )
+                    {
+                        if ( strpos( $nodePath, $path ) !== false )
+                        {
+                            $subtreeLimitationResult = true;
+                        }
+                    }
+                    // If a subtree limitation exists and none of the path corresponds then the user have not enough rights.
+                    if ( !$subtreeLimitationResult )
+                    {
+                        continue;
+                    }
                 }
                 if ( isset( $policy['NewSection'] ) )
                 {


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23341

If a role exists with a subtree limitation, section/assign check will not consider other (more permissive) roles .
This fixes it by looking at the subtree limitation at each policy, and denying it if subtrees don't match.
