### PR TITLE
Fix EZP-23879: ezinfo shows wrong copyright info after move to composer

### DIFF
--- a/design/admin/templates/ezinfo/about.tpl
+++ b/design/admin/templates/ezinfo/about.tpl
@@ -13,12 +13,14 @@
 
 <h3>{'What is eZ Publish?'|i18n( 'design/admin/ezinfo/about' )}</h3>
 {if is_set( $what_is_ez_publish )}
-    <p>{$what_is_ez_publish}</p>
+    {$what_is_ez_publish}
 {/if}
 
 <h3>{'License'|i18n( 'design/admin/ezinfo/about' )}</h3>
-{if is_set( $license )}
-    <p>{$license}</p>
+{if $license}
+    <pre style="height: 300px; overflow:scroll;">{$license|wash}</pre>
+{else}
+    <p>{'Could not load LICENSE file! You should have a LICENSE file in your eZ Publish root directory.'|i18n( 'design/admin/ezinfo/about' )}</p>
 {/if}
 
 {if and( is_set( $contributors ), is_array( $contributors ), count( $contributors )|ge( 1 ) )}
@@ -38,7 +40,7 @@
 
 <h3>{'Copyright Notice'|i18n( 'design/admin/ezinfo/about' )}</h3>
 <p>
-    Copyright &copy; 1999-2014 <a href="http://ez.no/">eZ Systems AS</a>, with portions copyright by other parties. A complete list of all contributors and third-party
+    Copyright for eZ Publish is included in the License shown above. Portions are copyright by other parties. A complete list of all contributors and third-party
     software follows.
 </p>
 

--- a/design/standard/templates/ezinfo/about.tpl
+++ b/design/standard/templates/ezinfo/about.tpl
@@ -6,7 +6,7 @@
 </div>
 <div class="object">
     {if is_set( $what_is_ez_publish )}
-       <p>{$what_is_ez_publish}</p>
+       {$what_is_ez_publish}
     {/if}
 </div>
 
@@ -14,8 +14,10 @@
     <h2>{'License'|i18n( 'design/standard/ezinfo/about' )}</h2>
 </div>
 <div class="object">
-    {if is_set( $license )}
-       <p>{$license}</p>
+    {if $license}
+        <pre style="height: 300px; overflow:scroll;">{$license|wash}</pre>
+    {else}
+        <p>{'Could not load LICENSE file! You should have a LICENSE file in your eZ Publish root directory.'|i18n( 'design/standard/ezinfo/about' )}</p>
     {/if}
 </div>
 
@@ -45,7 +47,7 @@
 </div>
 <div class="object">
     <p>
-        Copyright &copy; 1999-2014 <a href="http://ez.no/">eZ Systems AS</a>, with portions copyright by other parties. A complete list of all contributors and third-party
+        Copyright for eZ Publish is included in the License shown above. Portions are copyright by other parties. A complete list of all contributors and third-party
         software follows.
     </p>
 </div>

--- a/kernel/ezinfo/about.php
+++ b/kernel/ezinfo/about.php
@@ -11,6 +11,14 @@ define( 'EZ_ABOUT_THIRDPARTY_SOFTWARE_FILE', 'var/storage/third_party_software.p
 
 
 /*!
+  Returns contents of LICENSE file in ezp legacy root directory, or false on failure.
+*/
+function getLicense()
+{
+    return file_get_contents( 'LICENSE' );
+}
+
+/*!
   Returns list of contributors;
   Searches all php files in \a $pathToDir and tries to fetch contributor's info
 */
@@ -103,38 +111,25 @@ function strReplaceByArray( $searches = array(), $subjects = array() )
 
 $ezinfo = eZPublishSDK::version( true );
 
-$whatIsEzPublish = 'eZ Publish is a professional PHP application framework with advanced
-CMS (content management system) functionality. As a CMS its most notable
-featureis its revolutionary, fully customizable and extendable content
-model. Thisis also what makes eZ Publish suitable as a platform for
-general PHP  development,allowing you to rapidly create professional
-web-based applications.
+$whatIsEzPublish = '<p>eZ Publish is a professional PHP application framework with advanced
+CMS (content management system) functionality. As a CMS, its most notable
+feature is its revolutionary, fully customizable and extendable content
+model. This is also what makes eZ Publish suitable as a platform for
+general PHP development, allowing you to rapidly create professional
+web-based applications.</p>
 
-Standard CMS functionality (such as news publishing, e-commerce and
+<p>Standard CMS functionality (such as news publishing, e-commerce and
 forums) are already implemented and ready to use. Standalone libraries
 can be used for cross-platform database-independent browser-neutral
 PHP projects. Because eZ Publish is a web-based application, it can
-be accessed from anywhere you have an internet connection.';
+be accessed from anywhere you have an internet connection.</p>';
 
-$license =
-## BEGIN LICENSE INFO ##
-'This copy of eZ Publish is distributed under the terms and conditions of
-the GNU General Public License (GPL). Briefly summarized, the GPL gives
-you the right to use, modify and share this copy of eZ Publish. If you
-choose to share eZ Publish, you may only share it under the terms and
-conditions of the GPL. If you share a modified version of eZ Publish,
-these modifications must also be placed under the GPL. Read the
-complete legal terms and conditions of the GPL at
-http://www.gnu.org/licenses/gpl.txt or see the file named LICENSE in
-the root directory of this eZ Publish distribution.';
-## END LICENSE INFO ##
-
+$license = getLicense();
 $contributors = getContributors( EZ_ABOUT_CONTRIBUTORS_DIR );
 $thirdPartySoftware = getThirdPartySoftware( EZ_ABOUT_THIRDPARTY_SOFTWARE_FILE );
 $extensions = getExtensionsInfo();
 
 list( $whatIsEzPublish,
-      $license,
       $contributors,
       $thirdPartySoftware,
       $extensions ) = strReplaceByArray( array( 'eZ Systems AS' => '<a href="http://ez.no/">eZ Systems AS</a>',
@@ -143,7 +138,7 @@ list( $whatIsEzPublish,
                                                 'eZ systems as' => '<a href="http://ez.no/">eZ Systems AS</a>',
                                                 'eZ Publish' => '<a href="http://ez.no/ezpublish">eZ Publish</a>',
                                                 'eZ publish' => '<a href="http://ez.no/ezpublish">eZ Publish</a>' ),
-                                         array( $whatIsEzPublish, $license, $contributors, $thirdPartySoftware, $extensions ) );
+                                         array( $whatIsEzPublish, $contributors, $thirdPartySoftware, $extensions ) );
 
 $tpl = eZTemplate::factory();
 $tpl->setVariable( 'ezinfo', $ezinfo );


### PR DESCRIPTION
Several changes:
- Removed hardcoded license text, instead show the whole contents of LICENSE (in legacy root) in an iframe
- Copyright year is updated to 2015
- The "What is eZ Publish?" text was split in two paragraphs in the source, this was invisible in html since there was no tagging. These are added now.
- Several text fixes (speling, punctuation etc)
- "eZ Systems", "eZ Publish" in the license text were converted to links, this is not done anymore since A) it is redundant, and B) we are now loading the whole LICENSE file and we should not mess with that - lawyers are involved.

https://jira.ez.no/browse/EZP-23879