### PR TITLE
Fix EZP-24198: legacy admin: autosave will delete information about relations if AdvancedObjectRelationList = enabled

### DIFF
--- a/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
+++ b/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
@@ -457,7 +457,6 @@ class eZObjectRelationListType extends eZDataType
                         $version->store();
                     }
 
-                    $object->setAttribute( 'status', eZContentObject::STATUS_DRAFT );
                     $object->store();
                 }
             }


### PR DESCRIPTION
TL;DR: Don't set draft status on the related object. Why would you want to do that?

(Warning: This involves 12+ years old code!)
Object X has an attribute level relation (object relation list) to Y. AdvancedObjectRelationList = enabled, so while editing X, we can edit Y at the same time, embedded. When autosave triggers, it sets ezcontentobject.status = draft on Y, and the bug occurs when you discard the draft of X: ezcontentobject.status of Y is not set back to published. But my fix is to never set Y's object status to draft, because I see no reason to do so:

1. While the editor is working, the relation is broken. We should not modify the state of published, live objects during editing, that's what drafts are for.
2. The ezcontentobject_VERSION of Y is correctly created as a draft while editing, and is published when X is published. Again, no need to hack ezcontentobject.status.
3. When the draft of X is discarded, the draft of Y remains as a stale draft, before and after my fix. This is not optimal, but X carries no info about which version of Y to discard. Also, we have a script for cleaning up such stale drafts. Also also, AdvancedObjectRelationList is an ancient quirk, and optimising for it is hardly a priority.

https://jira.ez.no/browse/EZP-24198