### PR TITLE
 Fix EZP-25455: eZOracle: Link management doesn't show objects

### DIFF
--- a/kernel/classes/ezpersistentobject.php
+++ b/kernel/classes/ezpersistentobject.php
@@ -951,7 +951,7 @@ class eZPersistentObject
         if ( is_array( $rows ) )
         {
             $db = eZDB::instance();
-            foreach( $rows as $row )
+            foreach( $rows as &$row )
             {
                 self::replaceFieldsWithLongNames( $db, $objectDefinition['fields'], $row );
             }
@@ -962,7 +962,7 @@ class eZPersistentObject
             $objects = array();
             if ( is_array( $rows ) )
             {
-                foreach ( $rows as $row )
+                foreach ( $rows as &$row )
                 {
                     $objects[] = new $class_name( $row );
                 }


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-25455

Oracle uses short_names in ezPersistentObject to access DB field values.
The Bugfix ensures that the correct replacement of the attribute short_names with the longnames will be used
for objectcreation!
The first &$row is used for correct replacement and the second $row fixes an issue where rsults are correctly used for objeccreation
(otherwise e.g. worflow/grouplist was not shown correctly  3 groups but only 2 where displaxed one was overriden)