### PR TITLE
Fix EZP-24240: links applied incorrectly when text has line break.

### DIFF
--- a/extension/ezoe/design/standard/javascript/ezoe/popup_utils.js
+++ b/extension/ezoe/design/standard/javascript/ezoe/popup_utils.js
@@ -255,8 +255,14 @@ var eZOEPopupUtils = {
                 if ( n && n.nodeName )
                     s.editorElement = n;
             }
-            else
+            else {
                 ed.dom.setAttribs( s.editorElement, args );
+                // apply attributes to all '__mce_tmp' elements
+                if ( s.tagName == 'link' ) do {
+                    if ( nextElem = ed.dom.get('__mce_tmp') )
+                        ed.dom.setAttribs( nextElem, args );
+                } while ( nextElem )
+            }
 
             if ( args['id'] === undefined )
                 ed.dom.setAttrib( s.editorElement, 'id', '' );


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24240

#### Problem: ####
When applying links in ezoe to a multi-line text (using `<shift+enter>`), multiple `link` tags are created.
The first link is correct, however the second/other links have an incorrect id attribute "`__mce_tmp`" which is left unreplaced.

After this, adding a different link to another element in ezoe will replace the anchor of the existing link with id "`__mce_tmp`".

#### Solution: ####
When inserting links into multiple lines/elements, apply attributes to all the "__mce_tmp" instances.