### PR TITLE
Fix EZP-26449: Wrong version translation list in eZContentOperationCollection

### DIFF
--- a/kernel/content/ezcontentoperationcollection.php
+++ b/kernel/content/ezcontentoperationcollection.php
@@ -651,18 +651,18 @@ class eZContentOperationCollection
         $publishedLanguageCodes = array_keys( $publishedLanguages );
 
         $version = $object->version( $versionNum );
-        $versionTranslationList = $version->translationList( false, false );
+        $versionTranslationList = array_keys( eZContentLanguage::languagesByMask( $version->attribute( 'language_mask' ) ) );
 
         foreach ( $publishedVersionTranslations as $translation )
         {
-            if ( in_array( $translation->attribute( 'language_code' ), $versionTranslationList )
-              || !in_array( $translation->attribute( 'language_code' ), $publishedLanguageCodes ) )
+            $translationLanguageCode = $translation->attribute( 'language_code' );
+            if ( in_array( $translationLanguageCode, $versionTranslationList )
+                || !in_array( $translationLanguageCode, $publishedLanguageCodes ) )
             {
                 continue;
             }
 
-            $contentObjectAttributes = $translation->objectAttributes();
-            foreach ( $contentObjectAttributes as $attribute )
+            foreach ( $translation->objectAttributes() as $attribute )
             {
                 $clonedAttribute = $attribute->cloneContentObjectAttribute( $versionNum, $publishedVersionNum, $objectID );
                 $clonedAttribute->sync();


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-26449

When publishing a content from legacy (e.g. from admin interface), `content/publish` operation copies missing translations on the published version.
However, `eZContentOperationCollection::copyTranslations()` ignores the version language mask when retrieving the translation list for the version to publish, using `$version->translationList( false, false )`. While this is usually fine as a translation is generally a full bunch of translated attributes, this can lead to unexpected behavior, especially when using a mix of legacy and platform scripts.

Typical example is when using a _wait until date_ workflow (legacy admin/kernel), combined with several scripts from Symfony stack, like migration scripts for example:
- Webmaster publishes from admin interface with a publication date set in the future. Content has several translations.
- DevOps deliver a new version of code with migration scripts to update ContentTypes, including the one used by the webmaster, to add 1 new field
- Workflow cronjob is run to publish content from webmaster

The result here will be:
- Translation published by the webmaster will be OK
- All other translations will be broken, only having the new field.

This is due to `$version->translationList( false, false )` used in `eZContentOperationCollection::copyTranslations`, called by the workflow cronjob. This method will list all available translations for given version, by calling a `SELECT DISTINCT language_code FROM ezcontentobject_attribute`. As we added a new field using the public API, all translations are taken into account, instead of only published language.

Use `language_mask` from version instead of `$version->translationList()`.
