### PR TITLE
Fix EZP-23480: Error in json response when uploading file

### DIFF
--- a/design/admin/templates/content/datatype/edit/ezobjectrelation_ajaxuploader.tpl
+++ b/design/admin/templates/content/datatype/edit/ezobjectrelation_ajaxuploader.tpl
@@ -16,6 +16,12 @@
     {literal}
     (function () {
         YUI(YUI3_config).use('ezmodalwindow', 'ezajaxuploader', function (Y) {
+
+            // move modal-window outside the form (add it to the body node)
+            var modalwindow = Y.one('#relation-modal-window');
+            Y.one(document.body).append( modalwindow.cloneNode(true) );
+            modalwindow.remove();
+
             var uploaderConf = {
                 target: {},
                 open: {

--- a/design/admin/templates/content/datatype/edit/ezobjectrelationlist_ajaxuploader.tpl
+++ b/design/admin/templates/content/datatype/edit/ezobjectrelationlist_ajaxuploader.tpl
@@ -20,6 +20,12 @@
     {literal}
     (function () {
         YUI(YUI3_config).use('ezmodalwindow', 'ezajaxuploader', function (Y) {
+
+            // move modal-window outside the form (add it to the body node)
+            var modalwindow = Y.one('#relationlist-modal-window');
+            Y.one(document.body).append( modalwindow.cloneNode(true) );
+            modalwindow.remove();
+
             var uploaderConf = {
                 target: {},
                 open: {


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23480

Under IE, ajax upload of files can lead to errors due to an incompatibility with eZAutoSave.
This "blacklists" the returned form fields for the ajax upload interface (window popup), which causes autosave ignore user input.

Tests: manual.
