### PR TITLE
Fixed #EZP-24234: ezpublish_legacy - DebugByIP IPV4 not working correctl...

### DIFF
--- a/lib/ezutils/classes/ezdebug.php
+++ b/lib/ezutils/classes/ezdebug.php
@@ -1937,14 +1937,14 @@ class eZDebug
                     {
                         if ( $matches[6] )
                         {
-                            if ( self::isIPInNet( $itemToMatch, $matches[1], $matches[7] ) )
+                            if ( self::isIPInNet( $ipAddress, $matches[1], $matches[7] ) )
                             {
                                 return true;
                              }
                         }
                         else
                         {
-                            if ( $matches[1] == $itemToMatch )
+                            if ( $matches[1] == $ipAddress )
                             {
                                 return true;
                             }


### PR DESCRIPTION
backport of ipv4 matching from ez 2012.06
so ip and network matching for DebugByIp settings is working now

Link: https://jira.ez.no/browse/EZP-24234