### PR TITLE
Fix EZP-26168: User profile edits break change password 

### DIFF
--- a/kernel/classes/datatypes/ezuser/ezusertype.php
+++ b/kernel/classes/datatypes/ezuser/ezusertype.php
@@ -275,6 +275,10 @@ class eZUserType extends eZDataType
         {
             $user = $this->updateUserDraft( $user, $serializedDraft );
         }
+        // clear the serialized draft, otherwise it will override the new password hashes
+        // from a change or forgot password action upon a new profile/user object versions
+        $contentObjectAttribute->setAttribute('data_text', '');
+        $contentObjectAttribute->storeData();
 
         $user->store();
         $contentObjectAttribute->setContent( $user );


### PR DESCRIPTION
... and forgot password functionality

See also https://jira.ez.no/browse/EZP-26168

To correct existing records, the contentobject_attribute table needs to be cleared for historical draft data in the data_text column for published objects, for example:

1) View those affected records:
```
SELECT ezco.id, ezcoa.data_text FROM ezcontentobject ezco, ezcontentobject_attribute ezcoa 
WHERE ezco.id=ezcoa.contentobject_id
 AND ezcoa.data_text <> '' 
 AND ezcoa.data_type_string = 'ezuser' and ezco.status=1;
```
2) Clear affected records
```
UPDATE ezcontentobject ezco, ezcontentobject_attribute ezcoa SET ezcoa.data_text='' 
WHERE ezco.id=ezcoa.contentobject_id 
 AND ezcoa.data_text <> '' 
 AND ezcoa.data_type_string = 'ezuser' and ezco.status=1;
```