### PR TITLE
EZP-26680 INI Cache files are generated with wrong filepaths

### DIFF
--- a/lib/ezutils/classes/ezini.php
+++ b/lib/ezutils/classes/ezini.php
@@ -482,26 +482,26 @@ class eZINI
                  else
                     $overrideFile = eZDir::path( array( $rootDir, $overrideDir, $fileName ) );
 
-                if ( file_exists( $overrideFile . '.php' ) )
+                if ( file_exists( __DIR__ . '/../../../' . $overrideFile . '.php' ) )
                 {
                     // recursion eZDebug::writeStrict( "INI files with *.ini.php suffix is DEPRECATED, use *.ini or *.ini.append.php instead: $overrideFile.php", __METHOD__ );
-                    $inputFiles[] = $overrideFile . '.php';
+                    $inputFiles[] = __DIR__ . '/../../../' . $overrideFile . '.php';
                 }
 
-                if ( file_exists( $overrideFile ) )
+                if ( file_exists( __DIR__ . '/../../../' . $overrideFile ) )
                 {
-                    $inputFiles[] = $overrideFile;
+                    $inputFiles[] = __DIR__ . '/../../../' . $overrideFile;
                 }
 
-                if ( file_exists( $overrideFile . '.append.php' ) )
+                if ( file_exists( __DIR__ . '/../../../' . $overrideFile . '.append.php' ) )
                 {
-                    $inputFiles[] = $overrideFile . '.append.php';
+                    $inputFiles[] = __DIR__ . '/../../../' . $overrideFile . '.append.php';
                 }
 
-                if ( file_exists( $overrideFile . '.append' ) )
+                if ( file_exists( __DIR__ . '/../../../' . $overrideFile . '.append' ) )
                 {
                     // recursion eZDebug::writeStrict( "INI files with *.ini.append suffix is DEPRECATED, use *.ini or *.ini.append.php instead: $overrideFile.append", __METHOD__ );
-                    $inputFiles[] = $overrideFile . '.append';
+                    $inputFiles[] = __DIR__ . '/../../../' . $overrideFile . '.append';
                 }
             }
         }


### PR DESCRIPTION
When publicAPI calls are executed via Symfony controller and for example a user is created via UserService, this Signal is triggered into legacy System cache management.

The eZINI::instance() is called inside user datatype which checks site.ini cache file. In the cache file are relative paths to override ini files which do not work because application is in Symfony context (and not cwd in legacy).

The override file is not found via file_exists() and the new generated cachefile is w/o override files cached, which "destroys" legacy application.