### PR TITLE
Fix EZP-25065: non-translatable object relation not updated.

### DIFF
--- a/kernel/classes/datatypes/ezobjectrelation/ezobjectrelationtype.php
+++ b/kernel/classes/datatypes/ezobjectrelation/ezobjectrelationtype.php
@@ -158,23 +158,34 @@ class eZObjectRelationType extends eZDataType
         $contentObjectID = $contentObjectAttribute->ContentObjectID;
         $contentObjectVersion = $contentObjectAttribute->Version;
 
-        $obj = $contentObjectAttribute->object();
-        //get eZContentObjectVersion
-        $currVerobj = $obj->version( $contentObjectVersion );
-        // get array of language codes
-        $transList = $currVerobj->translations( false );
-        $countTsl = count( $transList );
+        /** @var eZContentObject */
+        $contentObject = $contentObjectAttribute->object();
 
-        if ( ( $countTsl == 1 ) )
+        // check if previous relation(s) can be removed according to existing translations
+        if ( $contentObjectAttribute->contentClassAttributeCanTranslate() )
         {
-             eZContentObject::fetch( $contentObjectID )->removeContentObjectRelation( false, $contentObjectVersion, $contentClassAttributeID, eZContentObject::RELATION_ATTRIBUTE );
+            /** @var eZContentObjectVersion */
+            $currVerobj = $contentObject->version( $contentObjectVersion );
+            // get array of language codes
+            $transList = $currVerobj->translations( false );
+            $removeRelation = ( count( $transList ) == 1 );
+        }
+        else
+        {
+            // not translatable, replace/remove previous relation
+            $removeRelation = true;
+        }
+
+        if ( $removeRelation )
+        {
+             $contentObject->removeContentObjectRelation( false, $contentObjectVersion, $contentClassAttributeID, eZContentObject::RELATION_ATTRIBUTE );
         }
 
         $objectID = $contentObjectAttribute->attribute( "data_int" );
 
         if ( $objectID )
         {
-            eZContentObject::fetch( $contentObjectID )->addContentObjectRelation( $objectID, $contentObjectVersion, $contentClassAttributeID, eZContentObject::RELATION_ATTRIBUTE );
+            $contentObject->addContentObjectRelation( $objectID, $contentObjectVersion, $contentClassAttributeID, eZContentObject::RELATION_ATTRIBUTE );
         }
     }
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25065

#### Problem:
When editing content with multiple languages and a non-translatable object relation, updating the relation object will cause the object to incorrectly display both the previous and the new relation.

#### Solution:
When the relation attribute is non-translatable, remove any existing relation when storing a new one, regardless of the number of current translations.
