### PR TITLE
Fix EZP-26096: Custom tags' text line parameters not saved correctly

### DIFF
--- a/extension/ezoe/tests/ezoexmltext_regression.php
+++ b/extension/ezoe/tests/ezoexmltext_regression.php
@@ -27,16 +27,12 @@ class eZOEXMLTextRegression extends ezpDatabaseTestCase
     {
         return array(
             array(
-                '<div type="custom" class="ezoeItemCustomTag factbox" customattributes="title|This > is > a > fact > attribute_separationalign|right">
-    <p>This is a fact</p>
-</div>',
+                '<div type="custom" class="ezoeItemCustomTag factbox" customattributes="title|This > is > a > fact > attribute_separationalign|right"><p>This is a fact</p></div>',
                 '<?xml version="1.0" encoding="utf-8"?>
 <section xmlns:image="http://ez.no/namespaces/ezpublish3/image/" xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/" xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/"><paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/"><custom name="factbox" custom:title="This &gt; is &gt; a &gt; fact &gt; "><paragraph>This is a fact</paragraph></custom></paragraph></section>',
             ),
             array(
-                '<div type="custom" class="ezoeItemCustomTag factbox" customattributes="title|<a href=&quot;#test&quot;>Test</a>attribute_separationalign|right">
-    <p>This is a fact</p>
-</div>',
+                '<div type="custom" class="ezoeItemCustomTag factbox" customattributes="title|<a href=&quot;#test&quot;>Test</a>attribute_separationalign|right"><p>This is a fact</p></div>',
                 '<?xml version="1.0" encoding="utf-8"?>
 <section xmlns:image="http://ez.no/namespaces/ezpublish3/image/" xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/" xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/"><paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/"><custom name="factbox" custom:title="&lt;a href=&amp;quot;#test&amp;quot;&gt;Test&lt;/a&gt;"><paragraph>This is a fact</paragraph></custom></paragraph></section>',
             )

--- a/extension/ezoe/tests/ezoexmltext_regression.php
+++ b/extension/ezoe/tests/ezoexmltext_regression.php
@@ -10,6 +10,40 @@
 class eZOEXMLTextRegression extends ezpDatabaseTestCase
 {
     /**
+     * Test for EZP-26096
+     * @link https://jira.ez.no/browse/EZP-26096
+     * @dataProvider providerParsingGreaterThanAttribute
+     */
+    public function testParsingGreaterThanAttribute( $html, $expectedXml )
+    {
+        $parser = new eZOEInputParser();
+        $dom = $parser->process( $html );
+
+        self::assertInstanceOf( 'DomDocument', $dom );
+        self::assertEquals( $expectedXml, trim( $dom->saveXML() ) );
+    }
+
+    public function providerParsingGreaterThanAttribute()
+    {
+        return array(
+            array(
+                '<div type="custom" class="ezoeItemCustomTag factbox" customattributes="title|This > is > a > fact > attribute_separationalign|right">
+    <p>This is a fact</p>
+</div>',
+                '<?xml version="1.0" encoding="utf-8"?>
+<section xmlns:image="http://ez.no/namespaces/ezpublish3/image/" xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/" xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/"><paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/"><custom name="factbox" custom:title="This &gt; is &gt; a &gt; fact &gt; "><paragraph>This is a fact</paragraph></custom></paragraph></section>',
+            ),
+            array(
+                '<div type="custom" class="ezoeItemCustomTag factbox" customattributes="title|<a href=&quot;#test&quot;>Test</a>attribute_separationalign|right">
+    <p>This is a fact</p>
+</div>',
+                '<?xml version="1.0" encoding="utf-8"?>
+<section xmlns:image="http://ez.no/namespaces/ezpublish3/image/" xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/" xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/"><paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/"><custom name="factbox" custom:title="&lt;a href=&amp;quot;#test&amp;quot;&gt;Test&lt;/a&gt;"><paragraph>This is a fact</paragraph></custom></paragraph></section>',
+            )
+        );
+    }
+
+    /**
      * Test for issue #16605: Online Editor adds a lot of Non Breaking spaces (nbsp)
      * 
      * @link http://issues.ez.no/16605

--- a/kernel/classes/datatypes/ezxmltext/ezxmlinputparser.php
+++ b/kernel/classes/datatypes/ezxmltext/ezxmlinputparser.php
@@ -605,8 +605,7 @@ class eZXMLInputParser
         $tagCode = substr( $data, $tagBeginPos, $endPos - $tagBeginPos );
         if ( strpos( $tagCode, '=' ) === false )
         {
-            // this tag has not attribute, so the next '>' is the right one.
-            // attribute on this tag, the next '>' is the right one
+            // this tag has no attribute, so the next '>' is the right one.
             return $endPos;
         }
         if ( $this->isValidXmlTag( $tagCode ) )


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26096

# Description

This patch fixes an issue in ezxmltext input parser which breaks when an attribute contains a `>`. Basically, to correctly detect an opening tag it's not enough to search for the next `>` after a `<` because the next `>` can be inside an attribute.

# Tests

manual + unit tests