### PR TITLE
Fix EZP-18486 - PHP notice while running cronjobs/indexcontent.php cronjob

### DIFF
--- a/kernel/classes/datatypes/ezbinaryfile/plugins/ezpdfparser.php
+++ b/kernel/classes/datatypes/ezbinaryfile/plugins/ezpdfparser.php
@@ -25,7 +25,10 @@ class eZPDFParser
 
         // save the buffer contents
         $buffer = ob_get_contents();
-        ob_end_clean();
+        if ( $buffer )
+        {
+            ob_end_clean();
+        }
 
         // fetch the module printout
         ob_start();


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-18486

#### Description

Occurs when indexing a file.
```
Notice: ob_end_clean(): failed to delete buffer. No buffer to delete. in /home/dp/dev/ezpublish/kernel/classes/datatypes/ezbinaryfile/plugins/ezpdfparser.php on line 28
 
Call Stack:
    0.0007     405456   1. {main}() /home/dp/dev/ezpublish/runcronjobs.php:0
    0.0920    6220844   2. eZRunCronjobs::runScript() /home/dp/dev/ezpublish/runcronjobs.php:329
    0.1043    6288448   3. include('/home/dp/dev/ezpublish/cronjobs/indexcontent.php') /home/dp/dev/ezpublish/kernel/classes/ezruncronjobs.php:59
    0.1412    9039224   4. eZSolr->addObject() /home/dp/dev/ezpublish/cronjobs/indexcontent.php:52
    0.2469   14888064   5. eZSolr->addFieldBaseToDoc() /home/dp/dev/ezfind/search/plugins/ezsolr/ezsolr.php:561
    0.2469   14888064   6. ezfSolrDocumentFieldBase->getData() /home/dp/dev/ezfind/search/plugins/ezsolr/ezsolr.php:626
    0.2475   14888444   7. eZContentObjectAttribute->metaData() /home/dp/dev/ezfind/classes/ezfsolrdocumentfieldbase.php:89
    0.2475   14888444   8. eZBinaryFileType->metaData() /home/dp/dev/ezpublish/kernel/classes/ezcontentobjectattribute.php:1130
    0.2496   14954300   9. eZBinaryFile->metaData() /home/dp/dev/ezpublish/kernel/classes/datatypes/ezbinaryfile/ezbinaryfiletype.php:596
    0.2559   14971580  10. eZPDFParser->parseFile() /home/dp/dev/ezpublish/kernel/classes/datatypes/ezbinaryfile/ezbinaryfile.php:206
    0.2560   14971668  11. ob_end_clean() /home/dp/dev/ezpublish/kernel/classes/datatypes/ezbinaryfile/plugins/ezpdfparser.php:28
```