### PR TITLE
Fix EZP-24692: creating content leaves stale video/binary files

### DIFF
--- a/kernel/classes/datatypes/ezbinaryfile/ezbinaryfiletype.php
+++ b/kernel/classes/datatypes/ezbinaryfile/ezbinaryfiletype.php
@@ -293,52 +293,63 @@ class eZBinaryFileType extends eZDataType
         if ( !eZHTTPFile::canFetch( $base . "_data_binaryfilename_" . $contentObjectAttribute->attribute( "id" ) ) )
             return false;
 
-        $binaryFile = eZHTTPFile::fetch( $base . "_data_binaryfilename_" . $contentObjectAttribute->attribute( "id" ) );
+        $httpBinaryFile = eZHTTPFile::fetch( $base . "_data_binaryfilename_" . $contentObjectAttribute->attribute( "id" ) );
 
-        $contentObjectAttribute->setContent( $binaryFile );
+        $contentObjectAttribute->setContent( $httpBinaryFile );
 
-        if ( $binaryFile instanceof eZHTTPFile )
+        if ( $httpBinaryFile instanceof eZHTTPFile )
         {
             $contentObjectAttributeID = $contentObjectAttribute->attribute( "id" );
             $version = $contentObjectAttribute->attribute( "version" );
 
             /*
             $mimeObj = new  eZMimeType();
-            $mimeData = $mimeObj->findByURL( $binaryFile->attribute( "original_filename" ), true );
+            $mimeData = $mimeObj->findByURL( $httpBinaryFile->attribute( "original_filename" ), true );
             $mime = $mimeData['name'];
             */
 
-            $mimeData = eZMimeType::findByFileContents( $binaryFile->attribute( "original_filename" ) );
+            $mimeData = eZMimeType::findByFileContents( $httpBinaryFile->attribute( "original_filename" ) );
             $mime = $mimeData['name'];
 
             if ( $mime == '' )
             {
-                $mime = $binaryFile->attribute( "mime_type" );
+                $mime = $httpBinaryFile->attribute( "mime_type" );
             }
-            $extension = eZFile::suffix( $binaryFile->attribute( "original_filename" ) );
-            $binaryFile->setMimeType( $mime );
-            if ( !$binaryFile->store( "original", $extension ) )
+            $extension = eZFile::suffix( $httpBinaryFile->attribute( "original_filename" ) );
+            $httpBinaryFile->setMimeType( $mime );
+            if ( !$httpBinaryFile->store( "original", $extension ) )
             {
-                eZDebug::writeError( "Failed to store http-file: " . $binaryFile->attribute( "original_filename" ),
+                eZDebug::writeError( "Failed to store http-file: " . $httpBinaryFile->attribute( "original_filename" ),
                                      "eZBinaryFileType" );
                 return false;
             }
 
             $binary = eZBinaryFile::fetch( $contentObjectAttributeID, $version );
             if ( $binary === null )
+            {
                 $binary = eZBinaryFile::create( $contentObjectAttributeID, $version );
+            }
+            else
+            {
+                // if storing a different file for the same version, see if the existing file can be removed.
+                $newfilename = basename( $httpBinaryFile->attribute( "filename" ) );
+                if ( $newFilename != $binary->Filename )
+                {
+                    $this->deleteStoredObjectAttribute( $contentObjectAttribute, $version );
+                }
+            }
 
-            $orig_dir = $binaryFile->storageDir( "original" );
+            $orig_dir = $httpBinaryFile->storageDir( "original" );
 
             $binary->setAttribute( "contentobject_attribute_id", $contentObjectAttributeID );
             $binary->setAttribute( "version", $version );
-            $binary->setAttribute( "filename", basename( $binaryFile->attribute( "filename" ) ) );
-            $binary->setAttribute( "original_filename", $binaryFile->attribute( "original_filename" ) );
+            $binary->setAttribute( "filename", basename( $httpBinaryFile->attribute( "filename" ) ) );
+            $binary->setAttribute( "original_filename", $httpBinaryFile->attribute( "original_filename" ) );
             $binary->setAttribute( "mime_type", $mime );
 
             $binary->store();
 
-            $filePath = $binaryFile->attribute( 'filename' );
+            $filePath = $httpBinaryFile->attribute( 'filename' );
             $fileHandler = eZClusterFileHandler::instance();
             $fileHandler->fileStore( $filePath, 'binaryfile', true, $mime );
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24692

When creating a video content the first upload creates a binaryfile entry, but saving or publishing the 1st version will create yet another file.
The DB entry in ezbinaryfile is updated for that version, so the file kept in var/storage becomes 'stale'.

This fix makes sure that the old file is removed when storing a new file for a given version.
Notes: 
*  fileName is not the actual (original) filename, but the pseudo-random hash.ext that can be seen under var/storage/
* `deleteStoredObjectAttribute()` method should only remove the file if no longer in use.