### PR TITLE
Fix EZP-23913: Override legacy fatal error message

### DIFF
--- a/settings/error.ini
+++ b/settings/error.ini
@@ -86,6 +86,10 @@ HTTPError[20]=404
 HTTPError[21]=404
 HTTPError[22]=404
 
+# Allow the default eZ Publish 500 error message to be overridden
+# Note: this will not work with siteaccess settings, will only be global (settings/override/error.ini.append.php), because of how early this is registered
+# FatalErrorHandler=CustomFatalErrorHandlerClass::FatalErrorHandlerFunction
+
 # Error handling for shop errors
 # See the kernel errors for details on usage
 [ErrorSettings-shop]


### PR DESCRIPTION
The message "Fatal error: The web server did not finish its request" cannot be overridden in eZ Publish:

https://github.com/ezsystems/ezpublish-legacy/blob/master/kernel/private/classes/ezpkernelweb.php#L213

See more at: https://jira.ez.no/browse/EZP-23913

This pull request allows this to be overridden, the developer can now define a error.ini (only in global escope, ie, settings/override/error.ini.append.php) variable like: 

[ErrorSettings-kernel]
FatalErrorHandler=CustomFatalErrorHandlerClass::FatalErrorHandlerFunction