### PR TITLE
EZP-24756: ezimage datatype - do not store file if not valid

### DIFF
--- a/kernel/classes/datatypes/ezimage/ezimagetype.php
+++ b/kernel/classes/datatypes/ezimage/ezimagetype.php
@@ -295,8 +295,8 @@ class eZImageType extends eZDataType
 
         $content = $contentObjectAttribute->attribute( 'content' );
         $httpFileName = $base . "_data_imagename_" . $contentObjectAttribute->attribute( "id" );
-
-        if ( eZHTTPFile::canFetch( $httpFileName ) )
+        if ( $contentObjectAttribute->IsValid != eZInputValidator::STATE_INVALID
+            && eZHTTPFile::canFetch( $httpFileName ) )
         {
             $httpFile = eZHTTPFile::fetch( $httpFileName );
             if ( $httpFile )


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24756
#### Problem:

When uploading invalid files to an ezimage attribute (empty files, non-images, etc), the input is validated but the file is still stored and eZ still tries to generate image aliases.
#### Solution:

This modifies the ezimage datatype so that the file is not stored if the validation result is `STATE_INVALID`, with a minor refactor.
