### PR TITLE
Fix EZP-26300: Fatal error when going through defaultExceptionHandler with PHP7

### DIFF
--- a/lib/ezutils/classes/ezexecution.php
+++ b/lib/ezutils/classes/ezexecution.php
@@ -177,7 +177,7 @@ class eZExecution
      * @params Exception the exception
      * @return void
      */
-    static public function defaultExceptionHandler( Exception $e )
+    static public function defaultExceptionHandler( $e )
     {
         if( PHP_SAPI != 'cli' )
         {

--- a/lib/ezutils/classes/ezexecution.php
+++ b/lib/ezutils/classes/ezexecution.php
@@ -174,7 +174,7 @@ class eZExecution
     /**
      * Installs the default Exception handler
      *
-     * @params Exception the exception
+     * @params Exception|Throwable the exception
      * @return void
      */
     static public function defaultExceptionHandler( $e )


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-26300

With PHP 7, exception handlers can now receive `Error` exceptions. Those exceptions are internal to PHP and are not directly linked to `Exception` class, except that they both implement `Throwable` interface, which is present in PHP 7 only.

This patch just removes `Exception` type hint in `eZExecution::defaultExceptionHandler()` in order to avoid fatal errors when receiving the new `Error` exceptions.