### PR TITLE
Fix EZP-26108: Typing right after adding a block custom tag breaks the contents

### DIFF
--- a/extension/ezoe/design/standard/javascript/ezoe/popup_utils.js
+++ b/extension/ezoe/design/standard/javascript/ezoe/popup_utils.js
@@ -270,8 +270,6 @@ var eZOEPopupUtils = {
 
             if ( 'TABLE'.indexOf( s.editorElement.tagName ) === 0 )
                 ed.selection.select( jQuery( s.editorElement ).find( "tr:first-child > *:first-child" ).get(0), true );
-            else if ( 'DIV'.indexOf( s.editorElement.tagName ) === 0 )
-                ed.selection.select( s.editorElement );
             else
                 ed.selection.select( s.editorElement, true );
             ed.nodeChanged();


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26108

# Description

Before this patch, if you type something right after adding a block custom tag, the content of the ezxmltext attribute is messed up. For instance, in Chrome, the following paragraph is added to the custom tag content, in Firefox, the custom tag is completely removed. This is happening because the newly added custom tag was completely selected, with the patch only its content is selected.

# Tests

manual tests