### PR TITLE
Fix EZP-23604: dont reuse session var when installing a different package

### DIFF
--- a/kernel/package/install.php
+++ b/kernel/package/install.php
@@ -14,7 +14,8 @@ $installer = false;
 $currentItem = 0;
 $displayStep = false;
 
-if ( $http->hasSessionVariable( 'eZPackageInstallerData' ) )
+// use session data when performing install steps (currentAction is set)
+if ( $module->currentAction() && $http->hasSessionVariable( 'eZPackageInstallerData' ) )
 {
     $persistentData = $http->sessionVariable( 'eZPackageInstallerData' );
     if ( isset( $persistentData['currentItem'] ) )


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-23604

Problem: After clicking "Install Package" and going back, packageName is stored in persistent data.
It will always be reused until `eZPackageInstallerData` is cleared.

On the first step, however, selecting a new package should _not_ reuse session variable.
