### PR TITLE
Fix EZP-25017: Administration Interface object title runs over language indicator

### DIFF
--- a/design/admin/stylesheets/pagelayout.css
+++ b/design/admin/stylesheets/pagelayout.css
@@ -875,7 +875,6 @@ div.content-navigation div.context-information p.left
 div.content-navigation div.context-information p.right
 {
     position:absolute;
-    top: -2.5em;
     width: 30%;
     right:0em;
 }


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-25017

This restores the language indicator to be below the title, on the same line as the author, object ID, and node ID information.