### PR TITLE
Fix EZP-24630: Checkbox value lost when conflicts

### DIFF
--- a/design/admin/templates/content/edit_conflict.tpl
+++ b/design/admin/templates/content/edit_conflict.tpl
@@ -84,6 +84,22 @@
 <input class="button" type="submit" name="ShowPublishedData" value="{'Show the published data'|i18n( 'design/admin/content/edit_draft' )}" title="{'Create a new draft. The contents of the new draft will be copied from the published version.'|i18n( 'design/admin/content/edit_draft' )}" />
 <input type="hidden" name="PublishAfterConflict" value="1" />
 
+{*
+   EZP-24630: ezboolean work around.
+   Since unchecked textboxes are not present in POST, storing their value in a hidden field.
+ *}
+{foreach $object.contentobject_attributes as $attribute}
+    {if eq( $attribute.data_type_string, 'ezboolean' )}
+        <input
+            id="ezcoa-{$attribute.contentclassattribute_id}_{$attribute.contentclass_attribute_identifier}"
+            class="ezcc-{$attribute.object.content_class.identifier} ezcca-{$attribute.object.content_class.identifier}_{$attribute.contentclass_attribute_identifier}"
+            type="hidden"
+            name="ContentObjectAttribute_data_boolean_{$attribute.id}"
+            value="{$attribute.data_int|wash}"
+        />
+    {/if}
+{/foreach}
+
 </div>
 {* DESIGN: Control bar END *}</div></div>
 

--- a/kernel/classes/datatypes/ezboolean/ezbooleantype.php
+++ b/kernel/classes/datatypes/ezboolean/ezbooleantype.php
@@ -111,6 +111,11 @@ class eZBooleanType extends eZDataType
         }
         else
         {
+            /*
+             * Note: in other DataTypes, false is returned if the variable is not present.
+             * Since HTTP checkboxes are not present in the POST when they are not checked,
+             * eZBooleanType might behave a bit differently. See EZP-24630 for a concrete use case.
+             */
             $data = 0;
         }
         $contentObjectAttribute->setAttribute( "data_int", $data );


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-24630

## Description
A 10 year old bug (at least).

I added comments in the code with explanations. 
The main idea is that DataTypes check if a value is present in POST and return false when a content should not be modified (nothing to do). 

The problem is that HTTP checkboxes "unchecked" value is "not being present in POST" making it impossible to know if the DataType needs to return false (nothing to do) or to update the data with "unchecked". The bug is that it was updating the data with "unchecked".

In order to fix that, I added checkboxes values in an hidden field in the conflict page which is a "nothing to do" case DataTypewise.

## Tests
Manual tests and sanity tests on checkbox editing

