### PR TITLE
Fix EZP-24890: Delayed indexing should fail gracefully on trashed / broken node (alt)

### DIFF
--- a/cronjobs/indexcontent.php
+++ b/cronjobs/indexcontent.php
@@ -62,6 +62,8 @@ while( true )
                     if ( !( $node instanceof eZContentObjectTreeNode ) )
                     {
                         $cli->error( "An error occured while trying fetching node $nodeId" );
+                        $db->query( "DELETE FROM ezpending_actions WHERE action = '$action' AND param = '$objectID'" );
+                        $db->commit();
                         continue;
                     }
 


### PR DESCRIPTION
An alternative to https://github.com/ezsystems/ezpublish-legacy/pull/1204 with a simpler diff: duplicating the DB commands.