### PR TITLE
EZP-23639: told dfs cleanup to clean dfs, not var

### DIFF
--- a/bin/php/dfscleanup.php
+++ b/bin/php/dfscleanup.php
@@ -164,7 +164,7 @@ if ( $checkDFS )
                 $cli->output( '  - ' . $filePathName );
                 if ( $delete )
                 {
-                    unlink( $filePathName );
+                    $dfsBackend->delete( $filePathName );
                 }
             }
         }


### PR DESCRIPTION
> See [EZP-23639](https://jira.ez.no/browse/EZP-23639)

I'm very confused by this one. If a file was created on the NFS, running `bin/php/dfscleanup.php -B -D` would find the extra file, and throw a warning when trying to unlink it.

Reason was simple: we were doing an unlink, meaning that the file was deleted from the var folder, while it was found on NFS. The fix is easy, but the question is: did it ever work ?
