### PR TITLE
Fix EZP-24530: Editing other language removes translations

### DIFF
--- a/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
+++ b/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
@@ -422,11 +422,6 @@ class eZObjectRelationListType extends eZDataType
         // order by asc
         sort( $translationList );
 
-        if ( ( $countTsl == 1 ) or ( $countTsl > 1 and $translationList[0] == $langCode ) )
-        {
-             eZContentObject::fetch( $contentObjectID )->removeContentObjectRelation( false, $contentObjectVersion, $contentClassAttributeID, eZContentObject::RELATION_ATTRIBUTE );
-        }
-
         foreach( $content['relation_list'] as $relationItem )
         {
             // Installing content object, postUnserialize is not called yet,


### PR DESCRIPTION
Given a content that has a relation list field, and has one translation in a secondary language with relations in the relation list field, publishing a new translation in the main language will remove the relations in other languages.

The lines that are removed go back to 2005 (@45eb5e7), and don't reference a bug, meaning that we don't really know what it fixed (something with reverse relations).

### Testing
1. Site has eng-GB and fre-FR, and a Content Type "Relation list" with a relation list attribute
2. Create a content of type "Relation list" in eng-GB, with a relation to object A
3. Edit the content in fre-FR, and add a relation to object B
4. Check in the object's relations tab that both relations to A and B are listed
5. Edit the content in eng-GB, publish without changing it
6. Check in the object's relations tab that both relations to A and B are listed.

Without the patch, step 6 fails, and only the eng-GB relation is listed.
