### PR TITLE
checking if object is already created

### DIFF
--- a/design/standard/templates/content/datatype/edit/ezuser.tpl
+++ b/design/standard/templates/content/datatype/edit/ezuser.tpl
@@ -18,7 +18,7 @@
 {* Username. *}
 <div class="element">
     <label for="{$id_base}_login">{'Username'|i18n( 'design/standard/content/datatype' )}:</label>
-    {if $attribute.content.has_stored_login}
+    {if and( $attribute.content.has_stored_login, $attribute.object.published )}
         <input id="{$id_base}_login" type="text" name="{$attribute_base}_data_user_login_{$attribute.id}_stored_login" size="16" value="{$attribute.content.login|wash()}" disabled="disabled" />
         <input id="{$id_base}_login_hidden" type="hidden" name="{$attribute_base}_data_user_login_{$attribute.id}" value="{$attribute.content.login|wash()}" />
     {else}


### PR DESCRIPTION
checking if object is already created before hiding the login text input, otherwise the login can't be changed (even if it is empty and throws an error) after the first form submit if the content object was newly created (example: user registration)