### PR TITLE
Port of EZP-25089 (object state) & EZP-26028 (ezoe php7 support)

### DIFF
--- a/doc/bc/5.4/changes-5.4.txt
+++ b/doc/bc/5.4/changes-5.4.txt
@@ -16,6 +16,10 @@ Change of behavior
   Note: To avoid that you have to many cache blocks take advantage of putting identical once in
   own template so they will share cache (template and location of block is part of internal unique key).
 
+- EZP-26028: Unable to use Online Editor when using PHP7
+
+  To fix this issue, first parameter of all XML input and output handlers, `$xmlData` can not be a reference anymore.
+
 
 Removed features
 ----------------

--- a/doc/features/5.4/event.txt
+++ b/doc/features/5.4/event.txt
@@ -2,6 +2,7 @@ Event system
 ============
 
 - Added new events for image aliases removal
+- 5.4.6 Added new events for state assigments
 
 New events
 ----------
@@ -10,3 +11,6 @@ image/invalidateAliases
 image/removeAliases ( $originalAliasURI )
 image/purgeAliases ( $originalAliasURI )
 image/trashAliases ( $originalAliasURI )
+
+
+content/state/assign ( $objectID, $selectedStateIDList )

--- a/extension/ezoe/ezxmltext/handlers/input/ezoexmlinput.php
+++ b/extension/ezoe/ezxmltext/handlers/input/ezoexmlinput.php
@@ -46,7 +46,7 @@ class eZOEXMLInput extends eZXMLInputHandler
      * @param string $aliasedType
      * @param eZContentObjectAttribute $contentObjectAttribute
      */
-    function eZOEXMLInput( &$xmlData, $aliasedType, $contentObjectAttribute )
+    function eZOEXMLInput( $xmlData, $aliasedType, $contentObjectAttribute )
     {
         $this->eZXMLInputHandler( $xmlData, $aliasedType, $contentObjectAttribute );
 

--- a/kernel/classes/datatypes/ezxmltext/handlers/input/ezsimplifiedxmlinput.php
+++ b/kernel/classes/datatypes/ezxmltext/handlers/input/ezsimplifiedxmlinput.php
@@ -10,7 +10,7 @@
 
 class eZSimplifiedXMLInput extends eZXMLInputHandler
 {
-    function eZSimplifiedXMLInput( &$xmlData, $aliasedType, $contentObjectAttribute )
+    function eZSimplifiedXMLInput( $xmlData, $aliasedType, $contentObjectAttribute )
     {
         $this->eZXMLInputHandler( $xmlData, $aliasedType, $contentObjectAttribute );
 

--- a/kernel/classes/datatypes/ezxmltext/handlers/output/ezpdfxmloutput.php
+++ b/kernel/classes/datatypes/ezxmltext/handlers/output/ezpdfxmloutput.php
@@ -11,7 +11,7 @@
 class eZPDFXMLOutput extends eZXHTMLXMLOutput
 {
 
-    function eZPDFXMLOutput( &$xmlData, $aliasedType, $contentObjectAttribute = null )
+    function eZPDFXMLOutput( $xmlData, $aliasedType, $contentObjectAttribute = null )
     {
         $this->eZXHTMLXMLOutput( $xmlData, $aliasedType, $contentObjectAttribute );
 

--- a/kernel/classes/datatypes/ezxmltext/handlers/output/ezplainxmloutput.php
+++ b/kernel/classes/datatypes/ezxmltext/handlers/output/ezplainxmloutput.php
@@ -10,7 +10,7 @@
 
 class eZPlainXMLOutput extends eZXMLOutputHandler
 {
-    function eZPlainXMLOutput( &$xmlData, $aliasedType )
+    function eZPlainXMLOutput( $xmlData, $aliasedType )
     {
         $this->eZXMLOutputHandler( $xmlData, $aliasedType );
     }

--- a/kernel/classes/datatypes/ezxmltext/handlers/output/ezxhtmlxmloutput.php
+++ b/kernel/classes/datatypes/ezxmltext/handlers/output/ezxhtmlxmloutput.php
@@ -125,7 +125,7 @@ class eZXHTMLXMLOutput extends eZXMLOutputHandler
                              'renderHandler' => 'renderText' )
     );
 
-    function eZXHTMLXMLOutput( &$xmlData, $aliasedType, $contentObjectAttribute = null )
+    function eZXHTMLXMLOutput( $xmlData, $aliasedType, $contentObjectAttribute = null )
     {
         $this->eZXMLOutputHandler( $xmlData, $aliasedType, $contentObjectAttribute );
 

--- a/kernel/content/ezcontentoperationcollection.php
+++ b/kernel/content/ezcontentoperationcollection.php
@@ -1376,6 +1376,9 @@ class eZContentOperationCollection
         //call appropriate method from search engine
         eZSearch::updateObjectState($objectID, $selectedStateIDList);
 
+        // Triggering content/state/assign event for persistence cache purge
+        ezpEvent::getInstance()->notify( 'content/state/assign', array( $objectID, $selectedStateIDList ) );
+
         eZContentCacheManager::clearContentCacheIfNeeded( $objectID );
 
         return array( 'status' => true );


### PR DESCRIPTION
Ports:
- EZP-26028: Unable to use Online Editor when using PHP7
- EZP-25089: Object state changes/assignments does not clear persistence cache in platform stack

Closes #1257, #1255, #1254