### PR TITLE
Fix EZP-23425: Pasting at the end of paragraph in Chrome put the text at the beginning

### DIFF
--- a/extension/ezoe/design/standard/templates/content/datatype/edit/ezxmltext_ezoe.tpl
+++ b/extension/ezoe/design/standard/templates/content/datatype/edit/ezxmltext_ezoe.tpl
@@ -131,7 +131,7 @@
         atd_css_url : {'javascript/plugins/AtD/css/content.css'|ezdesign},
         paste_text_linebreaktype : "br",
         paste_preprocess : function(pl, o) {ldelim}
-            var ed = pl.editor, uid, elt, prev;
+            var ed = pl.editor, uid, elt, prev, bm;
 
             // Strip <a> HTML tags from clipboard content (Happens on Internet Explorer)
             o.content = o.content.replace( /(\s[a-z]+=")<a\s[^>]+>([^<]+)<\/a>/gi, '$1$2' );
@@ -144,6 +144,7 @@
             if ( tinymce.isWebKit ) {
                 uid = tinymce.DOM.uniqueId();
                 ed.focus();
+                bm = ed.selection.getBookmark();
                 ed.execCommand('mceInsertContent', false, '<span id="' + uid + '"></span>');
                 elt = ed.getDoc().getElementById(uid);
 
@@ -157,6 +158,7 @@
                     }
                 }
                 ed.dom.remove(elt);
+                ed.selection.moveToBookmark(bm);
             }
             {/literal}
         {rdelim},


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23425
# Description

As the title says, if you paste something at the end of a paragraph with Chrome after adding a space, the pasted text appears at the beginning of the paragraph. This is a _regression_ caused by the patch for [EZP-21903](https://jira.ez.no/browse/EZP-21903) (see https://github.com/ezsystems/ezpublish-legacy/pull/834) that happens only in recent Chrome version.

The patch makes sure the text is pasted at the correct place by [using a _selection bookmark_](http://www.tinymce.com/wiki.php/API3:method.tinymce.dom.Selection.getBookmark).
# Tests

manual tests in Chrome 38
