### PR TITLE
EZP-24240: Make sure the custom temporary class is not added back on links

### DIFF
--- a/extension/ezoe/design/standard/javascript/ezoe/popup_utils.js
+++ b/extension/ezoe/design/standard/javascript/ezoe/popup_utils.js
@@ -212,8 +212,9 @@ var eZOEPopupUtils = {
             }
             else if ( s.tagName === 'link' )
             {
-                var links, linkClass = 'ezoeInsertedLink';
+                var links, linkClass = 'ezoeInsertedLink', origClass;
 
+                origClass = args['class'];
                 args['class'] = args['class'] ? args['class'] + " " + linkClass : linkClass;
                 ed.execCommand('mceInsertLink', false, args, {skip_undo : 1} );
                 links = ed.dom.select('.' + linkClass);
@@ -221,6 +222,7 @@ var eZOEPopupUtils = {
                     ed.dom.removeClass(link, linkClass);
                 });
                 s.editorElement = links[0];
+                args['class'] = origClass;
 
                 // fixup if we are inside embed tag
                 if ( tmp = eZOEPopupUtils.getParentByTag( s.editorElement, 'div,span', 'ezoeItemNonEditable' ) )


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24240

# Description

The fix for [EZP-24240](https://jira.ez.no/browse/EZP-24240) provided in https://github.com/ezsystems/ezpublish-legacy/pull/1176 was incomplete. This patch makes sure we don't re-add the custom temporary class `ezoeInsertedLink` otherwise if you create several links in a row, they'll all have the target of the last one.

# Tests

manual tests