### PR TITLE
EZP-24906: Fix breadcrumb link to pdf/list module

### DIFF
--- a/kernel/pdf/list.php
+++ b/kernel/pdf/list.php
@@ -50,7 +50,7 @@ $tpl->setVariable( 'pdfexport_list', $exportList );
 
 $Result = array();
 $Result['content'] = $tpl->fetch( "design:pdf/list.tpl" );
-$Result['path'] = array( array( 'url' => 'kernel/pdf',
+$Result['path'] = array( array( 'url' => 'pdf/list',
                                 'text' => ezpI18n::tr( 'kernel/pdf', 'PDF Export' ) ) );
 
 ?>


### PR DESCRIPTION
A small issue, but causes exception in Symfony context where ez_legacy route fails with an error about non existing module "kernel".

Link: https://jira.ez.no/browse/EZP-24906