### PR TITLE
CSS Compressing was ignoring @2x image path

### DIFF
--- a/extension/ezjscore/classes/ezjscpacker.php
+++ b/extension/ezjscore/classes/ezjscpacker.php
@@ -493,7 +493,7 @@ class ezjscPacker
      */
     static function fixImgPaths( $fileContent, $file )
     {
-        if ( preg_match_all( "/url\(\s*[\'|\"]?([A-Za-z0-9_\-\/\.\\%?&#=]+)[\'|\"]?\s*\)/ix", $fileContent, $urlMatches ) )
+        if ( preg_match_all( "/url\(\s*[\'|\"]?([A-Za-z0-9_\-\/\.\\%?&@#=]+)[\'|\"]?\s*\)/ix", $fileContent, $urlMatches ) )
         {
            $urlMatches = array_unique( $urlMatches[1] );
            $cssPathArray   = explode( '/', $file );


### PR DESCRIPTION
image path like background-image: url('../images/sample@2x.png'); wasnt replaced during CSS Compressing
