### PR TITLE
Fix EZP-23812: vertical align in table cells is not visible in the editor

### DIFF
--- a/extension/ezoe/design/standard/stylesheets/skins/default/content.css
+++ b/extension/ezoe/design/standard/stylesheets/skins/default/content.css
@@ -180,6 +180,26 @@ div.ezoeItemCustomTag.separator
 
 div.ezoeItemCustomTag.separator p { margin: 2px; }
 
+/* table valign */
+td[customattributes*="valign|top"], th[customattributes*="valign|top"]
+{
+    vertical-align: top;
+}
+
+td[customattributes*="valign|baseline"], th[customattributes*="valign|baseline"]
+{
+    vertical-align: baseline;
+}
+
+td[customattributes*="valign|middle"], th[customattributes*="valign|middle"]
+{
+    vertical-align: middle;
+}
+
+td[customattributes*="valign|bottom"], th[customattributes*="valign|bottom"]
+{
+    vertical-align: bottom;
+}
 
 /* change the style for embed tags */
 

--- a/extension/ezoe/design/standard/stylesheets/skins/o2k7/content.css
+++ b/extension/ezoe/design/standard/stylesheets/skins/o2k7/content.css
@@ -154,6 +154,27 @@ span.ezoeItemCustomTag.underline
   text-decoration: underline
 }
 
+/* table valign */
+td[customattributes*="valign|top"], th[customattributes*="valign|top"]
+{
+    vertical-align: top;
+}
+
+td[customattributes*="valign|baseline"], th[customattributes*="valign|baseline"]
+{
+    vertical-align: baseline;
+}
+
+td[customattributes*="valign|middle"], th[customattributes*="valign|middle"]
+{
+    vertical-align: middle;
+}
+
+td[customattributes*="valign|bottom"], th[customattributes*="valign|bottom"]
+{
+    vertical-align: bottom;
+}
+
 /* Visualisation of default block custom tags */
 
 div.ezoeItemCustomTag.pagebreak


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23812
# Description

The vertical alignment of the table cells (and headers) is not reflected in Online Editor. Before this patch, the content of a cell is always in the middle (even if the default vertical align is top).

With this patch:

![oe_valign](https://cloud.githubusercontent.com/assets/305563/5485518/8d6e8a84-869c-11e4-9a7d-218a6deb6b72.png)
# Tests

manual tests
