### PR TITLE
Fix EZP-19376: ezjscore CSS packer duplicate url path replacement

### DIFF
--- a/extension/ezjscore/classes/ezjscpacker.php
+++ b/extension/ezjscore/classes/ezjscpacker.php
@@ -495,6 +495,7 @@ class ezjscPacker
     {
         if ( preg_match_all( "/url\(\s*[\'|\"]?([A-Za-z0-9_\-\/\.\\%?&#=]+)[\'|\"]?\s*\)/ix", $fileContent, $urlMatches ) )
         {
+           $urlPaths = array();
            $urlMatches = array_unique( $urlMatches[1] );
            $cssPathArray   = explode( '/', $file );
            $wwwDir = self::getWwwDir();
@@ -515,9 +516,10 @@ class ezjscPacker
                        $newMatchPath .= implode( '/', $cssPathSlice ) . '/';
                    }
                    $newMatchPath .= str_replace( '../', '', $match );
-                   $fileContent = str_replace( $match, $newMatchPath, $fileContent );
+                   $urlPaths[$match] = $newMatchPath;
                }
            }
+           $fileContent = strtr( $fileContent, $urlPaths );
         }
         return $fileContent;
     }


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-19376

This makes sure that urls in CSS are not replaced with paths "recursively", see original description:

> When a file contained this kind of url :
> ```
>   src: url("fonts/HelveticaNeue55-Roman.eot");
>   src: url("fonts/HelveticaNeue55-Roman.eot?#iefix") format("embedded-opentype");
> ```
> we had these lines in return :
> ```
>   src: url("/extension/my_extension/design/my_design/fonts/HelveticaNeue55-Roman.eot");
>   src: url("/extension/my_extension/design/my_design//extension/my_extension/design/my_design/fonts/HelveticaNeue55-Roman.eot?#iefix");
> ```


Alternative for https://github.com/ezsystems/ezpublish-legacy/pull/1163 , which addresses the complexity of the initially proposed fix.
