### PR TITLE
Fix EZP-24889: Clear in-memory cache for moved nodes in delayed indexing script

### DIFF
--- a/cronjobs/indexcontent.php
+++ b/cronjobs/indexcontent.php
@@ -93,6 +93,9 @@ while( true )
                                 }
 
                                 $searchEngine->addObject( $childObject, false );
+
+                                // clear object cache to conserve memory
+                                eZContentObject::clearCache();
                             }
                         }
 


### PR DESCRIPTION
We clear in-memory cache for each normal indexed object, but not for moved node subtrees.

https://jira.ez.no/browse/EZP-24889