### PR TITLE
Fix EZP-23681: Delayed indexing of subtree on move

### DIFF
--- a/kernel/classes/ezcontentobjecttreenodeoperations.php
+++ b/kernel/classes/ezcontentobjecttreenodeoperations.php
@@ -109,10 +109,10 @@ class eZContentObjectTreeNodeOperations
                 $nodeAssignment->setAttribute( 'op_code', eZNodeAssignment::OP_CODE_MOVE );
                 $nodeAssignment->store();
 
-                // update search index
+                // update search index specifying we are doing a move operation
                 $nodeIDList = array( $nodeID );
                 eZSearch::removeNodeAssignment( $node->attribute( 'main_node_id' ), $newNode->attribute( 'main_node_id' ), $object->attribute( 'id' ), $nodeIDList );
-                eZSearch::addNodeAssignment( $newNode->attribute( 'main_node_id' ), $object->attribute( 'id' ), $nodeIDList );
+                eZSearch::addNodeAssignment( $newNode->attribute( 'main_node_id' ), $object->attribute( 'id' ), $nodeIDList, true );
             }
 
             $result = true;

--- a/kernel/classes/ezsearch.php
+++ b/kernel/classes/ezsearch.php
@@ -563,15 +563,16 @@ class eZSearch
      * @param int $mainNodeID
      * @param int $objectID
      * @param array $nodeAssignmentIDList
+     * @param bool $isMoved true if node is being moved
      * @return false|mixed False in case method is undefined, otherwise return the result of the search engine call
      */
-    public static function addNodeAssignment( $mainNodeID, $objectID, $nodeAssignmentIDList )
+    public static function addNodeAssignment( $mainNodeID, $objectID, $nodeAssignmentIDList, $isMoved = false )
     {
         $searchEngine = eZSearch::getEngine();
 
         if ( $searchEngine instanceof ezpSearchEngine && method_exists( $searchEngine, 'addNodeAssignment' ) )
         {
-            return $searchEngine->addNodeAssignment( $mainNodeID, $objectID, $nodeAssignmentIDList );
+            return $searchEngine->addNodeAssignment( $mainNodeID, $objectID, $nodeAssignmentIDList, $isMoved );
         }
 
         return false;

--- a/kernel/content/ezcontentoperationcollection.php
+++ b/kernel/content/ezcontentoperationcollection.php
@@ -565,8 +565,10 @@ class eZContentOperationCollection
      *       the calls within a db transaction; thus within db->begin and db->commit.
      *
      * @param int $objectID Id of the object.
+     * @param int $version Operation collection passes this default param. Not used in the method
+     * @param bool $isMoved true if node is being moved
      */
-    static public function registerSearchObject( $objectID )
+    static public function registerSearchObject( $objectID, $version = null, $isMoved = false )
     {
         $objectID = (int)$objectID;
         eZDebug::createAccumulatorGroup( 'search_total', 'Search Total' );
@@ -591,7 +593,9 @@ class eZContentOperationCollection
 
         if ( $insertPendingAction )
         {
-            eZDB::instance()->query( "INSERT INTO ezpending_actions( action, param ) VALUES ( 'index_object', '$objectID' )" );
+            $action = $isMoved ? 'index_moved_node' : 'index_object';
+
+            eZDB::instance()->query( "INSERT INTO ezpending_actions( action, param ) VALUES ( '$action', '$objectID' )" );
             return;
         }
 

--- a/tests/tests/kernel/content/ezcontentoperationdelete_regression.php
+++ b/tests/tests/kernel/content/ezcontentoperationdelete_regression.php
@@ -53,6 +53,7 @@ class eZContentOperationDeleteObjectRegression extends ezpDatabaseTestCase
         $this->folder->remove();
         $this->article->remove();
         eZPendingActions::removeByAction( 'index_object' );
+        eZPendingActions::removeByAction( 'index_moved_node' );
         $this->nodeIds = array();
         $this->objectIds = array();
 


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-23681
## Description

The only way to have a subtree indexed after a move is to use delayed indexing and a cronjob (for performance reason).
## Tests

Need to be done a bit more, still WIP
## TODO
- [x] Enjoy people's feedback on the approach
- [x] Sanity tests
- [x] fix unit test (or the code)
- [x] move the $version signature modification to a separate commit ?
