### PR TITLE
EZP-24868: Ignore class token if prefixed by "::"

### DIFF
--- a/kernel/private/classes/ezautoloadgenerator.php
+++ b/kernel/private/classes/ezautoloadgenerator.php
@@ -632,6 +632,13 @@ class eZAutoloadGenerator
                             case T_CLASS:
                             case T_INTERFACE:
                             case $tTrait:
+                                // Ignore token if prefixed by a double colon: "<ClassName>::class"
+                                // @see http://php.net/manual/en/language.oop5.basic.php#language.oop5.basic.class.class
+                                // TEXT_TOKEN - "::"-TEXT_TOKEN - CLASS_TOKEN
+                                if ($tokens[$key-1][1] === '::') {
+                                    break;
+                                }
+
                                 // Increment stat for found class.
                                 $this->incrementProgressStat( self::OUTPUT_PROGRESS_PHASE2, 'classCount' );
 


### PR DESCRIPTION
See https://jira.ez.no/browse/EZP-24868

Since PHP 5.5, it is possible to use `<ClassName>::class` for class name resolution, in addition to `get_class()`, see [PHP Manual: OOP Basics -> ::class](http://php.net/manual/en/language.oop5.basic.php#language.oop5.basic.class.class).

When this is used anywhere in a file parsed by the autoload generator, PHP Notices are thrown during generation:

```bash
$ php bin/php/ezpgenerateautoloads.php -e
Scanning for PHP-files.
 
Scan complete. Found 1525 PHP files.
 
Searching for classes (tokenizing).
 
PHP Notice:  Uninitialized string offset: 1 in kernel/private/classes/ezautoloadgenerator.php on line 632
PHP Stack trace:
PHP   1. {main}() bin/php/ezpgenerateautoloads.php:0
PHP   2. eZAutoloadGenerator->buildAutoloadArrays() bin/php/ezpgenerateautoloads.php:174
PHP   3. eZAutoloadGenerator->getClassFileList() kernel/private/classes/ezautoloadgenerator.php:192
```

This patch fixes this by ignoring class tokens which are prefixed by a double colon (`::`).

Cheers!
:octocat: Jérôme