### PR TITLE
Fix EZP-26501: In-edit Locations window (legacy) should not force "Visible" flag

### DIFF
--- a/design/admin/templates/content/edit_locations.tpl
+++ b/design/admin/templates/content/edit_locations.tpl
@@ -135,9 +135,8 @@
     {* Visibility status after publishing. *}
     <td>
     <select {if $location_ui_enabled|not}disabled="disabled" {/if}name="FutureNodeHiddenState_{$Node:parent_node.node_id}">
-    <option value="unchanged">{'Unchanged'|i18n( 'design/admin/content/edit' )}</option>
-    <option value="visible"{if $Node:item.is_hidden|not} selected="selected"{/if}>{'Visible'|i18n( 'design/admin/content/edit' )}</option>
-    <option value="hidden"{if $Node:item.is_hidden} selected="selected"{/if}>{'Hidden'|i18n( 'design/admin/content/edit' )}</option>
+    <option value="unchanged"{if or( is_set( $Node:item.node ), and( $Node:item.is_hidden|not(), $Node:item.parent_node_obj.is_invisible|not() ) )} selected="selected"{/if}>{'Unchanged'|i18n( 'design/admin/content/edit' )}</option>
+    {if is_unset( $Node:item.node )}<option value="hidden"{if or( $Node:item.is_hidden, and( is_set( $Node:item.node ), $Node:item.node.is_hidden ) )} selected="selected"{/if}>{'Hidden'|i18n( 'design/admin/content/edit' )}</option>{/if}
     </select>
     </td>
 


### PR DESCRIPTION
Work done to address https://jira.ez.no/browse/EZP-22260 also included this specific commit, whose goal was to save the user's selection of the "hidden flag" toggle in the Locations window in edit mode:

https://github.com/ezsystems/ezpublish-legacy/commit/c3e8ff555964b165bf4b0872baa9014818086a59

However, that commit caused the following:

* "Visible" is the new default in the Locations window, not "Unchanged"
* "Visible" overrides any hide effort of a workflow
* Selecting "Unchanged" as a user and then saving the draft actually saves the selection as "Visible"

Given that:
* The Locations window in edit mode is only enabled for first drafts. (Ref: http://share.ez.no/learn/ez-publish/node-visibility-hiding-and-revealing-content/(page)/4#eztoc2634_0_4)
* A node's hidden flag is technically only hidden or not. (Hidden by superior is derived from the parent.)
* By default a node's hidden flag is "off".
* The use of the Locations window in edit mode is only for hiding the node; otherwise its hidden flag is technically "unchanged".
* The effects of the Locations window in edit mode are applied after the content/publish/after trigger.
* The effects of the Locations window can thus unexpectedly override a content/publish/after workflow if "Visible" is selected.

This is technically true:
* The "Visible" option is never valid (or at least not a more accurate description than "Unchanged"). Thus it should not be used.

=== How to test this fix ===

First, enable the Locations window: Select "on" for "Locations" under the "User preferences" panel in the right sidebar. Then test the following scenarios:

* Create a new draft. "Visibility after publishing" should give you the options of "Unchanged" or "Hidden". "Unchanged" should be default.
* Store the draft with "Unchanged" as the selection. Note that the selection is kept.
* Store the draft with "Hidden" as the selection. Note that the selection is kept.
* Edit an existing object. The selection should always show as "Unchanged".