### PR TITLE
Fix EZP-26171: ezoe php7

### DIFF
--- a/extension/ezoe/ezxmltext/handlers/input/ezoexmlinput.php
+++ b/extension/ezoe/ezxmltext/handlers/input/ezoexmlinput.php
@@ -46,7 +46,7 @@ class eZOEXMLInput extends eZXMLInputHandler
      * @param string $aliasedType
      * @param eZContentObjectAttribute $contentObjectAttribute
      */
-    function eZOEXMLInput( &$xmlData, $aliasedType, $contentObjectAttribute )
+    function eZOEXMLInput( $xmlData, $aliasedType, $contentObjectAttribute )
     {
         $this->eZXMLInputHandler( $xmlData, $aliasedType, $contentObjectAttribute );
 


### PR DESCRIPTION
ezoe breaks under php7 due to the constructor using a reference.