### PR TITLE
EZP-25771: Add handler constructor existence verification to ezextension getHandler()

### DIFF
--- a/lib/ezutils/classes/ezextension.php
+++ b/lib/ezutils/classes/ezextension.php
@@ -544,10 +544,10 @@ class eZExtension
             // we rely on the autoload system here
             if ( class_exists( $handler ) )
             {
-                // only use reflection if we have params to avoid exception on objects withouth constructor
-                if ( $handlerParams !== null && is_array( $handlerParams ) && count( $handlerParams ) > 0 )
+                $reflection = new ReflectionClass( $handler );
+                // only pass parameters if the class has a constructor
+                if ( $reflection->getConstructor() !== null && $handlerParams !== null && is_array( $handlerParams ) && count( $handlerParams ) > 0 )
                 {
-                    $reflection = new ReflectionClass( $handler );
                     $object = $reflection->newInstanceArgs( $handlerParams );
                 }
                 else


### PR DESCRIPTION
JIRA: http://jira.ez.no/browse/EZP-25771

Then getHandlerClass method instantiates the handler using Reflector method newInstanceArgs() which causes an error is the class does not have a constructor.

This fixes the issue by calling Reflector method nweInstance() if the class does not have a constructor.