### PR TITLE
EZP-24278: Add new stack kernel around REST API v1

### DIFF
--- a/autoload/ezp_kernel.php
+++ b/autoload/ezp_kernel.php
@@ -604,6 +604,7 @@ return array(
       'ezpKernel'                                          => 'kernel/private/classes/ezpkernel.php',
       'ezpKernelHandler'                                   => 'kernel/private/interfaces/ezpkernelhandler.php',
       'ezpKernelRedirect'                                  => 'kernel/private/classes/ezpkernelredirect.php',
+      'ezpKernelRest'                                      => 'kernel/private/rest/classes/ezpkernelrest.php',
       'ezpKernelResult'                                    => 'kernel/private/classes/ezpkernelresult.php',
       'ezpKernelTreeMenu'                                  => 'kernel/private/classes/ezpkerneltreemenu.php',
       'ezpKernelWeb'                                       => 'kernel/private/classes/ezpkernelweb.php',

--- a/index_rest.php
+++ b/index_rest.php
@@ -9,70 +9,12 @@
  */
 
 require __DIR__ . '/autoload.php';
-require __DIR__ . '/kernel/private/rest/classes/lazy.php';
 
-// Below we are setting up a minimal eZ Publish environment from the old index.php
-// This is a temporary measure.
+ignore_user_abort( true );
+error_reporting ( E_ALL | E_STRICT & E_DEPRECATED);
+require 'autoload.php';
 
-eZDebug::setHandleType( eZDebug::HANDLE_NONE );
-$GLOBALS['eZGlobalRequestURI'] = eZSys::serverVariable( 'REQUEST_URI' );
-$ini = eZINI::instance();
-eZSys::init( 'index_rest.php', $ini->variable( 'SiteAccessSettings', 'ForceVirtualHost' ) == 'true' );
-$uri = eZURI::instance( eZSys::requestURI() );
-$GLOBALS['eZRequestedURI'] = $uri;
+$kernel = new ezpKernel( new ezpKernelRest() );
 
-// load extensions
-eZExtension::activateExtensions( 'default' );
-
-// setup for eZSiteAccess:change() needs some functions defined in old index.php
-function eZUpdateDebugSettings()
-{
-    $ini = eZINI::instance();
-    $debugSettings = array( 'debug-enabled' => false );
-    $logList = $ini->variable( 'DebugSettings', 'AlwaysLog' );
-    $logMap = array(
-        'notice' => eZDebug::LEVEL_NOTICE,
-        'warning' => eZDebug::LEVEL_WARNING,
-        'error' => eZDebug::LEVEL_ERROR,
-        'debug' => eZDebug::LEVEL_DEBUG,
-        'strict' => eZDebug::LEVEL_STRICT
-    );
-    $debugSettings['always-log'] = array();
-    foreach ( $logMap as $name => $level )
-    {
-        $debugSettings['always-log'][$level] = in_array( $name, $logList );
-    }
-
-    eZDebug::updateSettings( $debugSettings );
-}
-
-// set siteaccess from X-Siteaccess header if given and exists
-if ( isset( $_SERVER['HTTP_X_SITEACCESS'] ) && eZSiteAccess::exists( $_SERVER['HTTP_X_SITEACCESS'] ) )
-{
-    $access = array( 'name' => $_SERVER['HTTP_X_SITEACCESS'], 'type' => eZSiteAccess::TYPE_STATIC );
-}
-else
-{
-    $access = eZSiteAccess::match( $uri, eZSys::hostname(), eZSys::serverPort(), eZSys::indexFile() );
-}
-
-$access = eZSiteAccess::change( $access );
-
-// load siteaccess extensions
-eZExtension::activateExtensions( 'access' );
-
-// Now that all extensions are activated and siteaccess has been changed, reset
-// all eZINI instances as they may not take into account siteaccess specific settings.
-eZINI::resetAllInstances( false );
-
-if( ezpRestDebug::isDebugEnabled() )
-{
-    $debug = ezpRestDebug::getInstance();
-    $debug->updateDebugSettings();
-}
-
-$mvcConfig = new ezpMvcConfiguration();
-
-$frontController = new ezpMvcConfigurableDispatcher( $mvcConfig );
-$frontController->run();
-?>
+// mvc_tools will directly output the headers and content
+$kernel->run();

--- a/kernel/private/rest/classes/dispatcher.php
+++ b/kernel/private/rest/classes/dispatcher.php
@@ -131,7 +131,4 @@ class ezpMvcConfigurableDispatcher extends ezcMvcConfigurableDispatcher
         }
         while ( $continue );
     }
-
-
-
 }

--- a/kernel/private/rest/classes/ezpkernelrest.php
+++ b/kernel/private/rest/classes/ezpkernelrest.php
@@ -1,0 +1,256 @@
+<?php
+/**
+ * File containing the ezpKernelRest class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+class ezpKernelRest implements ezpKernelHandler
+{
+    /**
+     * Indicates is request has been properly initialized
+     *
+     * @var bool
+     */
+    protected $isInitialized = false;
+
+    /**
+     * Hash of internal settings
+     *
+     * @var array
+     */
+    protected $settings;
+
+    /**
+     * Current siteaccess data
+     *
+     * @var array
+     */
+    protected $access;
+
+    /**
+     * @var eZURI
+     */
+    protected $uri;
+
+    /**
+     * Custom ZetaComponents MvcTools ResponseWriter class name.
+     * Used to get a usable Response from the REST API's controllers.
+     *
+     * Must reference an implementation of ezpRestHttpResponseWriter.
+     *
+     * @var string
+     */
+    private $responseWriterClass;
+
+    private static $response;
+
+    /**
+     * @param array $settings
+     * @param null $responseWriterClass Name of the ezpRestHttpResponseWriter implementation to use during request
+     */
+    public function __construct( array $settings = array(), $responseWriterClass = null )
+    {
+        $this->responseWriterClass = $responseWriterClass;
+
+        if ( isset( $settings['injected-settings'] ) )
+        {
+            $injectedSettings = array();
+            foreach ( $settings['injected-settings'] as $keySetting => $injectedSetting )
+            {
+                list( $file, $section, $setting ) = explode( '/', $keySetting );
+                $injectedSettings[$file][$section][$setting] = $injectedSetting;
+            }
+            // Those settings override anything else in local .ini files and their overrides
+            eZINI::injectSettings( $injectedSettings );
+        }
+        if ( isset( $settings['injected-merge-settings'] ) )
+        {
+            $injectedSettings = array();
+            foreach ( $settings['injected-merge-settings'] as $keySetting => $injectedSetting )
+            {
+                list( $file, $section, $setting ) = explode( '/', $keySetting );
+                $injectedSettings[$file][$section][$setting] = $injectedSetting;
+            }
+            // Those settings override anything else in local .ini files and their overrides
+            eZINI::injectMergeSettings( $injectedSettings );
+        }
+        $this->settings = $settings + array(
+            'use-cache-headers'         => true,
+            'max-age'                   => 86400,
+            'siteaccess'                => null,
+            'use-exceptions'            => false
+        );
+        unset( $settings, $injectedSettings, $file, $section, $setting, $keySetting, $injectedSetting );
+
+        // lazy loaded database driver
+        include __DIR__ . '/lazy.php';
+
+        $this->setUseExceptions( $this->settings['use-exceptions'] );
+
+        // Tweaks ini filetime checks if not defined!
+        // This makes ini system not check modified time so
+        // that index_treemenu.php can assume that index.php does
+        // this regular enough, set in config.php to override.
+        if ( !defined( 'EZP_INI_FILEMTIME_CHECK' ) )
+        {
+            define( 'EZP_INI_FILEMTIME_CHECK', false );
+        }
+
+        eZExecution::addFatalErrorHandler(
+            function ()
+            {
+                if ( !headers_sent() )
+                {
+                    header( $_SERVER['SERVER_PROTOCOL'] . ' 500 Internal Server Error' );
+                }
+            }
+        );
+        eZDebug::setHandleType( eZDebug::HANDLE_FROM_PHP );
+
+        // Trick to get eZSys working with a script other than index.php (while index.php still used in generated URLs):
+        $_SERVER['SCRIPT_FILENAME'] = str_replace( '/index_rest.php', '/index.php', $_SERVER['SCRIPT_FILENAME'] );
+        $_SERVER['PHP_SELF'] = str_replace( '/index_rest.php', '/index.php', $_SERVER['PHP_SELF'] );
+
+        $ini = eZINI::instance();
+        $timezone = $ini->variable( 'TimeZoneSettings', 'TimeZone' );
+        if ( $timezone )
+        {
+            putenv( "TZ=$timezone" );
+        }
+
+        eZDebug::setHandleType( eZDebug::HANDLE_NONE );
+        $GLOBALS['eZGlobalRequestURI'] = eZSys::serverVariable( 'REQUEST_URI' );
+        $ini = eZINI::instance();
+        eZSys::init( 'index_rest.php', $ini->variable( 'SiteAccessSettings', 'ForceVirtualHost' ) == 'true' );
+        $uri = eZURI::instance( eZSys::requestURI() );
+        $GLOBALS['eZRequestedURI'] = $uri;
+
+        // load extensions
+        eZExtension::activateExtensions( 'default' );
+
+        require_once __DIR__ . '/restkernel_functions.php';
+
+        // set siteaccess from X-Siteaccess header if given and exists
+        if ( isset( $_SERVER['HTTP_X_SITEACCESS'] ) && eZSiteAccess::exists( $_SERVER['HTTP_X_SITEACCESS'] ) )
+        {
+            $access = array( 'name' => $_SERVER['HTTP_X_SITEACCESS'], 'type' => eZSiteAccess::TYPE_STATIC );
+        }
+        else
+        {
+            $access = eZSiteAccess::match( $uri, eZSys::hostname(), eZSys::serverPort(), eZSys::indexFile() );
+        }
+
+        eZSiteAccess::change( $access );
+
+        // load siteaccess extensions
+        eZExtension::activateExtensions( 'access' );
+
+        // Now that all extensions are activated and siteaccess has been changed, reset
+        // all eZINI instances as they may not take into account siteaccess specific settings.
+        eZINI::resetAllInstances( false );
+
+        if( ezpRestDebug::isDebugEnabled() )
+        {
+            $debug = ezpRestDebug::getInstance();
+            $debug->updateDebugSettings();
+        }
+    }
+
+    /**
+     * @return mixed
+     */
+    public static function getResponse()
+    {
+        return self::$response;
+    }
+
+    /**
+     * @param mixed $response
+     */
+    public static function setResponse( $response )
+    {
+        self::$response = $response;
+    }
+
+    /**
+     * Execution point for controller actions.
+     * Returns false if not supported
+     *
+     * @return ezpKernelResult
+     */
+    public function run()
+    {
+        $mvcConfig = new ezpMvcConfiguration( $this->responseWriterClass );
+        $frontController = new ezpMvcConfigurableDispatcher( $mvcConfig );
+        $result = $frontController->run();
+        $this->shutdown();
+        return $result;
+    }
+
+    /**
+     * Not supported by ezpKernelTreeMenu
+     *
+     * @throws \RuntimeException
+     */
+    public function runCallback( \Closure $callback, $postReinitialize = true )
+    {
+        throw new \RuntimeException( 'runCallback() method is not supported by ezpKernelRest' );
+    }
+
+    /**
+     * Sets whether to use exceptions inside the kernel.
+     *
+     * @param bool $useExceptions
+     */
+    public function setUseExceptions( $useExceptions )
+    {
+        eZModule::$useExceptions = (bool)$useExceptions;
+    }
+
+    /**
+     * Reinitializes the kernel environment.
+     *
+     * @return void
+     */
+    public function reInitialize()
+    {
+        $this->isInitialized = false;
+    }
+
+    /**
+     * Runs the shutdown process
+     */
+    protected function shutdown( $reInitialize = true )
+    {
+        eZExecution::cleanup();
+        eZExecution::setCleanExit();
+        eZExpiryHandler::shutdown();
+        if ( $reInitialize )
+            $this->isInitialized = false;
+    }
+
+    /**
+     * Checks whether the kernel handler has the Symfony service container
+     * container or not.
+     *
+     * @return bool
+     */
+    public function hasServiceContainer()
+    {
+        return false;
+    }
+
+    /**
+     * Returns the Symfony service container if it has been injected,
+     * otherwise returns null.
+     *
+     * @return \Symfony\Component\DependencyInjection\ContainerInterface|null
+     */
+    public function getServiceContainer()
+    {
+        return;
+    }
+}

--- a/kernel/private/rest/classes/mvc_configuration.php
+++ b/kernel/private/rest/classes/mvc_configuration.php
@@ -21,9 +21,12 @@ class ezpMvcConfiguration implements ezcMvcDispatcherConfiguration
      */
     public $apiPrefix;
 
-    public function __construct()
+    private $responseWriterClass;
+
+    public function __construct( $responseWriterClass = null )
     {
         $this->apiPrefix = eZINI::instance( 'rest.ini' )->variable( 'System', 'ApiPrefix' );
+        $this->responseWriterClass = $responseWriterClass;
     }
 
     public function createFatalRedirectRequest( ezcMvcRequest $request, ezcMvcResult $result, Exception $e )
@@ -49,7 +52,8 @@ class ezpMvcConfiguration implements ezcMvcDispatcherConfiguration
 
     public function createResponseWriter( ezcMvcRoutingInformation $routeInfo, ezcMvcRequest $request, ezcMvcResult $result, ezcMvcResponse $response )
     {
-        return new ezpRestHttpResponseWriter( $response );
+        $class = isset( $this->responseWriterClass ) ? $this->responseWriterClass : 'ezpRestHttpResponseWriter';
+        return new $class( $response );
     }
 
     public function createRouter( ezcMvcRequest $request )

--- a/kernel/private/rest/classes/restkernel_functions.php
+++ b/kernel/private/rest/classes/restkernel_functions.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+if ( !function_exists( 'eZUpdateDebugSettings' ) )
+{
+    function eZUpdateDebugSettings()
+    {
+        $ini = eZINI::instance();
+        $debugSettings = array( 'debug-enabled' => false );
+        $logList = $ini->variable( 'DebugSettings', 'AlwaysLog' );
+        $logMap = array(
+            'notice' => eZDebug::LEVEL_NOTICE,
+            'warning' => eZDebug::LEVEL_WARNING,
+            'error' => eZDebug::LEVEL_ERROR,
+            'debug' => eZDebug::LEVEL_DEBUG,
+            'strict' => eZDebug::LEVEL_STRICT
+        );
+        $debugSettings['always-log'] = array();
+        foreach ( $logMap as $name => $level )
+        {
+            $debugSettings['always-log'][$level] = in_array( $name, $logList );
+        }
+
+        eZDebug::updateSettings( $debugSettings );
+    }
+}


### PR DESCRIPTION
> Fixes http://jira.ez.no/browse/EZP-24278
> Requires ezsystems/LegacyBridge#25

This PR adds the required elements (custom kernel, mostly) to run the V1 REST API through the new stack.

index_rest.php is still used, but it uses the custom rest kernel instead.