### PR TITLE
FIx wrong path creation in css pack

### DIFF
--- a/extension/ezjscore/classes/ezjscpacker.php
+++ b/extension/ezjscore/classes/ezjscpacker.php
@@ -515,7 +515,7 @@ class ezjscPacker
                        $newMatchPath .= implode( '/', $cssPathSlice ) . '/';
                    }
                    $newMatchPath .= str_replace( '../', '', $match );
-                   $fileContent = str_replace( $match, $newMatchPath, $fileContent );
+                   $fileContent = preg_replace( "/url\(\s*[\'|\"]?".preg_quote($match, '/')."[\'|\"]?\s*\)/", "url($newMatchPath)", $fileContent );
                }
            }
         }


### PR DESCRIPTION
If you have several files of one font, for ex.: `url(fonts/font.woff)` `url(fonts/font.woff2)`
It's pack to this:
```
url(/design/siteaccess/stylesheets/fonts/font.woff)
url(/design/siteaccess/stylesheets//design/siteaccess/stylesheets/fonts/font.woff2)
```

The commit fix this bug.