### PR TITLE
Fix EZP-23421: Add support for static cache handler system in rss import cronjob part

### DIFF
--- a/cronjobs/rssimport.php
+++ b/cronjobs/rssimport.php
@@ -82,7 +82,16 @@ foreach ( $rssImportArray as $rssImport )
 
 }
 
-eZStaticCache::executeActions();
+if ( eZINI::instance( 'site.ini' )->variable( 'ContentSettings', 'StaticCache' ) == 'enabled' )
+{
+    $optionArray = array( 'iniFile' => 'site.ini',
+                          'iniSection' => 'ContentSettings',
+                          'iniVariable' => 'StaticCacheHandler' );
+
+    $options = new ezpExtensionOptions( $optionArray );
+    $staticCacheHandler = eZExtension::getHandlerClass( $options );
+    $staticCacheHandler::executeActions();
+}
 
 /*!
   Parse RSS 1.0 feed


### PR DESCRIPTION
Implemented: EZP-23421: Add support for static cache handler system in rss import cronjob part
# The problem

Hello,

Recently we tried on a new project to implement delayed to cronjob static caching support for rssimport cronjob imported content. We also implemented a custom static cache handler class and settings changes which work well except in one regard, rssimport of content.

Results were when using rssimport cronjob part the requests to update static cache via delayed to cronjob feature using the staticcache_cleanup cronjob part were not being stored.

This is because the rssimport cronjob part does not support the standard static cache handler system that the rest of the kernel supports. We traced the problem in code to one line 'eZStaticCache::executeActions();' in the cronjobs/rssimport.php file.
# The solution

We then wrote replacement code to enable support for the static cache handler system. See pull request file changes diff.

We have created a new issue ticket about this feature request, you can find it here: https://jira.ez.no/browse/EZP-23421

Please review and let us know what you think.

Thank you for your continued support!

Cheers,
Brookins Consulting
