### PR TITLE
EZP-26209 Textline legacy search indexing causes TransactionError

### DIFF
--- a/kernel/search/plugins/ezsearchengine/ezsearchengine.php
+++ b/kernel/search/plugins/ezsearchengine/ezsearchengine.php
@@ -96,7 +96,11 @@ class eZSearchEngine implements ezpSearchEngine
                     // Split text on whitespace
                     if ( is_numeric( trim( $text ) ) )
                     {
-                        $integerValue = (int) $text;
+                        //verify if value does not exceed MySQL int(11) unsigned maximum value
+                        if( (int)$text > (int)2147483647 )
+                            $integerValue = 0;
+                        else
+                            $integerValue = (int) $text;                      
                     }
                     else
                     {


### PR DESCRIPTION
Causes SQL error: #1264 - Out of range value for column 'integer_value' at row 1
@integerValue generation the value needs to be verified against MySQL's max int value.