### PR TITLE
Fix EZP-25058: md5 string comparision with "==" fails, if the strings…

### DIFF
--- a/kernel/classes/datatypes/ezuser/ezuser.php
+++ b/kernel/classes/datatypes/ezuser/ezuser.php
@@ -264,7 +264,7 @@ class eZUser extends eZPersistentObject
         $this->setAttribute( "email", $email );
         $this->setAttribute( "login", $login );
         if ( eZUser::validatePassword( $password ) and
-             $password == $passwordConfirm ) // Cannot change login or password_hash without login and password
+             $password === $passwordConfirm ) // Cannot change login or password_hash without login and password
         {
             $this->setAttribute( "password_hash", eZUser::createHash( $login, $password, eZUser::site(),
                                                                       eZUser::hashType() ) );

--- a/kernel/classes/ezcodetemplate.php
+++ b/kernel/classes/ezcodetemplate.php
@@ -311,7 +311,7 @@ class eZCodeTemplate
         {
             $originalMD5 = md5_file( $filePath );
             $updatedMD5 = md5_file( $tempFile );
-            if ( $originalMD5 == $updatedMD5 )
+            if ( $originalMD5 === $updatedMD5 )
             {
                 unlink( $tempFile );
                 return self::STATUS_NO_CHANGE;


### PR DESCRIPTION
… begin with "0e"

Link: https://jira.ez.no/browse/EZP-25058

## Description
With `==` some md5 strings are considered as float in the string comparison, see detailed info in the Jira.

## Test
Basic sanity on users.

