### PR TITLE
Fix trimming DOMElement textContent properties (re-enables PHP 5.6 on Travis)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,6 @@ env:
 
 # Aim to run tests on all versions of php, make sure each db is run at least once
 matrix:
-  allow_failures:
-    # Temporary until we can prioritize fixing xml issues in 5.6:
-    # https://travis-ci.org/ezsystems/ezpublish-legacy/jobs/38474236
-    - php: 5.6
-      env: DB="mysql" DB_USER="root"
   exclude:
     - php: 5.3.3
       env: DB="postgresql" DB_USER="postgres"

--- a/extension/ezoe/ezxmltext/handlers/input/ezoeinputparser.php
+++ b/extension/ezoe/ezxmltext/handlers/input/ezoeinputparser.php
@@ -951,11 +951,16 @@ class eZOEInputParser extends eZXMLInputParser
             if ( $trim )
             {
                 // Trim and remove if empty
-                $element->textContent = ltrim( $element->textContent );
-                if ( $element->textContent == '' )
+                $parent = $element->parentNode;
+                $trimmedElement = new DOMText( ltrim( $element->textContent ) );
+
+                if ( $trimmedElement->textContent == '' )
                 {
-                    $parent = $element->parentNode;
-                    $element = $parent->removeChild( $element );
+                    $parent->removeChild( $element );
+                }
+                else
+                {
+                    $parent->replaceChild( $trimmedElement, $element );
                 }
             }
         }

--- a/kernel/classes/datatypes/ezxmltext/handlers/input/ezsimplifiedxmlinputparser.php
+++ b/kernel/classes/datatypes/ezxmltext/handlers/input/ezsimplifiedxmlinputparser.php
@@ -684,11 +684,16 @@ class eZSimplifiedXMLInputParser extends eZXMLInputParser
             if ( $trim )
             {
                 // Trim and remove if empty
-                $element->textContent = ltrim( $element->textContent );
-                if ( $element->textContent == '' )
+                $parent = $element->parentNode;
+                $trimmedElement = new DOMText( ltrim( $element->textContent ) );
+
+                if ( $trimmedElement->textContent == '' )
                 {
-                    $parent = $element->parentNode;
-                    $element = $parent->removeChild( $element );
+                    $parent->removeChild( $element );
+                }
+                else
+                {
+                    $parent->replaceChild( $trimmedElement, $element );
                 }
             }
         }


### PR DESCRIPTION
The PHPUnit tests currently fail when running on PHP 5.6, which seems to… different on `DOMNode`'s read-only properties than previous reasons.

Currently, e.g. the `eZXMLTextRegression::testNonBreakingSpace()` would fail, because `esp&nbsp;ace` gets "trimmed" to `esp&amp;nbsp;ace`, which is happening in [eZSimplifiedXMLInputParser::structHandlerText()](https://github.com/ezsystems/ezpublish-legacy/blob/master/kernel/classes/datatypes/ezxmltext/handlers/input/ezsimplifiedxmlinputparser.php#L687)

```php
$element->textContent = ltrim( $element->textContent );
```

`$element->textContent` is a read-only property, as [documented here](http://php.net/manual/en/class.domnode.php).

I don't know why PHP does some HTML entity encoding (that's weird) instead of emitting an error or a warning, but whatever :).

This PR fixes the issue by replacing the overwriting of the property with a recreation of the TextNode.

The tests now run through on my local PHP 5.6 environment, and I hope the Travis-CI tests to as well for the other PHP versions.

Cheers
:octocat: Jérôme