### PR TITLE
Fix EZP-24754: PHP Notice while erasing content

### DIFF
--- a/kernel/content/ezcontentoperationcollection.php
+++ b/kernel/content/ezcontentoperationcollection.php
@@ -874,8 +874,11 @@ class eZContentOperationCollection
         {
             $allNodes = $objectIdList[$objectId]->assignedNodes();
             // Registering node that will be promoted as 'main'
-            $mainNodeChanged[$objectId] = $allNodes[0];
-            eZContentObjectTreeNode::updateMainNodeID( $allNodes[0]->attribute( 'node_id' ), $objectId, false, $allNodes[0]->attribute( 'parent_node_id' ) );
+            if ( isset( $allNodes[0] ) )
+            {
+                $mainNodeChanged[$objectId] = $allNodes[0];
+                eZContentObjectTreeNode::updateMainNodeID( $allNodes[0]->attribute( 'node_id' ), $objectId, false, $allNodes[0]->attribute( 'parent_node_id' ) );
+            }
         }
 
         // Give other search engines that the default one a chance to reindex


### PR DESCRIPTION
While erasing content in some cases PHP message: PHP Notice: Undefined offset: 0 in ezpublish_legacy/kernel/content/ezcontentoperationcollection.php

While removing content, in some strange cases it raises the exception

Link: https://jira.ez.no/browse/EZP-24754