### PR TITLE
EZP-24289: Priority of children lost when using CLI script ezsubtreecopy.php

### DIFF
--- a/bin/php/ezsubtreecopy.php
+++ b/bin/php/ezsubtreecopy.php
@@ -189,6 +189,7 @@ function copyPublishContentObject( $sourceObject,
                 $newNode->setAttribute( 'priority',     $srcNode->attribute( 'priority' ) );
                 $newNode->setAttribute( 'is_hidden',    $srcNode->attribute( 'is_hidden' ) );
                 $newNode->setAttribute( 'is_invisible', $srcNode->attribute( 'is_invisible' ) );
+                $newNode->store();
                 $syncNodeIDListSrc[] = $srcNode->attribute( 'node_id' );
                 $syncNodeIDListNew[] = $newNode->attribute( 'node_id' );
                 $bSrcParentFound = true;


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-24289

Entirely based on schroeder's 67d95d71c0af9da20113598e3c0b0f5b5333da23 fix.