### PR TITLE
Ezp 23753 node alias translation

### DIFF
--- a/kernel/classes/ezcontentobjecttreenode.php
+++ b/kernel/classes/ezcontentobjecttreenode.php
@@ -1883,7 +1883,7 @@ class eZContentObjectTreeNode extends eZPersistentObject
         {
             return $limitation;
         }
-        
+
         $currentUser = eZUser::currentUser();
         $currentUserID = $currentUser->attribute( 'contentobject_id' );
         $limitationList = array();
@@ -2080,7 +2080,7 @@ class eZContentObjectTreeNode extends eZPersistentObject
 
         if ( $asObject )
         {
-            $retNodeList = eZContentObjectTreeNode::makeObjectsArray( $nodeListArray );
+            $retNodeList = eZContentObjectTreeNode::makeObjectsArray( $nodeListArray, true, null, $language );
             if ( $loadDataMap === true )
                 eZContentObject::fillNodeListAttributes( $retNodeList );
             else if ( $loadDataMap && is_numeric( $loadDataMap ) && $loadDataMap >= count( $retNodeList ) )
@@ -2316,7 +2316,7 @@ class eZContentObjectTreeNode extends eZPersistentObject
 
         if ( $asObject )
         {
-            $retNodeList = eZContentObjectTreeNode::makeObjectsArray( $nodeListArray );
+            $retNodeList = eZContentObjectTreeNode::makeObjectsArray( $nodeListArray, true, null, $language );
         }
         else
         {
@@ -3147,7 +3147,7 @@ class eZContentObjectTreeNode extends eZPersistentObject
         {
             if ( $asObject )
             {
-                $returnValue = eZContentObjectTreeNode::makeObjectsArray( $nodeListArray );
+                $returnValue = eZContentObjectTreeNode::makeObjectsArray( $nodeListArray, true, null, $lang );
                 if ( count( $returnValue ) === 1 )
                     $returnValue = $returnValue[0];
             }
@@ -5221,7 +5221,7 @@ class eZContentObjectTreeNode extends eZPersistentObject
     // This code is automatically generated from templates/classcreatelist.ctpl
     // code-template::auto-generated:END can-instantiate-class-list
 
-    static public function makeObjectsArray( $array , $with_contentobject = true, array $propertiesOverride = null )
+    static public function makeObjectsArray( $array , $with_contentobject = true, array $propertiesOverride = null, $lang = null )
     {
         $retNodes = array();
         if ( !is_array( $array ) )
@@ -5310,7 +5310,11 @@ class eZContentObjectTreeNode extends eZPersistentObject
                 }
                 if ( isset( $node['real_translation'] ) && $node['real_translation'] != '' )
                 {
-                    $object->CurrentLanguage = $node['real_translation'];
+                    if ( $node['real_translation'] == $lang )
+                    {
+                        $object->CurrentLanguage = $node['real_translation'];
+                    }
+
                     $contentObject->CurrentLanguage = $node['real_translation'];
                 }
                 if ( $node['node_id'] == 1 )
@@ -5747,7 +5751,10 @@ class eZContentObjectTreeNode extends eZPersistentObject
         }
         $contentobject_id = $this->attribute( 'contentobject_id' );
         $obj = eZContentObject::fetch( $contentobject_id );
-        $obj->setCurrentLanguage( $this->CurrentLanguage );
+        if ( $this->CurrentLanguage )
+        {
+            $obj->setCurrentLanguage( $this->CurrentLanguage );
+        }
         $this->ContentObject = $obj;
         return $obj;
     }

--- a/kernel/classes/ezurlaliasml.php
+++ b/kernel/classes/ezurlaliasml.php
@@ -1122,16 +1122,21 @@ class eZURLAliasML extends eZPersistentObject
             $actionMap[$action][] = $row;
         }
 
-        // Ordered map, keys ensure uniqueness but the order in which the elements are introduced is important
-        $prioritizedLanguages = array();
-        foreach ( eZContentLanguage::prioritizedLanguages() as $language )
+        if ( $locale !== null && is_string( $locale ) && !empty( $locale ) )
         {
-            $prioritizedLanguages[$language->attribute( "id" )] = $language;
+            $selectedLanguage = eZContentLanguage::fetchByLocale( $locale );
+            $prioritizedLanguages = eZContentLanguage::prioritizedLanguages();
+            // Add $selectedLanguage on top of $prioritizedLanguages to take it into account with the highest priority
+            if ( $selectedLanguage instanceof eZContentLanguage )
+                array_unshift( $prioritizedLanguages, $selectedLanguage );
+        }
+        else
+        {
+            $prioritizedLanguages = eZContentLanguage::prioritizedLanguages();
         }
 
         $path = array();
         $lastID = false;
-        $lastActionValue = end( $actionValues );
         foreach ( $actionValues as $actionValue )
         {
             $action = $actionName . ":" . $actionValue;
@@ -1142,22 +1147,12 @@ class eZURLAliasML extends eZPersistentObject
             }
             $actionRows = $actionMap[$action];
             $defaultRow = null;
-
-            if ( $lastActionValue === $actionValue && $locale !== null && is_string( $locale ) && !empty( $locale ) )
-                $selectedLanguage = eZContentLanguage::fetchByLocale( $locale );
-                // Add $selectedLanguage on top of $prioritizedLanguages to take it into account with the highest priority
-                if ( $selectedLanguage instanceof eZContentLanguage )
-                {
-                    $prioritizedLanguages = array( $selectedLanguage->attribute( "id" ) => $selectedLanguage ) + $prioritizedLanguages;
-                }
-            }
-
-            foreach ( $prioritizedLanguages as $languageId => $language )
+            foreach( $prioritizedLanguages as $language )
             {
                 foreach ( $actionRows as $row )
                 {
                     $langMask   = (int)$row['lang_mask'];
-                    $wantedMask = (int)$languageId;
+                    $wantedMask = (int)$language->attribute( 'id' );
                     if ( ( $wantedMask & $langMask ) > 0 )
                     {
                         $defaultRow = $row;

--- a/kernel/classes/ezurlaliasml.php
+++ b/kernel/classes/ezurlaliasml.php
@@ -1144,7 +1144,6 @@ class eZURLAliasML extends eZPersistentObject
             $defaultRow = null;
 
             if ( $lastActionValue === $actionValue && $locale !== null && is_string( $locale ) && !empty( $locale ) )
-            {
                 $selectedLanguage = eZContentLanguage::fetchByLocale( $locale );
                 // Add $selectedLanguage on top of $prioritizedLanguages to take it into account with the highest priority
                 if ( $selectedLanguage instanceof eZContentLanguage )


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23753

Problem:
When a node that exists on a language different from the siteaccess default language, but has a translated parent/path, the UrlAlias will be incorrect.
For example, for a "FreFolder/EnArticle" the returned alias in fre siteaccess is "EnFolder/EnArticle".
Besides incorrect, this causes additional problems when there is a `PathPrefix` setting for that SA.

This happens because `eZContentObjectTreeNode` requests the alias in the current node's language:
``` eZURLAliasML::fetchPathByActionList( "eznode", $pathArray, $this->CurrentLanguage );```

The fix from EZP-20494 (PR #572) resolved this by prefering the wanted language ONLY for the last node, and returning the rest of the path according to the prioritized languages, however it introduced a change in behavior as well.

This PR resolves the problem by reverting 20494 (if applicable), and having the node fetch the alias full path using solely the prioritized language list.

