### PR TITLE
Fix EZP-24030: Relationlist contains wrong content after content removal

### DIFF
--- a/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
+++ b/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
@@ -1878,6 +1878,38 @@ class eZObjectRelationListType extends eZDataType
         return $return;
     }
 
+    /*!
+     Replaces node ID for object with given ID in the relations list
+    */
+    function updateRelatedObjectNodeID( $contentObjectAttribute, $objectID, $mainNodeID )
+    {
+        $xmlText = $contentObjectAttribute->attribute( 'data_text' );
+        if ( trim( $xmlText ) == '' ) return;
+
+        $doc = $this->parseXML( $xmlText );
+
+        $return = false;
+        $root = $doc->documentElement;
+        $relationList = $root->getElementsByTagName( 'relation-list' )->item( 0 );
+        if ( $relationList )
+        {
+            $relationItems = $relationList->getElementsByTagName( 'relation-item' );
+            if ( !empty( $relationItems ) )
+            {
+                foreach( $relationItems as $relationItem )
+                {
+                    if ( $relationItem->getAttribute( 'contentobject-id' ) == $objectID )
+                    {
+                        $relationItem->setAttribute( 'node-id', $mainNodeID );
+                        $return = true;
+                    }
+                }
+            }
+        }
+        $this->storeObjectDOMDocument( $doc, $contentObjectAttribute );
+        return $return;
+    }
+
     function supportsBatchInitializeObjectAttribute()
     {
         return true;

--- a/kernel/classes/ezcontentobjecttreenode.php
+++ b/kernel/classes/ezcontentobjecttreenode.php
@@ -2904,8 +2904,10 @@ class eZContentObjectTreeNode extends eZPersistentObject
             eZContentObjectTreeNode::assignSectionToSubTree( $mainNodeID, $newSectionID );
         }
 
-        $db->commit();
+        // EZP-24030: If the object has attribute level reverse related objects, change the node id reference to the new main node id.
+        $contentObject->updateMainNodeForReverseAttributeRelations( $mainNodeID );
 
+        $db->commit();
     }
 
     function fetchByCRC( $pathStr )


### PR DESCRIPTION
Update the attribute object relations xml whenever the main node id of an object changes. Always set it to main node id.

https://jira.ez.no/browse/EZP-24030