### PR TITLE
Fix EZP-23491: clear cache when using tag name list

### DIFF
--- a/bin/php/ezcache.php
+++ b/bin/php/ezcache.php
@@ -30,7 +30,7 @@ $script->startup();
 
 $options = $script->getOptions( "[clear-tag:][clear-id:][clear-all]" . /*[purge-tag:][purge-id:][purge-all]*/ "[iteration-sleep:][iteration-max:][expiry:][list-tags][list-ids][purge]",
                                 "",
-                                array( 'clear-tag' => 'Clears all caches related to a given tag',
+                                array( 'clear-tag' => 'Clears all caches related to a given tag, separate multiple tags with a comma',
                                        'clear-id' => 'Clears all caches related to a given id, separate multiple ids with a comma',
                                        'clear-all' => 'Clears all caches',
                                        'purge' => 'Enforces purging of cache items which ensures that specified entries are physically removed (Useful for saving diskspace). Used together with the clear-* options.',

--- a/kernel/classes/ezcache.php
+++ b/kernel/classes/ezcache.php
@@ -309,7 +309,7 @@ class eZCache
     /**
      * Finds all cache entries using tag $tagName.
      *
-     * @param string $tagName The tag name
+     * @param string $tagName The tag name, or comma-separated list of names
      * @param bool|array $cacheInfoList The list of cache info per entry
      * @return array An array with cache items.
      */
@@ -319,12 +319,17 @@ class eZCache
             $cacheInfoList = eZCache::fetchList();
 
         $cacheEntries = array();
+        $tagList = explode( ',', $tagName );
         foreach ( $cacheInfoList as $cacheInfo )
         {
-            $tagList = $cacheInfo['tag'];
-            if ( $tagList !== false and in_array( $tagName, $tagList ) )
+            if ( !is_array( $cacheInfo['tag'] ) )
+                continue;
+
+            $matchingTags = array_intersect( $tagList, $cacheInfo['tag'] );
+            if ( !empty( $matchingTags ) )
                 $cacheEntries[] = $cacheInfo;
         }
+
         return $cacheEntries;
     }
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23491

Documentation states it's possible to clear (legacy) cache by specifying a comma separated list:

```
--clear-tag=<cache_tag>[,<cache_tag2>...]
```

This PR implements the necessary changes so that it actually works.

Tests: Manual
