### PR TITLE
Fix EZP-23607: display actual published version in versionview

### DIFF
--- a/design/admin/templates/content/parts/object_information.tpl
+++ b/design/admin/templates/content/parts/object_information.tpl
@@ -40,7 +40,7 @@
 <p>
 <label>{'Published version'|i18n( 'design/admin/content/history' )}:</label>
 {if $object.published}
-{$object.current_version}
+{$object.published_version}
 {else}
 {'Not yet published'|i18n( 'design/admin/content/history' )}
 {/if}

--- a/kernel/classes/ezcontentobject.php
+++ b/kernel/classes/ezcontentobject.php
@@ -151,6 +151,7 @@ class eZContentObject extends eZPersistentObject
                                                                          'multiplicity' => '1..*' ) ),
                       "keys" => array( "id" ),
                       "function_attributes" => array( "current" => "currentVersion",
+                                                      "published_version" => "publishedVersion",
                                                       'versions' => 'versions',
                                                       'author_array' => 'authorArray',
                                                       "class_name" => "className",
@@ -1200,6 +1201,27 @@ class eZContentObject extends eZPersistentObject
     function currentVersion( $asObject = true )
     {
         return eZContentObjectVersion::fetchVersion( $this->attribute( "current_version" ), $this->ID, $asObject );
+    }
+
+    /**
+     * Returns the published version of the object, or false if not published yet.
+     *
+     * @return  int|null
+     */
+    public function publishedVersion()
+    {
+        $params = array(
+            'conditions' => array(
+                'status' => eZContentObjectVersion::STATUS_PUBLISHED
+            )
+        );
+        $versions = $this->versions( false, $params );
+
+        if ( !empty( $versions ) )
+        {
+            return $versions[0]['version'];
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23607

When viewing an old/archived version through versionview, object info shows incorrect "Published Version" information.

This resolves it by adding an new "published_version" function attr. and updating relevant template.
Feedback welcome
