### PR TITLE
Fix EZP-23739: Files uploaded with multiupload will be download with the...

### DIFF
--- a/kernel/classes/datatypes/ezbinaryfile/ezbinaryfiletype.php
+++ b/kernel/classes/datatypes/ezbinaryfile/ezbinaryfiletype.php
@@ -398,10 +398,14 @@ class eZBinaryFileType extends eZDataType
 
         $httpFile->setMimeType( $mimeData['name'] );
 
+        $suffix = false;
+        if ( isset( $mimeData['suffix'] ) )
+            $suffix = $mimeData['suffix'];
+
         $db = eZDB::instance();
         $db->begin();
 
-        if ( !$httpFile->store( "original", false, false ) )
+        if ( !$httpFile->store( "original", $suffix, false ) )
         {
             $result['errors'][] = array( 'description' => ezpI18n::tr( 'kernel/classes/datatypes/ezbinaryfile',
                                                         'Failed to store file %filename. Please contact the site administrator.', null,


### PR DESCRIPTION
... wrong Content-Type

Files uploaded with multiupload are saved internally without suffix. This means they are downloaded as application/octet-stream which I assume is the default. Since the mimedata already contains the suffix, the patch simply adds it to the eZHTTPFile::store call, as it is done in eZBinaryFileType::fetchObjectAttributeHTTPInput() for example.

https://jira.ez.no/browse/EZP-23739
