### PR TITLE
Fix EZP-23497: allow user de-selection when editing multiplexer workflow

### DIFF
--- a/kernel/classes/workflowtypes/event/ezmultiplexer/ezmultiplexertype.php
+++ b/kernel/classes/workflowtypes/event/ezmultiplexer/ezmultiplexertype.php
@@ -352,6 +352,11 @@ class eZMultiplexerType extends eZWorkflowEventType
 
     function fetchHTTPInput( $http, $base, $event )
     {
+        if ( !$http->hasPostVariable( "StoreButton" ) )
+        {
+            return;
+        }
+
         $sectionsVar = $base . "_event_ezmultiplexer_section_ids_" . $event->attribute( "id" );
         if ( $http->hasPostVariable( $sectionsVar ) )
         {
@@ -384,12 +389,12 @@ class eZMultiplexerType extends eZWorkflowEventType
         if ( $http->hasPostVariable( $usersVar ) )
         {
             $usersArray = $http->postVariable( $usersVar );
-            if ( in_array( '-1', $usersArray ) )
-            {
-                $usersArray = array( -1 );
-            }
             $usersString = implode( ',', $usersArray );
             $event->setAttribute( "data_text2", $usersString );
+        }
+        else
+        {
+            $event->setAttribute( "data_text2", '' );
         }
 
         $classesVar = $base . "_event_ezmultiplexer_class_ids_" . $event->attribute( "id" );


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23497

In the multiplexer workflow, "Users without Workflow IDs" should be de-selectable (no option), unlike the other properties (for which the value `-1` represents "All ...")

Fix: If the corresponding http var is not set, clear this event attribute.

However, `fetchHTTPInput()` was being called on ALL operations, not just on store.
This means that when editing the workflow, the attribute was being reset again (no http post vars)

Solution:
Fetch HTTP input only when storing the workflow.
