### PR TITLE
Fix EZP-23908: expiry.php race condition

### DIFF
--- a/lib/ezutils/classes/ezexpiryhandler.php
+++ b/lib/ezutils/classes/ezexpiryhandler.php
@@ -61,6 +61,24 @@ class eZExpiryHandler
      */
     function store()
     {
+        if ( !$this->IsModified )
+        {
+            return;
+        }
+
+        // EZP-23908: Restore timestamps before saving, to reduce chance of race condition issues
+        $modifiedTimestamps = $this->Timestamps;
+        $this->restore();
+
+        // Apply timestamps that have been added or modified in this process
+        foreach ( $modifiedTimestamps as $name => $value )
+        {
+            if ( $value > self::getTimestamp( $name, 0 ) )
+            {
+                $this->setTimestamp( $name, $value );
+            }
+        }
+
         if ( $this->IsModified )
         {
             $this->CacheFile->storeContents( "<?php\n\$Timestamps = " . var_export( $this->Timestamps, true ) . ";\n?>", 'expirycache', false, true );


### PR DESCRIPTION
Restore timestamps before saving, to reduce chance of race condition issues

This is the easy solution. The complete solution would be an asyncronous process with expiry request stored in db and a cron daemon which processes them at short intervals. I consider that overkill for legacy, which should not have new development.

Unknown: How much does this fix affect performance in cluster environments?

https://jira.ez.no/browse/EZP-23908