### PR TITLE
Fix EZP-23528: eZContentObjectTreeNode::createAttributeFilterSQLStrings(...

### DIFF
--- a/kernel/classes/ezcontentobjecttreenode.php
+++ b/kernel/classes/ezcontentobjecttreenode.php
@@ -1017,11 +1017,13 @@ class eZContentObjectTreeNode extends eZPersistentObject
                     $filterValue = is_array( $filter[2] ) ? '' : $db->escapeString( $filter[2] );
 
                     $useAttributeFilter = false;
+                    $filterFieldType = 'integer';
                     switch ( $filterAttributeID )
                     {
                         case 'path':
                         {
                             $filterField = 'path_string';
+                            $filterFieldType = 'string';
                         } break;
                         case 'published':
                         {
@@ -1103,11 +1105,13 @@ class eZContentObjectTreeNode extends eZPersistentObject
                         case 'class_identifier':
                         {
                             $filterField = 'ezcontentclass.identifier';
+                            $filterFieldType = 'string';
                         } break;
                         case 'class_name':
                         {
                             $classNameFilter = eZContentClassName::sqlFilter();
                             $filterField = $classNameFilter['nameField'];
+                            $filterFieldType = 'string';
                             $filterSQL['from'] .= " INNER JOIN $classNameFilter[from] ON ($classNameFilter[where])";
                         } break;
                         case 'priority':
@@ -1117,6 +1121,7 @@ class eZContentObjectTreeNode extends eZPersistentObject
                         case 'name':
                         {
                             $filterField = 'ezcontentobject_name.name';
+                            $filterFieldType = 'string';
                         } break;
                         case 'owner':
                         {
@@ -1284,7 +1289,15 @@ class eZContentObjectTreeNode extends eZPersistentObject
                                     while ( list( $key, $value ) = each( $filter[2] ) )
                                     {
                                         // Non-numerics must be escaped to avoid SQL injection
-                                        $filter[2][$key] = is_numeric( $value ) ? $value : "'" . $db->escapeString( $value ) . "'";
+                                        switch ( $filterFieldType )
+                                        {
+                                            case 'string':
+                                                $filter[2][$key] = "'" . $db->escapeString( $value ) . "'";
+                                                break;
+                                            case 'integer':
+                                            default:
+                                                $filter[2][$key] = (int) $value;
+                                        }
                                     }
                                     $filterValue = '(' .  implode( ",", $filter[2] ) . ')';
                                 }

--- a/tests/tests/kernel/classes/ezcontentobjecttreenode_test2.php
+++ b/tests/tests/kernel/classes/ezcontentobjecttreenode_test2.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * File containing the eZContentObjectTreeNodeTest2 class
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ * @package tests
+ */
+
+class eZContentObjectTreeNodeTest2 extends ezpDatabaseTestCase
+{
+    public function providerForTestIssue23528()
+    {
+        return array(
+            // integer
+            array( 'published',        "                            ( ezcontentobject.published IN (1,3,0,1,0)  ) AND " ),
+            array( 'modified',         "                            ( ezcontentobject.modified IN (1,3,0,1,0)  ) AND " ),
+            array( 'modified_subnode', "                            ( modified_subnode IN (1,3,0,1,0)  ) AND " ),
+            array( 'node_id',          "                            ( ezcontentobject_tree.node_id IN (1,3,0,1,0)  ) AND " ),
+            array( 'contentobject_id', "                            ( ezcontentobject_tree.contentobject_id IN (1,3,0,1,0)  ) AND " ),
+            array( 'section',          "                            ( ezcontentobject.section_id IN (1,3,0,1,0)  ) AND " ),
+            array( 'state',            "                            ( ezcontentobject.id IN (SELECT contentobject_id FROM ezcobj_state_link WHERE contentobject_state_id IN ( 1, 3, 0, 1, 0 )) ) AND " ),
+            array( 'depth',            "                            ( depth IN (1,3,0,1,0)  ) AND " ),
+            array( 'priority',         "                            ( ezcontentobject_tree.priority IN (1,3,0,1,0)  ) AND " ),
+            array( 'owner',            "                            ( ezcontentobject.owner_id IN (1,3,0,1,0)  ) AND " ),
+            array( 'visibility',       "                            ( ezcontentobject_tree.is_invisible IN (1,3,0,1,0)  ) AND " ),
+            // string
+            array( 'path',             "                            ( path_string IN ('1','3','foo','1foo','foo_1')  ) AND " ),
+            array( 'class_identifier', "                            ( ezcontentclass.identifier IN ('1','3','foo','1foo','foo_1')  ) AND " ),
+            array( 'class_name',       "                            ( ezcontentclass_name.name IN ('1','3','foo','1foo','foo_1')  ) AND " ),
+            array( 'name',             "                            ( ezcontentobject_name.name IN ('1','3','foo','1foo','foo_1')  ) AND " ),
+        );
+    }
+
+    /**
+     * eZContentObjectTreeNode::createAttributeFilterSQLStrings() returns
+     * invalid 'in'/'not in' SQL statements
+     *
+     * @link http://issues.ez.no/23528
+     * @dataProvider providerForTestIssue23528
+     */
+    public function testIssue23528( $name, $expected )
+    {
+        $params = array( 1, '3', 'foo', '1foo', 'foo_1' );
+        $attributeFilterParams = array( array( $name, 'in', $params ) );
+        $attributeFilter = eZContentObjectTreeNode::createAttributeFilterSQLStrings( $attributeFilterParams );
+        $this->assertEquals( $expected, $attributeFilter['where'] );
+    }
+}

--- a/tests/tests/kernel/suite.php
+++ b/tests/tests/kernel/suite.php
@@ -23,6 +23,7 @@ class eZKernelTestSuite extends ezpDatabaseTestSuite
         $this->addTestSuite( 'eZContentObjectTest2' );
         $this->addTestSuite( 'eZContentObjectTreeNodeRegression' );
         $this->addTestSuite( 'eZContentObjectTreeNodeTest' );
+        $this->addTestSuite( 'eZContentObjectTreeNodeTest2' );
         $this->addTestSuite( 'eZContentFunctionCollectionRegression' );
         $this->addTestSuite( 'eZContentFunctionCollectionTest' );
         $this->addTestSuite( 'eZURLAliasMLTest' );


### PR DESCRIPTION
...) returns invalid 'in'/'not in' SQL statements

> https://jira.ez.no/browse/EZP-23528
