### PR TITLE
eZCharTransform::commandUrlCleanupIRI replaces double quotes

### DIFF
--- a/lib/ezi18n/classes/ezchartransform.php
+++ b/lib/ezi18n/classes/ezchartransform.php
@@ -410,7 +410,7 @@ class eZCharTransform
     {
         // With IRI support we keep all characters except some reserved ones,
         // they are space, tab, ampersand, semi-colon, forward slash, colon, equal sign, question mark,
-        //          square brackets, parenthesis, plus.
+        //          square brackets, parenthesis, plus, double quotes.
         //
         // Note: Spaces and tabs are turned into a dash to make it easier for people to
         //       paste urls from the system and have the whole url recognized
@@ -420,7 +420,7 @@ class eZCharTransform
         $prepost = " ." . $sepQ;
         if ( $sep != "-" )
             $prepost .= "-";
-        $text = preg_replace( array( "#[ \t\\\\%\#&;/:=?\[\]()+]+#",
+        $text = preg_replace( array( "#[ \t\\\\%\#&;/:=?\[\]()+\"]+#",
                                      "#\.\.+#", # Remove double dots
                                      "#[{$sepQ}]+#", # Turn multiple separators into one
                                      "#^[{$prepost}]+|[!{$prepost}]+$#" ), # Strip "!", dots and separator from beginning/end


### PR DESCRIPTION
This bug came up in a client project. I'm pretty sure we want to replace double quotes in that function.