### PR TITLE
Fix EZP-22982: Treemenu throws PHP notices with nginx

### DIFF
--- a/lib/ezutils/classes/ezsys.php
+++ b/lib/ezutils/classes/ezsys.php
@@ -1234,13 +1234,16 @@ class eZSys
             $validateDir = '/' . implode( '/', $uri );
         }
 
-        // validate directly with phpself part
-        if ( strpos( $scriptFileName, $validateDir ) !== false )
-            return trim( $phpSelfParts[0], '/' );
+        if ( !empty( $validateDir ) )
+        {
+            // validate directly with phpself part
+            if ( strpos( $scriptFileName, $validateDir ) !== false )
+                return trim( $phpSelfParts[0], '/' );
 
-        // validate with windows path
-        if ( strpos( $scriptFileName, str_replace( '/', '\\', $validateDir ) ) !== false )
-            return trim( $phpSelfParts[0], '/' );
+            // validate with windows path
+            if ( strpos( $scriptFileName, str_replace( '/', '\\', $validateDir ) ) !== false )
+                return trim( $phpSelfParts[0], '/' );
+        }
 
         return null;
     }


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-22982
## Description

First of all, this patch is more of a workaround than a fix. It avoids the notice to happen, but doesn't optimize the behavior as it is done using apache.

`$_SERVER['PHP_SELF']` is not processed the same way in apache (with mod_rewrite) and nginx. Apache applies the rewrite rules on the returned value while nginx doesn't apply them returning a result matching what is specified in the doc http://php.net/manual/en/reserved.variables.server.php

For example requesting `http://ez5.local/ezdemo_site_admin` the value of `$_SERVER['PHP_SELF']`  would be:
- apache: `/ezdemo_site_admin/`
- nginx: `index.php/ezdemo_site_admin`

Ways to fix it:
- in ezpublish legacy code, replace the usage of `$_SERVER['PHP_SELF']` by `$_SERVER['REQUEST_URI']`: That could lead to a lot of BC breaks
- in nginx config, tweak the setting to make it behave the way apache does. This is not very clean and might lead to other problems using new and cleaner code.

That's why I decided in this PR to go with the safest approach (a workaround) since we are dealing with legacy code.
## Test

Manual test (on front and back) and ran the install wizard.
