### PR TITLE
Fix EZP-24100: Image content with big multibyte charset names won't be correctly created

### DIFF
--- a/kernel/classes/datatypes/ezimage/ezimagealiashandler.php
+++ b/kernel/classes/datatypes/ezimage/ezimagealiashandler.php
@@ -269,7 +269,7 @@ class eZImageAliasHandler
             }
         }
         $objectName = eZImageAliasHandler::normalizeImageName( $objectName );
-        $objectName .= $this->imageSerialNumber();
+        $objectName = $this->trimToFileSystemFileName( $objectName ) . $this->imageSerialNumber();
 
         return $objectName;
     }
@@ -304,7 +304,7 @@ class eZImageAliasHandler
             }
         }
         $objectName = eZImageAliasHandler::normalizeImageName( $objectName );
-        return $objectName;
+        return $this->trimToFileSystemFileName( $objectName );
     }
 
     /*!
@@ -378,11 +378,34 @@ class eZImageAliasHandler
         $pathParts = array( eZSys::storageDirectory(), $contentImageSubtree );
         if ( $pathString != '' )
         {
-            $pathParts[] = $pathString;
+            //Make sure that all folders are smaller than the FS limit
+            foreach ( explode( '/', $pathString ) as $folder )
+            {
+                $pathParts[] = $this->trimToFileSystemFileName( $folder );
+            }
         }
         $pathParts[] = $attributeID . '-' . $attributeVersion . '-' . $attributeLanguage;
         $imagePath = implode( '/', $pathParts );
         return $imagePath;
+    }
+
+    /**
+     * Trims a filename to a given limit (in bytes).
+     * It can be used to avoid file system limitations
+     *
+     * @param string $longName
+     * @param int $limit in bytes
+     *
+     * @return string shortened name
+     */
+    private function trimToFileSystemFileName( $longName, $limit = 200 )
+    {
+        if ( strlen( $longName ) <= $limit )
+        {
+            return $longName;
+        }
+
+        return mb_strcut( $longName, 0, $limit, "utf-8" );
     }
 
     /*!

--- a/tests/tests/kernel/datatypes/ezimage/ezimagealiashandler_regression.php
+++ b/tests/tests/kernel/datatypes/ezimage/ezimagealiashandler_regression.php
@@ -12,12 +12,6 @@ class eZImageAliasHandlerRegression extends ezpDatabaseTestCase
 {
     protected $backupGlobals = false;
 
-    public function __construct()
-    {
-        parent::__construct();
-        $this->setName( "eZImageAliasHandler Regression Tests" );
-    }
-
     /**
      * Regression test for issue #15155
      *
@@ -87,6 +81,83 @@ class eZImageAliasHandlerRegression extends ezpDatabaseTestCase
 
         array_map( 'unlink', $toDelete );
         $image->purge();
+    }
+
+    /**
+     * @return array
+     */
+    public function providerForTestImageNameObjectFalse()
+    {
+        return array(
+            array(
+                str_repeat( 'a', 180 ) . "This is a Very Long Name isn't it?",
+                str_repeat( 'a', 180 ) . "This-is-a-Very-Long-1"
+            ),
+            array(
+                str_repeat( 'a', 180 ) . "私は簡単にパブリッシュの記事で使用することができるようなも",
+                str_repeat( 'a', 180 ) . "私は簡単にパ1"
+            ),
+            array(
+                str_repeat( 'a', 180 ) . "私aはb簡c単dにeパfブgリhッシュの記事で使用することがで",
+                str_repeat( 'a', 180 ) . "私aはb簡c単dにe1"
+            )
+        );
+    }
+
+    public function providerForTestImageNameByNodeObjectFalse()
+    {
+        return array(
+            array(
+                str_repeat( 'a', 180 ) . "This is a Very Long Name isn't it?",
+                str_repeat( 'a', 180 ) . "This-is-a-Very-Long-"
+            ),
+            array(
+                str_repeat( 'a', 180 ) . "私は簡単にパブリッシュの記事で使用することができるようなも",
+                str_repeat( 'a', 180 ) . "私は簡単にパ"
+            ),
+            array(
+                str_repeat( 'a', 180 ) . "私aはb簡c単dにeパfブgリhッシュの記事で使用することができるようなも",
+                str_repeat( 'a', 180 ) . "私aはb簡c単dにe"
+            )
+        );
+    }
+
+    /**
+     * @dataProvider providerForTestImageNameObjectFalse
+     */
+    public function testImageNameObjectFalse( $longName, $expects )
+    {
+        ezpINIHelper::setINISetting( 'site.ini', 'URLTranslator', 'TransformationGroup', 'urlalias_iri' );
+
+        $handler = new eZImageAliasHandler( null );
+        $language = "fre-FR";
+        $contentVersionMock = $this->getMockBuilder( 'eZContentObjectVersion' )->disableOriginalConstructor()->getMock();
+        $contentVersionMock->expects( $this->any() )->method( 'versionName' )->will( $this->returnValue( $longName ) );
+
+        $name = $handler->imageName( null, $contentVersionMock, $language );
+
+        $this->assertEquals( $expects, $name );
+
+        ezpINIHelper::setINISetting( 'site.ini', 'URLTranslator', 'TransformationGroup', 'urlalias' );
+    }
+
+    /**
+     * @dataProvider providerForTestImageNameByNodeObjectFalse
+     */
+    public function testImageNameByNodeObjectFalse( $longName, $expects )
+    {
+        ezpINIHelper::setINISetting( 'site.ini', 'URLTranslator', 'TransformationGroup', 'urlalias_iri' );
+        $handler = new eZImageAliasHandler( null );
+        $language = "fre-FR";
+
+        $mainNodeMock = $this->getMockBuilder( 'eZContentObjectTreeNode' )->disableOriginalConstructor()->getMock();
+        $mainNodeMock->expects( $this->any() )->method( 'getName' )->will( $this->returnValue( $longName ) );
+
+        $name = $handler->imageNameByNode( null, $mainNodeMock, $language );
+
+        $this->assertEquals( $expects, $name );
+
+        ezpINIHelper::setINISetting( 'site.ini', 'URLTranslator', 'TransformationGroup', 'urlalias' );
     }
 }
 


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-24100

## Description
When using `urlalias_iri` images are renamed with the object name. The limit for object names is by default 255 UTF-8 char (and can be customized). The problem is that most file systems have a 255 bytes limit so they won't be able to create the image file.

This patch introduces a 200 bytes limit for images (leaving a bit of room for alias name and extension).

## Tests
Manual and unit tests

## TODO
* [x] Maybe change the public method to private, but need to find a way to unit test it.
* [x] Rebase/squash commits once accepted


