### PR TITLE
[WIP] Fix EZP-24424: Increase max length of the sort_key_string field

### DIFF
--- a/kernel/classes/ezcontentobjectattribute.php
+++ b/kernel/classes/ezcontentobjectattribute.php
@@ -82,7 +82,6 @@ class eZContentObjectAttribute extends eZPersistentObject
                                                                   'required' => true ),
                                          "sort_key_string" => array( 'name' => "SortKeyString",
                                                                      'datatype' => 'string',
-                                                                     'max_length' => 255,
                                                                      'default' => '',
                                                                      'required' => true ),
                                          "data_type_string" => array( 'name' => "DataTypeString",

--- a/share/db_schema.dba
+++ b/share/db_schema.dba
@@ -2017,7 +2017,7 @@ $schema = array (
       ),
       'sort_key_string' => 
       array (
-        'length' => 255,
+        'length' => 4096,
         'type' => 'varchar',
         'not_null' => '1',
         'default' => '',


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24424
#### Problem

The eZCountry Type, with multi-select, requires a large string to store the list of countries names, so that it can be searched properly.

Because of this, the cleanest solution is to update the `sort_key_string` field to be able to hold larger strings.
Performance should remain unaffected, and the index length the same (255).

TODO:
- [ ] further testing ( postgres / etc )
