### PR TITLE
Fix EZP-24565 AttributeFilter not_in: Escape string only if the value isn't numeric

### DIFF
--- a/kernel/classes/ezcontentobjecttreenode.php
+++ b/kernel/classes/ezcontentobjecttreenode.php
@@ -1135,6 +1135,7 @@ class eZContentObjectTreeNode extends eZPersistentObject
                         default:
                         {
                             $useAttributeFilter = true;
+                            $filterFieldType = false;
                         } break;
                     }
 
@@ -1288,8 +1289,13 @@ class eZContentObjectTreeNode extends eZPersistentObject
                                     reset( $filter[2] );
                                     while ( list( $key, $value ) = each( $filter[2] ) )
                                     {
+                                      // If filterFieldType is explicitely set
+                                      if( $filterFieldType ){
+                                        $filter[2][$key] = ( $filterFieldType == "integer" ) ? (int) $value : "'" . $db->escapeString( $value ) . "'";
+                                      }else{
                                         // Non-numerics must be escaped to avoid SQL injection
                                         $filter[2][$key] = is_numeric( $value ) ? $value : "'" . $db->escapeString( $value ) . "'";
+                                      }
                                     }
                                     $filterValue = '(' .  implode( ",", $filter[2] ) . ')';
                                 }

--- a/kernel/classes/ezcontentobjecttreenode.php
+++ b/kernel/classes/ezcontentobjecttreenode.php
@@ -1289,15 +1289,7 @@ class eZContentObjectTreeNode extends eZPersistentObject
                                     while ( list( $key, $value ) = each( $filter[2] ) )
                                     {
                                         // Non-numerics must be escaped to avoid SQL injection
-                                        switch ( $filterFieldType )
-                                        {
-                                            case 'string':
-                                                $filter[2][$key] = "'" . $db->escapeString( $value ) . "'";
-                                                break;
-                                            case 'integer':
-                                            default:
-                                                $filter[2][$key] = (int) $value;
-                                        }
+                                        $filter[2][$key] = is_numeric( $value ) ? $value : "'" . $db->escapeString( $value ) . "'";
                                     }
                                     $filterValue = '(' .  implode( ",", $filter[2] ) . ')';
                                 }


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-24565

We check if the provided parameter is numeric or not before escaping it. The escaping doesn't rely on the `$filterFieldType` parameter anymore (which isn't set for custom attributes anyway)