### PR TITLE
Refresh eZExpiryHandler instance after change siteaccess.

### DIFF
--- a/kernel/classes/ezsiteaccess.php
+++ b/kernel/classes/ezsiteaccess.php
@@ -552,6 +552,8 @@ class eZSiteAccess
             eZUpdateDebugSettings();
             eZDebugSetting::writeDebug( 'kernel-siteaccess', "Updated settings to use siteaccess '$name'", __METHOD__ );
         }
+        
+        eZExpiryHandler::refresh();
 
         return $access;
     }

--- a/lib/ezutils/classes/ezexpiryhandler.php
+++ b/lib/ezutils/classes/ezexpiryhandler.php
@@ -160,6 +160,15 @@ class eZExpiryHandler
 
         return $GLOBALS['eZExpiryHandlerInstance'];
     }
+    
+    static function refresh()
+    {
+        if ( isset( $GLOBALS['eZExpiryHandlerInstance'] ) )
+        {
+            unset( $GLOBALS['eZExpiryHandlerInstance'] );
+        }
+        return self::instance();
+    }
 
     /**
      * Checks if a shared instance of eZExpiryHandler exists


### PR DESCRIPTION
This pull requeste is needed in multisite-multidb installations. The expiry values are stored in each var dir, rather than globally where the values of the various db may conflict.