### PR TITLE
Fix EZP-23312: Async pub: old processes are filling up the database

### DIFF
--- a/bin/php/ezasynchronouspublisher.php
+++ b/bin/php/ezasynchronouspublisher.php
@@ -35,26 +35,15 @@ foreach( $pcntlFunctions as $pcntlFunction )
 
 $options = $script->getOptions(
     // options definition
-    "[n|daemon][p:|pid-file:][cleanup-interval:]",
+    "[n|daemon][p:|pid-file:]",
     // arguments definition
     "",
     // options documentation
     array( 'daemon' => 'Run in the background',
-           'pid-file' => 'PID file',
-           'cleanup-interval' => 'Number of seconds between each db table cleanup. Default value is 43200 (12 hours)' ) );
+           'pid-file' => 'PID file' ) );
 $sys = eZSys::instance();
 
 $script->initialize();
-
-$cleanup = 0;
-if ( isset( $options['cleanup-interval'] ) )
-{
-    $cleanup = $options['cleanup-interval'];
-    if ( !is_int( $cleanup ) || $cleanup < 1 )
-    {
-        $script->shutdown( 3, "Invalid value for cleanup-interval:'$cleanup'" );
-    }
-}
 
 if ( isset( $options['pid-file'] ) )
 {
@@ -203,7 +192,6 @@ else
 $processor = ezpContentPublishingQueueProcessor::instance();
 $processor->setOutput( $output );
 $processor->setSignalHandler( $daemonSignalHandler );
-$processor->setCleanupInterval( $cleanup );
 $processor->run();
 
 eZScript::instance()->shutdown( 0 );

--- a/settings/content.ini
+++ b/settings/content.ini
@@ -511,6 +511,14 @@ AsynchronousPublishingQueueReader=ezpContentPublishingQueue
 # default: 1
 AsynchronousPollingInterval=1
 
+# How frequent the daemon cleans the queue (sleep in seconds)
+# default: 43200 (12 hours)
+AsynchronousCleanupInterval=43200
+
+# How old processes need to be in order to be cleaned (in seconds)
+# default: 604800 (a week)
+AsynchronousCleanupAgeLimit=604800
+
 [TestingSettings]
 # Enable or disable multivariate testing feature
 MultivariateTesting=disabled


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-23312
## Description

This is a follow up of #1067. It replaces command line arguments by ini configuration so it is more coherent with existing way to setup the deamon: https://doc.ez.no/eZ-Publish/Technical-manual/5.x/Features/Queue-handling-in-asynchronous-publishing/Enable-the-publishing-queue-functionality
## Tests

Manual tests
