### PR TITLE
Change value's key of Sorting in the array of parameters to fix sorting with ezfind

### DIFF
--- a/kernel/content/ezcontentfunctioncollection.php
+++ b/kernel/content/ezcontentfunctioncollection.php
@@ -416,7 +416,7 @@ class eZContentFunctionCollection
         if ( $publishDate !== false )
             $parameters['SearchDate'] = $publishDate;
         if ( $sortArray !== false )
-            $parameters['SortArray'] = $sortArray;
+            $parameters['SortBy'] = $sortArray;
         $parameters['SearchLimit'] = $limit;
         $parameters['SearchOffset'] = $offset;
         $parameters['IgnoreVisibility'] = $ignoreVisibility;

--- a/kernel/setup/steps/ezstep_welcome.php
+++ b/kernel/setup/steps/ezstep_welcome.php
@@ -64,6 +64,11 @@ class eZStepWelcome extends eZStepInstaller
         $this->PersistenceList['tests_run'] = $testsRun;
         $this->PersistenceList['optional_tests_run'] = $testsRun;
 
+        if ( $this->hasKickstartData() )
+        {
+            return $this->kickstartContinueNextStep();
+        }
+
         return false; // Always show welcome message
     }
 


### PR DESCRIPTION
In eZ Publish 5, when we search content using that (from SF2 action) [ eZFunctionHandler::execute('content','search', array(...)) ] , I detect that currently we cannot search by sort parameter.

**Why ?**

Because in eZFind's extension on this file extension/ezfind/classes/ezfezpsolrquerybuilder.php at line [878 ](https://github.com/ezsystems/ezfind/blob/master/classes/ezfezpsolrquerybuilder.php#L878)exactly, this key is known by 'SortBy' and not by 'SortArray',  that's why search by sorting does not work. 

**Solution :**

I just changed the value's key of Sorting in the array of parameters and checked if there is some regressions.

**2nd Solution (if 1st is bad) :**

Change in the other side on this file extension/ezfind/classes/ezfezpsolrquerybuilder.php the value's key of sorting.