### PR TITLE
EZP-15983 - Only include ezp_override when present

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -120,7 +120,8 @@ if ( !class_exists( 'ezpAutoloader', false ) )
                 {
                     // won't work, as eZDebug isn't initialized yet at that time
                     // eZDebug::writeError( "Kernel override is enabled, but var/autoload/ezp_override.php has not been generated\nUse bin/php/ezpgenerateautoloads.php -o", 'autoload.php' );
-                    if ( $ezpKernelOverrideClasses = include __DIR__ . '/var/autoload/ezp_override.php' )
+                    $ezpKernelOverridePath = __DIR__ . '/var/autoload/ezp_override.php';
+                    if ( file_exists( $ezpKernelOverridePath ) && $ezpKernelOverrideClasses = include $ezpKernelOverridePath )
                     {
                         self::$ezpClasses = array_merge( self::$ezpClasses, $ezpKernelOverrideClasses );
                     }


### PR DESCRIPTION
When generating autoloads on a fresh ezpublish-legacy install through Symfony, the missing file raises a notice which is caught by the Symfony exception handler - This means that the autoloads can't be generated through Symfony, unless they have previously been generated by legacy.

This change is trivial and mitigates the issue.

Duplicate/response to https://jira.ez.no/browse/EZP-15983 - Please don't hate me for using a file_exists @bdunogier!