### PR TITLE
Fix EZP-23725: Wrong path_identification_string with custom RootNode

### DIFF
--- a/kernel/classes/ezcontentobjecttreenode.php
+++ b/kernel/classes/ezcontentobjecttreenode.php
@@ -3613,7 +3613,11 @@ class eZContentObjectTreeNode extends eZPersistentObject
         {
         }
 
-        $this->updatePathIdentificationString( $pathIdentificationName );
+        // Only update pathIdentificationString if new name is defined (not set for RootNode)
+        if ( $pathIdentificationName )
+        {
+            $this->updatePathIdentificationString( $pathIdentificationName );
+        }
 
         $languageID = $obj->attribute( 'initial_language_id' );
         $cleanup    = false;


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23725

When a different RootNode is specified for a SA, along with a PathPrefix, it's generated path will be empty;
However path_string should remain the full value.

Because path_string is based on each node's parent, simply not updating the new RootNode to empty should resolve the issue.
