### PR TITLE
EZP-23249: Switching siteaccess does not update prioritized languages

### DIFF
--- a/kernel/classes/ezsiteaccess.php
+++ b/kernel/classes/ezsiteaccess.php
@@ -547,6 +547,8 @@ class eZSiteAccess
 
             eZSys::setAccessPath( $access['uri_part'], $name );
 
+            eZContentLanguage::expireCache( false );
+
             eZUpdateDebugSettings();
             eZDebugSetting::writeDebug( 'kernel-siteaccess', "Updated settings to use siteaccess '$name'", __METHOD__ );
         }

--- a/kernel/content/versionview.php
+++ b/kernel/content/versionview.php
@@ -245,8 +245,6 @@ eZTranslatorManager::resetTranslations();
 ezpI18n::reset();
 eZContentObject::clearCache();
 
-eZContentLanguage::expireCache( false );
-
 $Module->setTitle( 'View ' . $class->attribute( 'name' ) . ' - ' . $contentObject->attribute( 'name' ) );
 
 $ini = eZINI::instance();

--- a/kernel/setup/steps/ezstep_create_sites.php
+++ b/kernel/setup/steps/ezstep_create_sites.php
@@ -660,13 +660,13 @@ id=$engLanguageID";
             $db->query( $updateSql );
             eZContentLanguage::expireCache();
             $primaryLanguageObj = eZContentLanguage::fetchByLocale( $primaryLanguageLocaleCode );
-            /*
+
             // Add it if it is missing (most likely)
             if ( !$primaryLanguageObj )
             {
                 $primaryLanguageObj = eZContentLanguage::addLanguage( $primaryLanguageLocaleCode, $primaryLanguageName );
             }
-            */
+
             $primaryLanguageID = (int)$primaryLanguageObj->attribute( 'id' );
 
             // Find objects which are always available
@@ -1124,12 +1124,21 @@ language_locale='eng-GB'";
                     {
                         $templateLookObject = current( $objectList );
                         $dataMap = $templateLookObject->fetchDataMap();
-                        $dataMap[ 'title' ]->setAttribute( 'data_text', $siteINIChanges['SiteSettings']['SiteName'] );
-                        $dataMap[ 'title' ]->store();
-                        $dataMap[ 'siteurl' ]->setAttribute( 'data_text', $siteINIChanges['SiteSettings']['SiteURL'] );
-                        $dataMap[ 'siteurl' ]->store();
-                        $dataMap[ 'email' ]->setAttribute( 'data_text', $siteINIChanges['MailSettings']['AdminEmail'] );
-                        $dataMap[ 'email' ]->store();
+                        if ( isset( $dataMap[ 'title' ] ) )
+                        {
+                            $dataMap[ 'title' ]->setAttribute( 'data_text', $siteINIChanges['SiteSettings']['SiteName'] );
+                            $dataMap[ 'title' ]->store();
+                        }
+                        if ( isset( $dataMap[ 'siteurl' ] ) )
+                        {
+                            $dataMap[ 'siteurl' ]->setAttribute( 'data_text', $siteINIChanges['SiteSettings']['SiteURL'] );
+                            $dataMap[ 'siteurl' ]->store();
+                        }
+                        if ( isset( $dataMap[ 'email' ] ) )
+                        {
+                            $dataMap[ 'email' ]->setAttribute( 'data_text', $siteINIChanges['MailSettings']['AdminEmail'] );
+                            $dataMap[ 'email' ]->store();
+                        }
                         $objectName = $templateLookClass->contentObjectName( $templateLookObject );
                         $templateLookObject->setName( $objectName );
                         $templateLookObject->store();


### PR DESCRIPTION
This fork has the code from:
https://github.com/ezsystems/ezpublish-legacy/pull/1078#issuecomment-56054814

which fixes:
https://jira.ez.no/browse/EZP-23249

with minor changes that prevent the setup wizard from failing when choosing 'Remove existing data' from the database.
