### PR TITLE
Fix EZP-23672: display modifier of latest version in versionview

### DIFF
--- a/design/admin/templates/content/parts/object_information.tpl
+++ b/design/admin/templates/content/parts/object_information.tpl
@@ -29,8 +29,9 @@
 <p>
 <label>{'Modified'|i18n( 'design/admin/content/history' )}:</label>
 {if $object.modified}
+{def $latest_version=$object.versions|extract_right(1)[0]}
 {$object.modified|l10n( shortdatetime )}<br />
-{$object.current.creator.name|wash}
+{$latest_version.creator.name|wash}
 {else}
 {'Not yet published'|i18n( 'design/admin/content/history' )}
 {/if}


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23672

When viewing an old/archived version through versionview, object info shows incorrect "modifier" name (displaying the modifier of the version being viewed instead)

This resolves it by getting the info from the latest version instead.
