### PR TITLE
EZP-25077: fix incorrect order of trashed image validity check.

### DIFF
--- a/update/common/scripts/5.4/fixtrashedimagereferences.php
+++ b/update/common/scripts/5.4/fixtrashedimagereferences.php
@@ -51,8 +51,8 @@ if ( $optDryRun ) {
  */
 function fixupTrashedImageXml( $imageAttribute, $optDryRun )
 {
-    if ( stripos(' dirpath="/trashed" ', $imageAttribute['data_text']) === false ||
-        stripos(' is_valid="" ', $imageAttribute['data_text']) === false )
+    if ( stripos( $imageAttribute['data_text'], ' dirpath="/trashed" ' ) === false ||
+        stripos( $imageAttribute['data_text'], ' is_valid="" ' ) === false )
     {
         return;
     }


### PR DESCRIPTION
Somehow the string comparison for matching invalid/empty, trashed images was incorrect, this fixes it.