### PR TITLE
EZP-24099: Generate relationlist metadata for Search (Solr) using published content

### DIFF
--- a/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
+++ b/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
@@ -814,18 +814,33 @@ class eZObjectRelationListType extends eZDataType
         return $doc;
     }
 
+    /**
+     * Returns xml identifier to attribute map
+     *
+     * Key is xml identifier as used in attribute data_string format, and value is the name exposed in attribute.
+     *
+     * Warning: Besides contentobject_id most attributes are not updated on changes and hence represent the values when
+     *          the relation was first created. These should ideally have been prefixed with "original" (see inline).
+     *          You can see this in affect all over this datatype that for instance version number from attribute
+     *          source is newer used for basis to generate things like title, metadata or toString value.
+     *
+     * @return array
+     */
     static function contentObjectArrayXMLMap()
     {
         return array( 'identifier' => 'identifier',
                       'priority' => 'priority',
                       'in-trash' => 'in_trash',
                       'contentobject-id' => 'contentobject_id',
+                      'is-modified' => 'is_modified',
+
+                      // The following attributes should in retrospective have been prefixed with "original"
+                      // If you are interested in current published meta data of relation, fetch content object.
                       'contentobject-version' => 'contentobject_version',
                       'node-id' => 'node_id',
                       'parent-node-id' => 'parent_node_id',
                       'contentclass-id' => 'contentclass_id',
                       'contentclass-identifier' => 'contentclass_identifier',
-                      'is-modified' => 'is_modified',
                       'contentobject-remote-id' => 'contentobject_remote_id' );
     }
 
@@ -1564,15 +1579,23 @@ class eZObjectRelationListType extends eZDataType
                 $attributes = $content['temp'][$subObjectID]['attributes'];
             else
             {
-                $subObjectVersion = $relationItem['contentobject_version'];
-                $object = eZContentObject::fetch( $subObjectID );
+                $subObjectVersionNum = $relationItem['contentobject_version'];
+                $subObject = eZContentObject::fetch( $subObjectID );
+
+                // Using last version of object (version inside xml data is the original version)
+                $subCurrentVersionObject = $subObject->currentVersion();
+                if( $subCurrentVersionObject instanceof eZContentObjectVersion )
+                {
+                    $subObjectVersionNum = $subCurrentVersionObject->attribute( 'version' );
+                }
+
                 if ( eZContentObject::recursionProtect( $subObjectID ) )
                 {
-                    if ( !$object )
+                    if ( !$subObject )
                     {
                         continue;
                     }
-                    $attributes = $object->contentObjectAttributes( true, $subObjectVersion, $language );
+                    $attributes = $subObject->contentObjectAttributes( true, $subObjectVersionNum, $language );
                 }
             }
 


### PR DESCRIPTION
Using current (published) content instead of original data (from when relation was added).

See change for further info on why, but in short this is already the case for generation of title and to/from string and online documentation (that code should never expect meta data like version, node id and so on to be up-to-date).

Credits: Original patch from @phalasz can be found in https://jira.ez.no/browse/EZP-24099
         Expanded in this version with more doc, cs, and cleanup of variable names for readability.