### PR TITLE
Fix EZP-25927 ezpgenerateautloads.php expects vendor folder in a place where is not

### DIFF
--- a/bin/php/ezpgenerateautoloads.php
+++ b/bin/php/ezpgenerateautoloads.php
@@ -18,7 +18,7 @@ if ( file_exists( "config.php" ) )
 //{
 $appName = defined( 'EZP_APP_FOLDER_NAME' ) ? EZP_APP_FOLDER_NAME : 'ezpublish';
 $appFolder = getcwd() . "/../$appName";
-$legacyVendorDir = getcwd() . "/vendor";
+$legacyVendorDir = getcwd() . "/../vendor";
 
 $baseEnabled = true;
 // Bundled


### PR DESCRIPTION
Fixes https://jira.ez.no/browse/EZP-25297

vendor and app/ezpublish folder are in the same level, so i think actually legacyVendorDir definition was wrong. 

ping @emodric @bdunogier @andrerom 