### PR TITLE
Fix EZP-24141: Double slash in url after having searched a default locat...

### DIFF
--- a/lib/ezutils/classes/ezmodule.php
+++ b/lib/ezutils/classes/ezmodule.php
@@ -857,14 +857,17 @@ class eZModule
             $uri .= $unorderedURI;
         }
 
-        if ( is_array( $userParameters ) )
+        if ( !empty( $userParameters ) && is_array( $userParameters ) )
         {
+            // Remove any slash(es) at the end of the uri, because the user params are appended with a leading slash
+            $uri = preg_replace( "#(^.*)(/+)$#", "\$1", $uri );
             foreach ( $userParameters as $name => $value )
             {
                 $uri .= '/(' . $name . ')/' . $value;
             }
         }
 
+        // Remove multiple slashes at the end of the uri
         $uri = preg_replace( "#(^.*)(//+)$#", "\$1", $uri );
         if ( $anchor !== false )
             $uri .= '#' . urlencode( $anchor );


### PR DESCRIPTION
...ion for an object relation in class edit module

If there are any unordered parameters, remove trailing slash(es) before adding the parameters, to avoid double slash.

The secondary complaint, that `language` occurs twice in URLs like `/class/edit/45/language/fre-FR//(language)/fre-FR`, is not fixed. It doesn't cause any problems for the issue reporter, and would require quite some rewriting of the class edit view, so I don't think it's worthwhile given that it's legacy.

https://jira.ez.no/browse/EZP-24141