### PR TITLE
Fix EZP-21686: ezinfo/copyright has extra "\" that don't allow the links...

### DIFF
--- a/kernel/ezinfo/copyright.php
+++ b/kernel/ezinfo/copyright.php
@@ -8,34 +8,33 @@
 
 $Module = $Params['Module'];
 
-$text =
-## BEGIN COPYRIGHT INFO ##
-'<p>Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.</p>
+$text = <<<'COPYRIGHT'
+<p>Copyright (C) 1999-2015 eZ Systems AS. All rights reserved.</p>
 
 <p>This file may be distributed and/or modified under the terms of the
-\"GNU General Public License\" version 2 as published by the Free
+"GNU General Public License" version 2 as published by the Free
 Software Foundation and appearing in the file LICENSE included in
 the packaging of this file.</p>
 
-<p>Licencees holding a valid \"eZ Publish professional licence\" version 2
-may use this file in accordance with the \"eZ Publish professional licence\"
-version 2 Agreement provided with the Software.</p>
+<p>Licencees holding a valid "eZ Business Use License" version 2.1
+may use this file in accordance with the "eZ Business Use License"
+version 2.1 Agreement provided with the Software.</p>
 
 <p>This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING
 THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR
 PURPOSE.</p>
 
-<p>The \"eZ Publish professional licence\" version 2 is available at
-<a href=\"http://ez.no/ez_publish/licences/professional/\">http://ez.no/ez_publish/licences/professional/</a> and in the file
+<p>The "eZ Business Use License" version 2.1 is available at
+<a href="http://ez.no/Products/About-our-Software/Licenses/eZ-Business-Use-License-Agreement-eZ-BUL-Version-2.1">http://ez.no/Products/About-our-Software/Licenses/eZ-Business-Use-License-Agreement-eZ-BUL-Version-2.1</a> and in the file
 PROFESSIONAL_LICENCE included in the packaging of this file.
-For pricing of this licence please contact us via e-mail to licence@ez.no.
-Further contact information is available at <a href=\"http://ez.no/company/contact/\">http://ez.no/company/contact/</a>.</p>
+For pricing of this licence please contact us via e-mail to <a href="mailto:licence@ez.no">licence@ez.no</a>.
+Further contact information is available at <a href="http://ez.no/About-eZ/Contact-Us">http://ez.no/About-eZ/Contact-Us</a>.</p>
 
-<p>The \"GNU General Public License\" (GPL) is available at
-<a href=\"http://www.gnu.org/copyleft/gpl.html\">http://www.gnu.org/copyleft/gpl.html</a>.</p>
+<p>The "GNU General Public License" (GPL) is available at
+<a href="http://www.gnu.org/copyleft/gpl.html">http://www.gnu.org/copyleft/gpl.html</a>.</p>
 
-<p>Contact eZ Systems if any conditions of this licencing isn\'t clear to you.</p>';
-## END COPYRIGHT INFO ##
+<p>Contact eZ Systems if any conditions of this licencing isn't clear to you.</p>
+COPYRIGHT;
 
 $Result = array();
 $Result['content'] = $text;


### PR DESCRIPTION
... to work

Alternative solution to PR #779. Implemented with nowdoc segment rather than quoted strings. Updated year to 2015. Added mailto-link for email address.

https://jira.ez.no/browse/EZP-21686