### PR TITLE
Fix EZP-24419: clear stale active_extension cache files.

### DIFF
--- a/kernel/classes/ezcache.php
+++ b/kernel/classes/ezcache.php
@@ -781,6 +781,7 @@ class eZCache
         $handler->setTimestamp( $cacheItem['expiry-key'], time() );
         $handler->store();
 
+        eZExtension::clearActiveExtensionsCache();
         eZExtension::clearActiveExtensionsMemoryCache();
     }
 

--- a/lib/ezutils/classes/ezextension.php
+++ b/lib/ezutils/classes/ezextension.php
@@ -585,6 +585,23 @@ class eZExtension
     {
         self::$activeExtensionsCache = array();
     }
+
+    /**
+     * Clears (removes) active extension cache files from the cache folder.
+     * @return void
+     */
+    public static function clearActiveExtensionsCache()
+    {
+        $filesList = glob( self::CACHE_DIR . 'active_extensions_*.php' );
+        foreach ( $filesList as $path )
+        {
+            if ( is_file( $path ) )
+            {
+                $handler = eZFileHandler::instance( false );
+                $handler->unlink( $path );
+            }
+        }
+    }
 }
 
 ?>


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24419

##### Problem: #####
Cache files for active_extensions aren't removed when clearing/purging caches.

##### Solution: #####
Make sure to remove them :)

Note that `ClusterFileHandler` isn't used here, also active extension cache is hardcoded to var/cache.
As no record of files is kept, the proposed solution is to have eZExtension clean up the stale files much in the same way as it creates them: manually (see [ezextension.php#L115](https://github.com/ezsystems/ezpublish-legacy/blob/master/lib/ezutils/classes/ezextension.php#L115) ).


##### Tests: #####
Manual.