### PR TITLE
Fix EZP-23928: Preview cache not being updated

### DIFF
--- a/kernel/content/attribute_edit.php
+++ b/kernel/content/attribute_edit.php
@@ -316,6 +316,10 @@ if ( $storingAllowed && $hasObjectInput)
         $object->storeInput( $contentObjectAttributes,
                              $attributeInputMap );
         $db->commit();
+        ezpEvent::getInstance()->notify(
+            'content/cache/version',
+            array( $object->attribute( 'id' ), $version->attribute( 'version' ) )
+        );
     }
 
     $validation['processed'] = true;


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-23928

When saving a draft (not publishing), preview won't reflect the changes. A previously cached content is displayed instead.
Only applies if the frontend siteaccess is *not* using `legacy_mode`.

This patch introduces a new `content/cache/version` event.