### PR TITLE
Fix EZP-23624: Unable to change base translation when editing content

### DIFF
--- a/kernel/content/edit.php
+++ b/kernel/content/edit.php
@@ -204,6 +204,13 @@ if ( $http->hasPostVariable( 'NewDraftButton' ) )
     }
 }
 
+// Action to base current translation on a different language
+if ( $Module->isCurrentAction( 'FromLanguage' ) && $http->hasPostVariable( 'FromLanguage' ) && is_numeric( $EditVersion ) )
+{
+    $FromLanguage = $http->postVariable( 'FromLanguage' );
+    return $Module->redirectToView( 'edit', array( $obj->attribute( 'id' ), $EditVersion, $EditLanguage, $FromLanguage ) );
+}
+
 // Action for the edit_language.tpl page.
 // LanguageSelection is used to choose a language to edit the object in.
 if ( $http->hasPostVariable( 'LanguageSelection' ) )


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23624

When editing content, it should be possible to base the current draft on an existing translation 
(/content/edit/object/version/EditLanguage/fromLanguage )

However, it seems the generated POST action was being handled too late in the process, and a number of checks are done before.
This handles the `FromLanguage` action, performing the redirect much sooner in the process.

Tests: Manual

See also: https://github.com/ezsystems/ezpublish-legacy/blob/master/kernel/content/edit.php#L562
