### PR TITLE
Fix EZP-23307: PHP Fatal error: Failed opening required ezpkernelredirec...

### DIFF
--- a/kernel/classes/datatypes/ezuser/ezuser.php
+++ b/kernel/classes/datatypes/ezuser/ezuser.php
@@ -1107,7 +1107,7 @@ WHERE user_id = '" . $userID . "' AND
      */
     static function instance( $id = false )
     {
-        if ( !empty( $GLOBALS["eZUserGlobalInstance_$id"] ) )
+        if ( is_numeric( $id ) && $id > 0 && !empty( $GLOBALS["eZUserGlobalInstance_$id"] ) )
         {
             return $GLOBALS["eZUserGlobalInstance_$id"];
         }
@@ -1228,7 +1228,10 @@ WHERE user_id = '" . $userID . "' AND
             eZDebug::writeWarning( 'Anonymous user not found, returning NoUser' );
         }
 
-        $GLOBALS["eZUserGlobalInstance_$id"] = $currentUser;
+        if ( is_numeric( $id ) && $id > 0 )
+        {
+            $GLOBALS["eZUserGlobalInstance_$id"] = $currentUser;
+        }
         return $currentUser;
     }
 


### PR DESCRIPTION
...t.php

The wrong currentUser() is returned on post-login redirect, because instance() creates and loads invalid globals cache.

https://jira.ez.no/browse/EZP-23307

Don't ask me to explain the finer details of this, I have no idea. Also, if it passes all tests, I'll book a trip to Las Vegas.
