### PR TITLE
Fix EZP-23483: Additional fix for languageswitcher redirection

### DIFF
--- a/kernel/classes/ezurlaliasml.php
+++ b/kernel/classes/ezurlaliasml.php
@@ -969,10 +969,10 @@ class eZURLAliasML extends eZPersistentObject
         {
             $langMask = "(" . trim( eZContentLanguage::languagesSQLFilter( 'ezurlalias_ml', 'lang_mask' ) ) . ") AND ";
         }
-        else if ( is_string( $maskLanguages ) )
+        else if ( is_string( $maskLanguages ) || is_array( $maskLanguages ) )
         {
             // maskByLocale can support array input, here we only want one item.
-            $mask = eZContentLanguage::maskByLocale( $maskLanguages );
+            $mask = eZContentLanguage::maskByLocale( (array)$maskLanguages );
             $langFilter = $db->bitAnd( 'lang_mask', $mask );
             $langMask = "({$langFilter} > 0) AND";
         }

--- a/kernel/private/classes/ezplanguageswitcher.php
+++ b/kernel/private/classes/ezplanguageswitcher.php
@@ -177,7 +177,13 @@ class ezpLanguageSwitcher implements ezpLanguageSwitcherCapable
 
             $nodeId = eZURLAliasML::fetchNodeIDByPath( $this->origUrl );
         }
-        $destinationElement = eZURLAliasML::fetchByAction( 'eznode', $nodeId, $this->destinationLocale, false );
+
+        $siteLanguageList = $this->getSiteAccessIni()->variable( 'RegionalSettings', 'SiteLanguageList' );
+        // set prioritized languages of destination SA, and fetch corresponding (prioritized) URL alias
+        eZContentLanguage::setPrioritizedLanguages( $siteLanguageList );
+        $destinationElement = eZURLAliasML::fetchByAction( 'eznode', $nodeId, false, true );
+
+        eZContentLanguage::clearPrioritizedLanguages();
 
         if ( empty( $destinationElement ) || ( !isset( $destinationElement[0] ) && !( $destinationElement[0] instanceof eZURLAliasML ) ) )
         {
@@ -194,7 +200,7 @@ class ezpLanguageSwitcher implements ezpLanguageSwitcherCapable
             {
                 $urlAlias = $this->origUrl;
 
-                // if applicable, remove destination PathPrefix from url,
+                // if applicable, remove destination PathPrefix from url
                 if ( !self::removePathPrefixIfNeeded( $this->getSiteAccessIni(), $urlAlias ) )
                 {
                     // If destination siteaccess has a PathPrefix but url is not matched,
@@ -213,11 +219,11 @@ class ezpLanguageSwitcher implements ezpLanguageSwitcherCapable
         else
         {
             // Translated object found, forwarding to new URL.
-
-            $saIni = $this->getSiteAccessIni();
-            $siteLanguageList = $saIni->variable( 'RegionalSettings', 'SiteLanguageList' );
-
             $urlAlias = $destinationElement[0]->getPath( $this->destinationLocale, $siteLanguageList );
+
+            // if applicable, remove destination PathPrefix from url
+            self::removePathPrefixIfNeeded( $this->getSiteAccessIni(), $urlAlias );
+
             $urlAlias .= $this->userParamString;
         }
 


### PR DESCRIPTION
Additional fix for https://jira.ez.no/browse/EZP-23483

When performing redirect from language switcher, fetch url alias according to the prioritized languages of the destination siteaccess.
In addition, properly adjust path when an urlalias is found on the wanted language(s).
