### PR TITLE
Fix EZP-24233: undisclosed-recipients:; breaks sendmail

### DIFF
--- a/lib/ezutils/classes/ezsendmailtransport.php
+++ b/lib/ezutils/classes/ezsendmailtransport.php
@@ -65,7 +65,9 @@ class eZSendmailTransport extends eZMailTransport
             if ( $sys->osType() != 'win32' )
             {
                 $excludeHeaders[] = 'To';
-                $receiverEmailText = count( $mail->ReceiverElements ) > 0 ? $mail->receiverEmailText() : 'undisclosed-recipients:;';
+                $insertUndisclosedRecipient = $ini->variable( 'MailSettings', 'SendmailInsertUndisclosedRecipient' );
+                $recipientText = $insertUndisclosedRecipient == 'disabled' ? '' : 'undisclosed-recipients:;';
+                $receiverEmailText = count( $mail->ReceiverElements ) > 0 ? $mail->receiverEmailText() : $recipientText;
             }
             // If Windows PHP mail() implementation, we can specify a To: header in the $additional_headers parameter,
             // it will be used as the only To: header.

--- a/settings/site.ini
+++ b/settings/site.ini
@@ -1264,6 +1264,9 @@ HeaderLineEnding=auto
 # SendmailOptions[]=-r
 # SendmailOptions[]=muchspam@ez.no
 SendmailOptions[]
+# Allows inserting undisclosed-recipients into the "TO:" of email headers.
+# As this is not a standard, some MTA might reject it, in that case you can set it to "disabled"
+SendmailInsertUndisclosedRecipient=enabled
 # If enabled, all emails will be sent to DebugReceiverEmail instead of to their original recipient(s)
 DebugSending=disabled
 # Receiver email address to use when DebugSending is enabled


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-24233
You can also have a look at the (old): https://jira.ez.no/browse/EZP-13617

## Description
Sendmail (the MTA) doesn't support `undisclosed-recipients:;` in the `TO:` of the header. It doesn't seem to be a standard to have it there according to https://tools.ietf.org/html/rfc5322#section-3.6.3

This patch introduces a new setting. I know we are trying to avoid it, but the goal is to avoid BC breaks as much as possible. This setting allows to replace the `undisclosed-recipients:;` by an empty string.

## Test
I am not using sendmail as MTA. So I made sure  `undisclosed-recipients:;`  is removed (or not) from the headers and I did sanity tests using my MTA (exim4). It has been tested by somebody else using sendmail.

## TODO
* [x] : Have somebody test it on sendmail