### PR TITLE
Fix EZP-25109: purge stale binary files when removing from cluster

### DIFF
--- a/kernel/classes/datatypes/ezbinaryfile/ezbinaryfiletype.php
+++ b/kernel/classes/datatypes/ezbinaryfile/ezbinaryfiletype.php
@@ -185,7 +185,10 @@ class eZBinaryFileType extends eZDataType
                 $file = eZClusterFileHandler::instance( $filePath );
 
                 if ( $file->exists() and count( $binaryObjectsWithSameFileName ) < 1 )
+                {
                     $file->delete();
+                    $file->purge();
+                }
             }
         }
         else
@@ -208,7 +211,10 @@ class eZBinaryFileType extends eZDataType
                 $file = eZClusterFileHandler::instance( $filePath );
 
                 if ( $file->exists() and count( $binaryObjectsWithSameFileName ) < 1 )
+                {
                     $file->delete();
+                    $file->purge();
+                }
             }
         }
     }


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25109

When updating the first draft of a content the binary files (videos/etc) are removed but not purged from the cluster.
This is an alternative to having to run the dfscleanup script.