### PR TITLE
Fix EZP-24734: Users (eztextfileuser) created in wrong group

### DIFF
--- a/settings/textfile.ini
+++ b/settings/textfile.ini
@@ -17,9 +17,9 @@ FilePath=root
 FileFieldSeparator=tab
 # Could be id or name
 DefaultUserGroupType=id
-# Default place to store users from textfile. Could be node id or group name, 
+# Default place to store users from textfile. Could be object id or group name, 
 # depends on DefaultUserGroupType.
-DefaultUserGroup=12
+DefaultUserGroup=11
 # Field column nr for login.
 LoginAttribute=1
 # Field column nr for password.


### PR DESCRIPTION
Currently file register users on Admin Group
Fixes: https://jira.ez.no/browse/EZP-24734

Where the objectId is used: https://github.com/ezsystems/ezpublish-legacy/blob/master/kernel/classes/datatypes/ezuser/eztextfileuser.php#L186