### PR TITLE
Fix sticky object relations

### DIFF
--- a/kernel/classes/ezcontentobjectattribute.php
+++ b/kernel/classes/ezcontentobjectattribute.php
@@ -178,6 +178,14 @@ class eZContentObjectAttribute extends eZPersistentObject
         }
     }
 
+    /**
+     * @param $classAttributeID
+     * @param $objectID
+     * @param $version
+     * @param $languageID
+     * @param bool $asObject
+     * @return eZContentObjectAttribute
+     */
     static function fetchByClassAttributeID( $classAttributeID, $objectID, $version, $languageID, $asObject = true )
     {
         return eZPersistentObject::fetchObject( eZContentObjectAttribute::definition(),
@@ -395,6 +403,9 @@ class eZContentObjectAttribute extends eZPersistentObject
                                                 $asObject );
     }
 
+    /**
+     * @return eZContentObject|null
+     */
     function object()
     {
         if( isset( $this->ContentObjectID ) and $this->ContentObjectID )
@@ -404,6 +415,9 @@ class eZContentObjectAttribute extends eZPersistentObject
         return null;
     }
 
+    /**
+     * @return eZContentObjectVersion
+     */
     function objectVersion()
     {
         return eZContentObjectVersion::fetchVersion( $this->Version, $this->ContentObjectID );


### PR DESCRIPTION
This pull request was developed here:
https://github.com/mugoweb/ezpublish-legacy/pull/31

A previous pull request introduced an issue with the object relation list. I repost the steps to reproduce the issue here. More details are on the link above:

== TESTING INSTRUCTIONS ==

1) Create a node that has a objectrelationslist attribute.
2) Add an object relation in that attribute
3) Publish the node
4) Confirm that the relation is listed on the relation tab
5) Edit the newly created node
6) Remove the object relation you previously created
7) Publish the node
8) Confirm that the relation is not listed on the relation tab

Without this pull request, you would still see the object relation listed in the relation tab.