### PR TITLE
Fixing HTTP ContentLanguage

### DIFF
--- a/share/locale/ara-SA.ini
+++ b/share/locale/ara-SA.ini
@@ -27,7 +27,7 @@ Allowed[]=cp850
 Allowed[]=dec-mcs
 
 [HTTP]
-ContentLanguage=ara-SA
+ContentLanguage=ar-SA
 
 [Currency]
 Symbol=MAD

--- a/share/locale/cat-ES.ini
+++ b/share/locale/cat-ES.ini
@@ -13,7 +13,7 @@ Allowed[]=iso-8859-14
 Allowed[]=iso-8859-15
 
 [HTTP]
-ContentLanguage=cat-ES
+ContentLanguage=ca-ES
 
 [Currency]
 Symbol=EUR

--- a/share/locale/cro-HR.ini
+++ b/share/locale/cro-HR.ini
@@ -27,7 +27,7 @@ Allowed[]=cp850
 Allowed[]=dec-mcs
 
 [HTTP]
-ContentLanguage=hr-HR
+ContentLanguage=hr
 
 [Currency]
 Symbol=kn

--- a/share/locale/dan-DK.ini
+++ b/share/locale/dan-DK.ini
@@ -26,7 +26,7 @@ Allowed[]=cp850
 Allowed[]=dec-mcs
 
 [HTTP]
-ContentLanguage=da-DK
+ContentLanguage=da
 
 [Currency]
 Symbol=kr

--- a/share/locale/dut-NL.ini
+++ b/share/locale/dut-NL.ini
@@ -14,7 +14,7 @@ Allowed[]=cp1252
 
 
 [HTTP]
-ContentLanguage=dut-NL
+ContentLanguage=nl-NL
 
 [Currency]
 Symbol=€

--- a/share/locale/ell-GR.ini
+++ b/share/locale/ell-GR.ini
@@ -27,7 +27,7 @@ Allowed[]=cp1253
 #Allowed[]=dec-mcs
 
 [HTTP]
-ContentLanguage=ell-GR
+ContentLanguage=el
 
 [Currency]
 Symbol=€

--- a/share/locale/epo-EO.ini
+++ b/share/locale/epo-EO.ini
@@ -12,7 +12,7 @@ Allowed[]=utf-8
 Allowed[]=iso-8859-3
 
 [HTTP]
-ContentLanguage=epo-EO
+ContentLanguage=eo
 
 [Currency]
 Symbol=€

--- a/share/locale/esl-MX.ini
+++ b/share/locale/esl-MX.ini
@@ -13,7 +13,7 @@ Allowed[]=iso-8859-14
 Allowed[]=iso-8859-15
 
 [HTTP]
-ContentLanguage=mx-esl
+ContentLanguage=es-MX
 
 [Currency]
 Symbol=$

--- a/share/locale/heb-IL.ini
+++ b/share/locale/heb-IL.ini
@@ -16,7 +16,7 @@ Allowed[]=macHebrew
 Allowed[]=cp1255
 
 [HTTP]
-ContentLanguage=heb-IL
+ContentLanguage=he
 
 [Currency]
 Symbol=ג×

--- a/share/locale/hun-HU.ini
+++ b/share/locale/hun-HU.ini
@@ -13,7 +13,7 @@ Allowed[]=iso-8859-2
 Allowed[]=cp1252
 
 [HTTP]
-ContentLanguage=hun-HU
+ContentLanguage=hu
 
 [Currency]
 Symbol=Ft

--- a/share/locale/nno-NO.ini
+++ b/share/locale/nno-NO.ini
@@ -26,7 +26,7 @@ Allowed[]=cp850
 Allowed[]=dec-mcs
 
 [HTTP]
-ContentLanguage=no-nynorsk
+ContentLanguage=nn
 
 [Currency]
 Symbol=kr

--- a/share/locale/nor-NO.ini
+++ b/share/locale/nor-NO.ini
@@ -26,7 +26,7 @@ Allowed[]=cp850
 Allowed[]=dec-mcs
 
 [HTTP]
-ContentLanguage=no-bokmaal
+ContentLanguage=nb
 
 [Currency]
 Symbol=kr

--- a/share/locale/pol-PL.ini
+++ b/share/locale/pol-PL.ini
@@ -15,7 +15,7 @@ Allowed[]=cp1250
 Allowed[]=cp852
 
 [HTTP]
-ContentLanguage=pl-PL
+ContentLanguage=pl
 
 [Currency]
 Symbol=zł

--- a/share/locale/por-MZ.ini
+++ b/share/locale/por-MZ.ini
@@ -17,7 +17,7 @@ Allowed[]=cp1252
 Allowed[]=cp1250
 
 [HTTP]
-ContentLanguage=pt-PT
+ContentLanguage=pt-MZ
 
 [Currency]
 Symbol= 

--- a/share/locale/ser-SR.ini
+++ b/share/locale/ser-SR.ini
@@ -28,7 +28,7 @@ Allowed[]=dec-mcs
 
 
 [HTTP]
-ContentLanguage=sr-SR
+ContentLanguage=sr-Latn
 
 [Currency]
 Symbol=DIN

--- a/share/locale/srp-RS.ini
+++ b/share/locale/srp-RS.ini
@@ -28,7 +28,7 @@ Allowed[]=dec-mcs
 
 
 [HTTP]
-ContentLanguage=sr-SR
+ContentLanguage=sr-Cyrl
 
 [Currency]
 Symbol=DIN

--- a/share/locale/swe-SE.ini
+++ b/share/locale/swe-SE.ini
@@ -25,7 +25,7 @@ Allowed[]=cp850
 Allowed[]=dec-mcs
 
 [HTTP]
-ContentLanguage=swe-SE
+ContentLanguage=sv-se
 
 [Currency]
 Symbol=kr

--- a/share/locale/tur-TR.ini
+++ b/share/locale/tur-TR.ini
@@ -30,7 +30,7 @@ Allowed[]=cp850
 Allowed[]=dec-mcs
 
 [HTTP]
-ContentLanguage=tur-TR
+ContentLanguage=tr
 
 [Currency]
 Symbol=ytl

--- a/share/locale/ukr-UA.ini
+++ b/share/locale/ukr-UA.ini
@@ -15,7 +15,7 @@ Allowed[]=iso-8859-5
 Allowed[]=cp1251
 
 [HTTP]
-ContentLanguage=ua-UA
+ContentLanguage=uk
 
 [Currency]
 Symbol=грн.


### PR DESCRIPTION
Some HTTP ContentLanguage values seem to be quite inaccurate.

I tried to fix them using the following ressources:
http://www.metamodpro.com/browser-language-codes
http://www.iana.org/assignments/language-subtag-registry/language-subtag-registry

By the way, the `ser-SR.ini` should be renammed `ser-RS` (since SR is actually the country code of Suriname), but it might break existing installations using this locale if the database is not updated accordingly.