### PR TITLE
Fix EZP-23529: Storing a draft with a bad object relation link should no...

### DIFF
--- a/kernel/classes/ezcontentobject.php
+++ b/kernel/classes/ezcontentobject.php
@@ -2833,6 +2833,14 @@ class eZContentObject extends eZPersistentObject
                                  "eZContentObject::addContentObjectRelation" );
             return false;
         }
+
+        if ( !eZContentObject::exists( $toObjectID ) )
+        {
+            eZDebug::writeError( "Related object ID (toObjectID): '$toObjectID', does not refer to any existing object.",
+                                 "eZContentObject::addContentObjectRelation" );
+            return false;
+        }
+
         $fromObjectID =(int) $fromObjectID;
         $attributeID =(int) $attributeID;
         $fromObjectVersion =(int) $fromObjectVersion;


### PR DESCRIPTION
...t create an entry in ezcontentobject_link

Do not store the ezcontentobject_link entry if the object doesn't exist. This does not change the behaviour of the draft storing/publishing process. So you get the same error messages as before, and it refuses to publish until you remove the bad link. The only change is that the bad link is never stored to DB.

https://jira.ez.no/browse/EZP-23529
