### PR TITLE
Fix EZP-18202: Impossible to clear previously populated ISBN field

### DIFF
--- a/kernel/classes/datatypes/ezisbn/ezisbntype.php
+++ b/kernel/classes/datatypes/ezisbn/ezisbntype.php
@@ -224,6 +224,7 @@ class eZISBNType extends eZDataType
 
             if ( !$contentObjectAttribute->validateIsRequired() and ( !$number13 or $number13 == '' ) )
             {
+                $contentObjectAttribute->setAttribute( self::CONTENT_VALUE, '' );
                 return true;
             }
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-18202

#### Problem:
When clearing an isbn13 field that was already filled in (and the field is not required), saving will not actually clear the field / save the empty value.

This makes it so the empty value is actually saved.