### PR TITLE
EZP-25036: Add EncodingDataMap Parameter to ezjsc::search Ajax function

### DIFF
--- a/extension/ezjscore/classes/ezjscserverfunctionsjs.php
+++ b/extension/ezjscore/classes/ezjscserverfunctionsjs.php
@@ -435,6 +435,9 @@ YUI( YUI3_config ).add('io-ez', function( Y )
         if ( self::hasPostValue( $http, 'EncodingFormatDate' ) )
             $encodeParams['formatDate'] = $http->postVariable( 'EncodingFormatDate' );
 
+        if ( self::hasPostValue( $http, 'EncodingDataMap' ) )
+            $encodeParams['dataMap'] = $http->postVariable( 'EncodingDataMap' );
+
         // Prepare search parameters
         $params = array( 'SearchOffset' => $searchOffset,
                          'SearchLimit' => $searchLimit,


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25036

With this change it is possible to get the data map from the search results.
I need it to display additionally fields for the ezrelationlist ajax search.