### PR TITLE
EZP-24115 front multisite rootnode

### DIFF
--- a/kernel/classes/ezcontentobjecttreenode.php
+++ b/kernel/classes/ezcontentobjecttreenode.php
@@ -3613,11 +3613,7 @@ class eZContentObjectTreeNode extends eZPersistentObject
         {
         }
 
-        // Only update pathIdentificationString if new name is defined (not set for RootNode)
-        if ( $pathIdentificationName )
-        {
-            $this->updatePathIdentificationString( $pathIdentificationName );
-        }
+        $this->updatePathIdentificationString( $pathIdentificationName );
 
         $languageID = $obj->attribute( 'initial_language_id' );
         $cleanup    = false;

--- a/kernel/classes/ezcontentobjecttreenode.php
+++ b/kernel/classes/ezcontentobjecttreenode.php
@@ -3518,7 +3518,7 @@ class eZContentObjectTreeNode extends eZPersistentObject
 
         // Only set name if current node is not the content root
         $ini = eZINI::instance( 'content.ini' );
-        $contentRootID = $ini->variable( 'NodeSettings', 'RootNode' );
+        $contentRootID = $ini->variable( 'NodeSettings', 'ContentTreeRootNode' );
         $obj           = $this->object();
         $alwaysMask    = ( $obj->attribute( 'language_mask' ) & 1 );
         $languages     = $obj->allLanguages();
@@ -3621,6 +3621,7 @@ class eZContentObjectTreeNode extends eZPersistentObject
         {
             $text     = $nameEntry['text'];
             $language = $nameEntry['language'];
+
             $result = eZURLAliasML::storePath( $text, 'eznode:' . $nodeID, $language, false, $alwaysMask, $parentElementID, $cleanup );
             if ( $result['status'] === true )
                 $changeCount++;

--- a/settings/content.ini
+++ b/settings/content.ini
@@ -240,8 +240,10 @@ AvailableClasses[]
 CustomAttributes[]
 
 [NodeSettings]
-# The node ID of the normal content tree
+# The node ID for the site's content
 RootNode=2
+# The node ID of the normal content tree
+ContentTreeRootNode=2
 # The node ID of the user tree
 UserRootNode=5
 # The node ID for the media tree


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24115

When using a custom RootNode (multisite settings), editing the root node through  the frontend will cause issues with the UrlAlias (the homepage / site root displays wrong content).

The problem is that data in the ezurlalias table (as well as the path_ident_string field in content_tree) should  not be specific and relative to a given siteaccess, but for the "whole" site (as defined in the backoffice).

This reverts commit for EZP-23725, and introduces a new setting `ContentTreeRootNode` in `content.ini`.
This setting is used solely in eZContentObjectTreeNode, for the purpose of updating the subtree paths (urlalias as well as path_ident_string).