### PR TITLE
EZP-26276: Exclamation mark followed by non-chars at end of URL does not work in emails

### DIFF
--- a/lib/ezi18n/classes/ezchartransform.php
+++ b/lib/ezi18n/classes/ezchartransform.php
@@ -395,12 +395,10 @@ class eZCharTransform
         $sep  = eZCharTransform::wordSeparator();
         $sepQ = preg_quote( $sep );
         $text = preg_replace( array( "#[^a-zA-Z0-9_!\.-]+#",
-                                     "#^[\.]+|[!\.]+$#", # Remove dots at beginning/end
                                      "#\.\.+#", # Remove double dots
                                      "#[{$sepQ}]+#", # Turn multiple separators into one
-                                     "#^[{$sepQ}]+|[{$sepQ}]+$#" ), # Strip separator from beginning/end
+                                     "#^[\.{$sepQ}]+|[!\.{$sepQ}]+$#" ), # Strip "!", dots and separator from beginning/end
                               array( $sep,
-                                     $sep,
                                      $sep,
                                      $sep,
                                      "" ),
@@ -423,12 +421,10 @@ class eZCharTransform
         if ( $sep != "-" )
             $prepost .= "-";
         $text = preg_replace( array( "#[ \t\\\\%\#&;/:=?\[\]()+]+#",
-                                     "#^[\.]+|[!\.]+$#", # Remove dots at beginning/end
                                      "#\.\.+#", # Remove double dots
                                      "#[{$sepQ}]+#", # Turn multiple separators into one
-                                     "#^[{$prepost}]+|[{$prepost}]+$#" ),
+                                     "#^[{$prepost}]+|[!{$prepost}]+$#" ), # Strip "!", dots and separator from beginning/end
                               array( $sep,
-                                     $sep,
                                      $sep,
                                      $sep,
                                      "" ),


### PR DESCRIPTION
Fix for https://jira.ez.no/browse/EZP-14719 (old zombie issue)
https://jira.ez.no/browse/EZP-26276 (new incarnation)

`This is "My Article!"` becomes `This-is-My-Article!`. The exclamation mark should not be there.