### PR TITLE
Fix for Issue EZP-25301

### DIFF
--- a/kernel/classes/ezcontentupload.php
+++ b/kernel/classes/ezcontentupload.php
@@ -246,7 +246,7 @@ class eZContentUpload
         // The handler will be responsible for the rest of the execution.
         if ( is_object( $handler ) )
         {
-            $originalFilename = $nameString ? $nameString : $filePath;
+            $originalFilename = $nameString != '' ? $nameString : $filePath;
             return $handler->handleFile( $this, $result,
                                          $filePath, $originalFilename, $mimeData,
                                          $location, $existingNode );

--- a/kernel/classes/ezcontentupload.php
+++ b/kernel/classes/ezcontentupload.php
@@ -246,7 +246,7 @@ class eZContentUpload
         // The handler will be responsible for the rest of the execution.
         if ( is_object( $handler ) )
         {
-            $originalFilename = $filePath;
+            $originalFilename = $nameString ? $nameString : $filePath;
             return $handler->handleFile( $this, $result,
                                          $filePath, $originalFilename, $mimeData,
                                          $location, $existingNode );


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-25301

With eZContentUpload you can use custom UploadHandler. eZContentUpload will then call the method 'handleFile' of your custom UploadHandler. One of the method parameters is the original file name "originalFilename". eZContentUpload is not sending the correct value for this parameter -- this PR is fixing it.