### PR TITLE
Fix EZP-24135: Output buffer gets cleared after legacy call

### DIFF
--- a/kernel/classes/ezscript.php
+++ b/kernel/classes/ezscript.php
@@ -235,8 +235,11 @@ class eZScript
     */
     function initialize()
     {
-        if( ob_get_length() != 0 )
-            ob_end_clean();
+        if ( !ezpKernel::hasInstance() )
+        {
+            if ( ob_get_length() != 0 )
+                ob_end_clean();
+        }
 
         // Initialize text codec settings
         $this->updateTextCodecSettings();

--- a/kernel/private/classes/ezpkernel.php
+++ b/kernel/private/classes/ezpkernel.php
@@ -120,6 +120,16 @@ class ezpKernel implements ezpWebBasedKernelHandler
     }
 
     /**
+     * Checks if the kernel has already been instantiated.
+     *
+     * @return bool
+     */
+    public static function hasInstance()
+    {
+        return self::$instance !== null;
+    }
+
+    /**
      * Returns the current instance of ezpKernel.
      *
      * @throws LogicException if no instance of ezpKernel has been instantiated
@@ -127,14 +137,15 @@ class ezpKernel implements ezpWebBasedKernelHandler
      */
     public static function instance()
     {
-        if ( self::$instance === null )
+        if ( !self::hasInstance() )
         {
             throw new LogicException(
                 'Cannot return the instance of '
-                    . __CLASS__
-                    . ', it has not been instantiated'
+                . __CLASS__
+                . ', it has not been instantiated'
             );
         }
         return self::$instance;
     }
 }
+


### PR DESCRIPTION
Dirty trick to see if we are in legacy context, do ob_end_clean only when we are. Seems to work.

https://jira.ez.no/browse/EZP-24135