### PR TITLE
Fix EXP-23312: Async pub: old processes are filling up the database - Typo fix

### DIFF
--- a/kernel/private/classes/ezpcontentpublishingqueueprocessor.php
+++ b/kernel/private/classes/ezpcontentpublishingqueueprocessor.php
@@ -179,7 +179,7 @@ class ezpContentPublishingQueueProcessor
                 $db = eZDB::instance();
                 eZDB::setInstance( null );
                 $deleteBefore = time() - $this->cleanupAgeLimit;
-                $definition = ezpContentPublishingProcess::definition()
+                $definition = ezpContentPublishingProcess::definition();
                 $processTable = $definition['name'];
                 $db->query( "DELETE from ". $processTable. " WHERE status =".  ezpContentPublishingProcess::STATUS_FINISHED. " AND finished < ". $deleteBefore );
                 $this->cleanupLastTime = time();


### PR DESCRIPTION
### EXP-23312: Async pub: old processes are filling up the database

This additional fix is needed due to the fact that ezrobots didn't detect the missing ;
introduced in #1083 
