### PR TITLE
Fix EZP-23527: ezdatetime with no default value causes class edit to fai...

### DIFF
--- a/kernel/classes/datatypes/ezdatetime/ezdatetimetype.php
+++ b/kernel/classes/datatypes/ezdatetime/ezdatetimetype.php
@@ -625,7 +625,7 @@ class eZDateTimeType extends eZDataType
 
             default:
             {
-                $default = null;
+                return array();
             }
         }
 


### PR DESCRIPTION
...l

According to the other datatypes I have checked, it should return an empty array in this case.

https://jira.ez.no/browse/EZP-23527
