### PR TITLE
Fix EZP-23687: Notice when running "$phpbin runcronjobs.php monitor"

### DIFF
--- a/lib/ezdbschema/classes/ezdbschemachecker.php
+++ b/lib/ezdbschema/classes/ezdbschemachecker.php
@@ -228,7 +228,7 @@ class eZDbSchemaChecker
     static function diffIndex( $index1, $index2, $schema1Type, $schema2Type )
     {
         if ( ( $index1['type'] != $index2['type'] ) ||
-             count( array_diff( $index1, $index2 ) ) )
+             serialize( $index1 ) !== serialize( $index2 ) )
         {
             return $index2;
         }


### PR DESCRIPTION
array_diff() does not work recursively. Compare serialize() output instead, since we just want to check if the arrays are equal.

https://jira.ez.no/browse/EZP-23687
