### PR TITLE
Fix EZP-23477: exception when trashing empty image

### DIFF
--- a/kernel/classes/datatypes/ezimage/ezimagetype.php
+++ b/kernel/classes/datatypes/ezimage/ezimagetype.php
@@ -57,7 +57,10 @@ class eZImageType extends eZDataType
 
         // Now clean all other aliases, not cleanly registered within the attribute content
         // First get all remaining aliases full path to then safely move them to the trashed folder
-        ezpEvent::getInstance()->notify( 'image/trashAliases', array( $originalAlias['url'] ) );
+        if ( (string)$originalAlias['url'] !== '' )
+        {
+            ezpEvent::getInstance()->notify( 'image/trashAliases', array( $originalAlias['url'] ) );
+        }
         $aliasNames = array_keys( $imageHandler->aliasList() );
         $aliasesPath = array();
         foreach ( $aliasNames as $aliasName )


### PR DESCRIPTION
> Fixes [EZP-23477](https://jira.ez.no/browse/EZP-23477)

```
Argument 'BinaryFile::id' is invalid: '' is wrong value in class 'BinaryFile'
```

Fixed by only calling `ezpEvent::getInstance()->notify( 'image/trashAliases', array( $originalAlias['url'] ) );` if there is an actual image to trash aliases for.
