### PR TITLE
Fix EZP-19376: CSS packer and font-face conflict

### DIFF
--- a/extension/ezjscore/classes/ezjscpacker.php
+++ b/extension/ezjscore/classes/ezjscpacker.php
@@ -501,6 +501,9 @@ class ezjscPacker
            // Pop the css file name
            array_pop( $cssPathArray );
            $cssPathCount = count( $cssPathArray );
+           // Sort by url length
+           array_multisort( array_map( 'strlen', $urlMatches ), SORT_DESC, $urlMatches );
+           $replace = array();
            foreach ( $urlMatches as $match )
            {
                $match = str_replace( '\\', '/', $match );
@@ -515,9 +518,15 @@ class ezjscPacker
                        $newMatchPath .= implode( '/', $cssPathSlice ) . '/';
                    }
                    $newMatchPath .= str_replace( '../', '', $match );
-                   $fileContent = str_replace( $match, $newMatchPath, $fileContent );
+                   // Set match hash
+                   $hash = md5( uniqid( mt_rand(), true ) );
+                   // Store hash and new match path
+                   $replace[$hash] = $newMatchPath;
+                   // Replace match element by hash
+                   $fileContent = str_replace( $match, $hash, $fileContent );
                }
            }
+           $fileContent = str_replace( array_keys( $replace ), array_values( $replace ), $fileContent );
         }
         return $fileContent;
     }


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-19376

This PR changes the URL replacement algorithm. **The new algorithm avoids the following problem.**

When a file contained this kind of url :

``` css
  src: url("fonts/HelveticaNeue55-Roman.eot");
  src: url("fonts/HelveticaNeue55-Roman.eot?#iefix") format("embedded-opentype");
```

we had these lines in return :

``` css
  src: url("/extension/my_extension/design/my_design/fonts/HelveticaNeue55-Roman.eot");
  src: url("/extension/my_extension/design/my_design//extension/my_extension/design/my_design/fonts/HelveticaNeue55-Roman.eot?#iefix");
```
