### PR TITLE
Fix EZP-24783: only clear cache if needed in sort operations

### DIFF
--- a/extension/ezjscore/classes/ezjscserverfunctionsnode.php
+++ b/extension/ezjscore/classes/ezjscserverfunctionsnode.php
@@ -212,7 +212,7 @@ class ezjscServerFunctionsNode extends ezjscServerFunctions
         if ( $http->hasPostVariable( 'ContentObjectID' ) )
         {
             $objectID = $http->postVariable( 'ContentObjectID' );
-            eZContentCacheManager::clearContentCache( $objectID );
+            eZContentCacheManager::clearContentCacheIfNeeded( $objectID );
         }
     }
 

--- a/kernel/content/action.php
+++ b/kernel/content/action.php
@@ -1098,7 +1098,7 @@ else if ( $http->hasPostVariable( 'UpdatePriorityButton' ) )
     if ( $http->hasPostVariable( 'ContentObjectID' ) )
     {
         $objectID = $http->postVariable( 'ContentObjectID' );
-        eZContentCacheManager::clearContentCache( $objectID );
+        eZContentCacheManager::clearContentCacheIfNeeded( $objectID );
     }
 
     if ( $http->hasPostVariable( 'RedirectURIAfterPriority' ) )

--- a/kernel/content/ezcontentoperationcollection.php
+++ b/kernel/content/ezcontentoperationcollection.php
@@ -1195,7 +1195,7 @@ class eZContentOperationCollection
              $curNode->store();
              $db->commit();
              $object = $curNode->object();
-             eZContentCacheManager::clearContentCache( $object->attribute( 'id' ) );
+             eZContentCacheManager::clearContentCacheIfNeeded( $object->attribute( 'id' ) );
         }
         return array( 'status' => true );
     }


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24783

##### Problem:
Some node sort operations (either through content/action, content operation or ezjscore) clear cache without checking if it is enabled or not.