### PR TITLE
Fix EZP-23620: Segmentation fault error when copying subtree

### DIFF
--- a/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
+++ b/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
@@ -586,7 +586,7 @@ class eZObjectRelationListType extends eZDataType
                                 $contentModified = true;
                             }
                         }
-                        else
+                        else if ( $object->attribute( 'status' ) != eZContentObject::STATUS_ARCHIVED )
                         {
                             if ( !isset( $copiedRelatedAccordance[ $relationItem['contentobject_id'] ] ) )
                                 $copiedRelatedAccordance[ $relationItem['contentobject_id'] ] = array();


### PR DESCRIPTION
The ezobjectrelationlist attribute copies related objects that are in the subtree of it's own object, and objects that have no node. The latter also includes objects in trash, leading to an infinite loop in certain cases. Changed to never copy objects that are in trash.

If this fix is accepted, we need to check if the same must be done for ezobjectrelation. (Edit: Never mind, it has no such code.)

https://jira.ez.no/browse/EZP-23620
