### PR TITLE
 Fix EZP-24565: correctly quote attributes of custom AttributeFilters

### DIFF
--- a/kernel/classes/ezcontentobjecttreenode.php
+++ b/kernel/classes/ezcontentobjecttreenode.php
@@ -1178,6 +1178,7 @@ class eZContentObjectTreeNode extends eZPersistentObject
                                 if ( $filterDataType == 'string' )
                                 {
                                     $sortKey = 'sort_key_string';
+                                    $filterFieldType = 'string';
                                 }
                                 else
                                 {

--- a/tests/tests/kernel/classes/ezcontentobjecttreenode_test2.php
+++ b/tests/tests/kernel/classes/ezcontentobjecttreenode_test2.php
@@ -30,6 +30,19 @@ class eZContentObjectTreeNodeTest2 extends ezpDatabaseTestCase
             array( 'class_identifier', "                            ( ezcontentclass.identifier IN ('1','3','foo','1foo','foo_1')  ) AND " ),
             array( 'class_name',       "                            ( ezcontentclass_name.name IN ('1','3','foo','1foo','foo_1')  ) AND " ),
             array( 'name',             "                            ( ezcontentobject_name.name IN ('1','3','foo','1foo','foo_1')  ) AND " ),
+            // custom
+            array( 1,                  "
+                                  a0.contentobject_id = ezcontentobject.id AND
+                                  a0.contentclassattribute_id = 1 AND
+                                  a0.version = ezcontentobject_name.content_version AND 
+ ( a0.language_id & ezcontentobject.language_mask > 0 AND
+     ( (   ezcontentobject.language_mask - ( ezcontentobject.language_mask & a0.language_id ) ) & 1 )
+   + ( ( ( ezcontentobject.language_mask - ( ezcontentobject.language_mask & a0.language_id ) ) & 2 ) )
+   <
+     ( a0.language_id & 1 )
+   + ( ( a0.language_id & 2 ) )
+ ) 
+ AND                             ( a0.sort_key_string IN ('1','3','foo','1foo','foo_1')  ) AND " ),
         );
     }
 


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-24565

Replaces https://github.com/ezsystems/ezpublish-legacy/pull/1182 : the approach is not right as every items of the in/not_in statement must have the same type (either string or integer) to be properly quoted in the final SQL query.

TODO:
- [x] add tests