### PR TITLE
Fix EZP-25292: additional check for relationlist xml

### DIFF
--- a/update/common/scripts/5.4/cleanuntranslatablerelations.php
+++ b/update/common/scripts/5.4/cleanuntranslatablerelations.php
@@ -53,8 +53,15 @@ if ( $optDryRun ) {
  */
 function parseRelationListIds( $relationListXml )
 {
+    if ( empty( trim( $relationListXml ) ) )
+        return array();
+
     $xml = simplexml_load_string( $relationListXml );
     $list = $xml->{'relation-list'};
+
+    if ( !( $list instanceof SimpleXMLElement ) ) {
+        return array();
+    }
 
     $contentIds = array();
     foreach ( $list->children() as $item ) {


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25292

This adds an additional check for non-translatable relation(s) cleanup script in #1227

For cases where the `data_text` column of relationlist attribute is `null`, for whatever reason, the script would try to access a non-object when processing the relations xml.

Ref: `eZObjectRelationListType` @ https://github.com/ezsystems/ezpublish-legacy/blob/master/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php#L1415