### PR TITLE
Fix EZP-24334: Error exporting ezpackage with ezpm.php through ezpublish:legacy:script

### DIFF
--- a/lib/ezsession/classes/ezpsessionhandlersymfony.php
+++ b/lib/ezsession/classes/ezpsessionhandlersymfony.php
@@ -45,6 +45,11 @@ class ezpSessionHandlerSymfony extends ezpSessionHandler
 
     public function destroy( $sessionId )
     {
+        if ( eZSys::isShellExecution() )
+        {
+            return false;
+        }
+
         $sfHandler = $this->storage->getSaveHandler();
         ezpEvent::getInstance()->notify( 'session/destroy', array( $sessionId ) );
         if ( method_exists( $sfHandler, 'destroy' ) )
@@ -56,6 +61,11 @@ class ezpSessionHandlerSymfony extends ezpSessionHandler
 
     public function regenerate( $updateBackendData = true )
     {
+        if ( eZSys::isShellExecution() )
+        {
+            return false;
+        }
+
         $oldSessionId = session_id();
         $this->storage->regenerate( $updateBackendData );
         $newSessionId = session_id();
@@ -72,11 +82,15 @@ class ezpSessionHandlerSymfony extends ezpSessionHandler
             eZSession::triggerCallback( 'regenerate_post', array( $db, $escNewKey, $escOldKey, $escUserID ) );
         }
         return true;
-
     }
 
     public function gc( $maxLifeTime )
     {
+        if ( eZSys::isShellExecution() )
+        {
+            return false;
+        }
+
         ezpEvent::getInstance()->notify( 'session/gc', array( $maxLifeTime ) );
         $db = eZDB::instance();
         eZSession::triggerCallback( 'gc_pre', array( $db, $maxLifeTime ) );


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-24334

Some scripts, like `ezpm.php`, initialize `eZScript` with session support.
In that case, when shutting down, `eZScript` tries to log out current user and to clean up the session. This calls `ezpSessionHandlerSymfony`, which calls Symfony session storage, which does... a legacy callback.

This patch ensures that calls to session regenerate/destroy/gc in `ezpSessionHandlerSymfony`, and  made from CLI doesn't do anything.

AFAICS, there should not be any BC break.