### PR TITLE
Fix EZP-25089: Add ezpEvent on object state assignment

### DIFF
--- a/doc/features/5.4/event.txt
+++ b/doc/features/5.4/event.txt
@@ -2,6 +2,7 @@ Event system
 ============
 
 - Added new events for image aliases removal
+- 5.4.6 Added new events for state assigments
 
 New events
 ----------
@@ -10,3 +11,6 @@ image/invalidateAliases
 image/removeAliases ( $originalAliasURI )
 image/purgeAliases ( $originalAliasURI )
 image/trashAliases ( $originalAliasURI )
+
+
+content/state/assign ( $objectID, $selectedStateIDList )

--- a/kernel/content/ezcontentoperationcollection.php
+++ b/kernel/content/ezcontentoperationcollection.php
@@ -1376,6 +1376,9 @@ class eZContentOperationCollection
         //call appropriate method from search engine
         eZSearch::updateObjectState($objectID, $selectedStateIDList);
 
+        // Triggering content/state/assign event for persistence cache purge
+        ezpEvent::getInstance()->notify( 'content/state/assign', array( $objectID, $selectedStateIDList ) );
+
         eZContentCacheManager::clearContentCacheIfNeeded( $objectID );
 
         return array( 'status' => true );


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-25089

Before this patch, you would end up in a scenario where an object state was changed from being not available to available but the front-end would crash with an error related to the old state.

Needs to be combined with https://github.com/ezsystems/LegacyBridge/pull/61