### PR TITLE
Fix EZP-23499: Fatal error removing class with unexistant datatype.

### DIFF
--- a/kernel/classes/ezcontentclass.php
+++ b/kernel/classes/ezcontentclass.php
@@ -812,7 +812,17 @@ You will need to change the class of the node by using the swap functionality.' 
         foreach ( $this->fetchAttributes() as $attribute )
         {
             $dataType = $attribute->dataType();
-            if ( !$dataType->isClassAttributeRemovable( $attribute ) )
+
+            if ( $dataType === null )
+            {
+                eZDebug::writeError(
+                    "Skipping removal of class attribute for non-existent datatype " . $attribute->DataTypeString,
+                    __METHOD__
+                );
+                continue;
+            }
+
+            if ( $dataType->isClassAttributeRemovable( $attribute ) )
             {
                 $info = $dataType->classAttributeRemovableInformation( $attribute, $includeAll );
                 $result['list'][] = $info;
@@ -857,6 +867,14 @@ You will need to change the class of the node by using the swap functionality.' 
             foreach ( $classAttributes as $classAttribute )
             {
                 $dataType = $classAttribute->dataType();
+                if ( $dataType === null )
+                {
+                    eZDebug::writeError(
+                        "Skipping removal of class attribute for non-existent datatype " . $classAttribute->DataTypeString,
+                        __METHOD__
+                    );
+                    continue;
+                }
                 $dataType->deleteStoredClassAttribute( $classAttribute, $version );
             }
             eZPersistentObject::removeObject( eZContentClassAttribute::definition(),


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23499

This prevents a PHP fatal error when removing a class (contentType) if a datatype has been removed.
Instead, it is logged to error.log
