### PR TITLE
FIX french typo for 'Enter account information' (Entez -> Entrez)

### DIFF
--- a/share/translations/fre-FR/translation.ts
+++ b/share/translations/fre-FR/translation.ts
@@ -28432,7 +28432,7 @@ your account.</source>
     </message>
     <message>
         <source>Enter account information</source>
-        <translation>Entez les informations du compte utilisateur</translation>
+        <translation>Entrez les informations du compte utilisateur</translation>
     </message>
     <message>
         <source>VAT types</source>


### PR DESCRIPTION
Little typo.

Have a nice day.
