### PR TITLE
FIX EZP-25456 - ezp_legacy: eZPersistentObject $this->$def["functions"][$attr]();

### DIFF
--- a/kernel/classes/ezpersistentobject.php
+++ b/kernel/classes/ezpersistentobject.php
@@ -1339,7 +1339,7 @@ class eZPersistentObject
 
         if ( isset( $def["functions"][$attr] ) )
         {
-            return $this->$def["functions"][$attr]();
+            return $def["functions"][$attr]();
         }
 
         eZDebug::writeError( "Attribute '$attr' does not exist", $def['class_name'] . '::attribute' );


### PR DESCRIPTION
Bugfix in eZPersistentObject changing
$this->$def["functions"][$attr]();
 => 
$def["functions"][$attr]();