### PR TITLE
Fix EZP-25156: clusterpurge requires a valid list of scope(s)

### DIFF
--- a/kernel/private/classes/ezscriptclusterpurge.php
+++ b/kernel/private/classes/ezscriptclusterpurge.php
@@ -65,6 +65,12 @@ class eZScriptClusterPurge
     {
         $cli = eZCLI::instance();
 
+        if ( empty( $this->optScopes ) )
+        {
+            $cli->warning( "No scope(s) to purge provided, exiting..." );
+            return;
+        }
+
         if ( $this->optMemoryMonitoring == true )
         {
             eZLog::rotateLog( self::LOG_FILE );


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25156

If no `--scopes=` parameter is provided, exit with a warning instead of proceeding and failing silently with a SQL error ( `IN()` operator with an empty string ).
