### PR TITLE
EZP-24744 - Increase password security

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,8 @@
         "zetacomponents/persistent-object": "~1.8",
         "zetacomponents/signal-slot": "~1.2",
         "zetacomponents/system-information": "~1.1",
-        "zetacomponents/webdav": "~1.1"
+        "zetacomponents/webdav": "~1.1",
+        "ircmaxell/password-compat": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*",

--- a/doc/bc/5.4/changes-5.4.txt
+++ b/doc/bc/5.4/changes-5.4.txt
@@ -3,7 +3,13 @@ Changes to BC and behavior in version 5.4
 
 INI setting changes
 -------------------
-
+- EZP-24744 - Increase password security
+  
+  With the implementation of this new feature, a new option has been introduced
+  for the user HashType, the bcrypt. This new option will encrypt the user password
+  using bcrypt algorithm.
+  Caution - Using the PASSWORD_BCRYPT, will result in the password parameter 
+  being truncated to a maximum length of 72 characters
 
 Change of behavior
 ------------------

--- a/kernel/classes/datatypes/ezuser/ezuser.php
+++ b/kernel/classes/datatypes/ezuser/ezuser.php
@@ -27,6 +27,8 @@ class eZUser extends eZPersistentObject
     const PASSWORD_HASH_MYSQL = 4;
     /// Passwords in plaintext, should not be used for real sites
     const PASSWORD_HASH_PLAINTEXT = 5;
+    /// Passwords in bcrypt of password
+    const PASSWORD_BCRYPT = 6;
 
     /**
      * Max length allowed for a login or a password
@@ -135,6 +137,10 @@ class eZUser extends eZPersistentObject
             {
                 return 'plaintext';
             } break;
+            case self::PASSWORD_BCRYPT:
+            {
+                return 'bcrypt';
+            } break;
         }
     }
 
@@ -165,6 +171,10 @@ class eZUser extends eZPersistentObject
             case 'plaintext':
             {
                 return self::PASSWORD_HASH_PLAINTEXT;
+            } break;
+            case 'bcrypt':
+            {
+                return self::PASSWORD_BCRYPT;
             } break;
         }
     }
@@ -611,6 +621,8 @@ WHERE user_id = '" . $userID . "' AND
             return self::PASSWORD_HASH_MD5_USER;
         else if ( $type == 'plaintext' )
             return self::PASSWORD_HASH_PLAINTEXT;
+        else if ( $type == 'bcrypt' )
+            return self::PASSWORD_BCRYPT;
         else
             return self::PASSWORD_HASH_MD5_PASSWORD;
     }
@@ -1802,6 +1814,19 @@ WHERE user_id = '" . $userID . "' AND
         }
         else if ( $type == self::PASSWORD_HASH_PLAINTEXT )
         {
+            $str = $password;
+        }
+        else if ( $type == self::PASSWORD_BCRYPT )
+        {
+            if ( $hash ) {
+                if ( password_verify( $password, $hash ) ) {
+                    return $hash;
+                } else {
+                    return false;
+                }
+            } else {
+                $str = password_hash( $password, PASSWORD_BCRYPT );
+            }
             $str = $password;
         }
         else // self::PASSWORD_HASH_MD5_PASSWORD

--- a/settings/site.ini
+++ b/settings/site.ini
@@ -563,6 +563,7 @@ UserCreatorID=14
 # md5_site generates password hash from site, user and password
 # plaintext does not generate a hash but has the password as it is, this is not
 # recommended since it is a huge security risc.
+# bcrypt generates password bcrypt from password only.
 # note: password hashes generated with md5_site will not work after
 #       changing the site name.
 HashType=md5_user

--- a/share/db_schema.dba
+++ b/share/db_schema.dba
@@ -7272,7 +7272,7 @@ $schema = array (
       ),
       'password_hash' => 
       array (
-        'length' => 50,
+        'length' => 255,
         'type' => 'varchar',
         'default' => NULL,
       ),

--- a/update/common/scripts/5.4/updatepasswordhashlength.php
+++ b/update/common/scripts/5.4/updatepasswordhashlength.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ * @package kernel
+ */
+
+require 'autoload.php';
+
+set_time_limit( 0 );
+
+$cli = eZCLI::instance();
+$script = eZScript::instance(
+    array(
+        'description' => 'Script responsible for changing the number of characters the password_hash column, in ezuser table',
+    )
+);
+
+$script->initialize();
+$script->startup();
+
+$db = eZDB::instance();
+
+$rows = $db->query( "ALTER TABLE `ezuser` CHANGE COLUMN `password_hash` `password_hash` VARCHAR(255) NULL DEFAULT NULL ;" );
+
+$cli->output( ' Done' );

--- a/update/database/mysql/5.9/dbupdate-5.4.0-to-5.90.0.sql
+++ b/update/database/mysql/5.9/dbupdate-5.4.0-to-5.90.0.sql
@@ -1,0 +1,3 @@
+-- See https://jira.ez.no/browse/EZP-24744 - Increase password security
+ALTER TABLE ezuser CHANGE password_hash password_hash VARCHAR(255) NULL DEFAULT NULL;
+

--- a/update/database/postgresql/5.9/dbupdate-5.4.0-to-5.90.0.sql
+++ b/update/database/postgresql/5.9/dbupdate-5.4.0-to-5.90.0.sql
@@ -1,0 +1,3 @@
+-- See https://jira.ez.no/browse/EZP-24744 - Increase password security
+ALTER TABLE ezuser ALTER COLUMN password_hash TYPE character varying(255);
+


### PR DESCRIPTION
## EZP-24744 - Increase password security

Currently eZ Publish is only using plain text or MD5 for password hash, this improvement implements the usage of BCRYPT to improve the security of the stored passwords

Using https://github.com/ircmaxell/password_compat
