### PR TITLE
Fix EZP-24233: copysubtree: wrap object copy in transaction.

### DIFF
--- a/kernel/content/copysubtree.php
+++ b/kernel/content/copysubtree.php
@@ -167,6 +167,9 @@ function copyPublishContentObject( $sourceObject,
         return 0;
     }
 
+    $db = eZDB::instance();
+    $db->begin();
+
     // make copy of source object
     $newObject             = $sourceObject->copy( $allVersions ); // insert source and new object's ids in $syncObjectIDList
     // We should reset section that will be updated in updateSectionID().
@@ -226,6 +229,8 @@ function copyPublishContentObject( $sourceObject,
             $newObjAssignments[0]->store();
         }
     }
+
+    $db->commit();
 
     // publish the newly created object
     $result = eZOperationHandler::execute( 'content', 'publish', array( 'object_id' => $newObject->attribute( 'id' ),


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24223

When using MySQL master/slave setup, copysubtree will fail with a fatal error (`Call to a member function attribute() on a non-object  ...`)
This happens because a new object version is created and immediately read from (on the slave server).

Fixed by wrapping relevant section in a DB transaction.
