### PR TITLE
Fix EZP-23459: eZContentObjectTreeNodeOperations::move missing features

### DIFF
--- a/kernel/classes/ezcontentobjecttreenodeoperations.php
+++ b/kernel/classes/ezcontentobjecttreenodeoperations.php
@@ -68,7 +68,12 @@ class eZContentObjectTreeNodeOperations
         }
 
         // clear cache for old placement.
-        eZContentCacheManager::clearContentCacheIfNeeded( $objectID );
+        // If child count exceeds threshold, do nothing here, and instead clear all view cache at the end.
+        $childCountInThresholdRange = eZContentCache::inCleanupThresholdRange( $node->childrenCount( false ) );
+        if ( $childCountInThresholdRange )
+        {
+            eZContentCacheManager::clearContentCacheIfNeeded( $objectID );
+        }
 
         $db = eZDB::instance();
         $db->begin();
@@ -120,7 +125,15 @@ class eZContentObjectTreeNodeOperations
         $db->commit();
 
         // clear cache for new placement.
-        eZContentCacheManager::clearContentCacheIfNeeded( $objectID );
+        // If child count exceeds threshold, clear all view cache instead.
+        if ( $childCountInThresholdRange )
+        {
+            eZContentCacheManager::clearContentCacheIfNeeded( $objectID );
+        }
+        else
+        {
+            eZContentCacheManager::clearAllContentCache();
+        }
 
         return $result;
     }


### PR DESCRIPTION
Ensure that it checks whether view caching is enabled before clearing it. (Edit: Never mind, is already done)
Ensure that CacheThreshold is respected, if exceeded clear all cache.

https://jira.ez.no/browse/EZP-23459

(Part 3: Defer to script monitor will be moved to a separate issue)
