### PR TITLE
Fix EZP-24641: Copy button next to Published article not triggering an action

### DIFF
--- a/design/admin/templates/content/history.tpl
+++ b/design/admin/templates/content/history.tpl
@@ -168,7 +168,6 @@
 {if $object.can_diff}
 {def $languages=$object.languages}
 <div class="button-right">
-<form action={concat( $module.functions.history.uri, '/', $object.id, '/' )|ezurl} method="post">
         <select name="Language">
             {foreach $languages as $lang}
                 <option value="{$lang.locale}">{$lang.name|wash}</option>
@@ -186,7 +185,6 @@
         </select>
     <input type="hidden" name="ObjectID" value="{$object.id}" />
     <input class="button" type="submit" name="DiffButton" value="{'Show differences'|i18n( 'design/admin/content/history' )}" />
-</form>
 </div>
 {/if}
 
@@ -195,12 +193,10 @@
 
 <div class="block">
 <div class="button-left">
-<form name="versionsback" action={concat( '/content/history/', $object.id, '/' )|ezurl} method="post">
 {if is_set( $redirect_uri )}
 <input class="text" type="hidden" name="RedirectURI" value="{$redirect_uri}" />
 {/if}
 <input class="button" type="submit" name="BackButton" value="{'Back'|i18n( 'design/admin/content/history' )}" />
-</form>
 
 </div>
 </div>


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-24641

## Description
Forms with the same action were nested (see opening tag line 49), which is not allowed by (modern) browsers.
The fix removes the nested form tags.

## Tests
Manual test and sanity checks on the page