### PR TITLE
EZP-23627: Priority of children lost during subtree copy

### DIFF
--- a/kernel/content/copysubtree.php
+++ b/kernel/content/copysubtree.php
@@ -278,6 +278,7 @@ function copyPublishContentObject( $sourceObject,
                 else
                     $newNode->setAttribute( 'is_invisible', $srcNode->attribute( 'is_invisible' ) );
 
+                $newNode->store();
                 $syncNodeIDListSrc[] = $srcNode->attribute( 'node_id' );
                 $syncNodeIDListNew[] = $newNode->attribute( 'node_id' );
                 $bSrcParentFound = true;


### PR DESCRIPTION
Issue: https://jira.ez.no/browse/EZP-23627
