### PR TITLE
Update ezwordtoimageoperator.php

### DIFF
--- a/kernel/common/ezwordtoimageoperator.php
+++ b/kernel/common/ezwordtoimageoperator.php
@@ -268,7 +268,7 @@ class eZWordToImageOperator
                 }
                 else
                 {
-                    $size = $sizes[0];
+                    $size = reset( $sizes );
                 }
 
                 $pathDivider = strpos( $size, ';' );


### PR DESCRIPTION
using php "reset" function to retrieve first element of $sizes array because $sizes[0] is not always set

ex. in ezpublish_legacy/share/icons/crystal-admin/icon.ini
[IconSettings]
# Defined sizes, each size refers to the name of the subdirectory
# of the icon theme. If the name contains two numbers with an
# x in between it will be considered to be the width and height
# of the icon, if not no size is will be given
Sizes[]
Sizes[normal]=32x32
Sizes[small]=16x16_indexed
Sizes[ghost]=16x16_ghost
Sizes[original]=16x16_original