### PR TITLE
Unit test db setup

### DIFF
--- a/tests/toolkit/ezpdatabasesuite.php
+++ b/tests/toolkit/ezpdatabasesuite.php
@@ -37,10 +37,15 @@ class ezpDatabaseTestSuite extends ezpTestSuite
      */
     protected static $isDatabaseSetup = false;
 
+    protected function setUp()
+    {
+        $this->setDatabaseEnv();
+    }
+
     /**
      * Sets up the database environment
      */
-    protected function setUp()
+    protected function setDatabaseEnv()
     {
         if ( !ezpTestRunner::dbPerTest() && !self::$isDatabaseSetup )
         {
@@ -60,4 +65,5 @@ class ezpDatabaseTestSuite extends ezpTestSuite
         }
     }
 }
+
 ?>


### PR DESCRIPTION
ezpDatabaseTestSuite is the parent class for a lot of test classes that need a DB connection. In the setUp(), it is setting the DB environment. This patch is simply moving that logic into a dedicated PHP function setDatabaseEnv(). In setUp() it's just calling the function - so basically no changes in the logic, just the code organisation changed.

Why is that even worth doing?

Normally, you can write a single test in a single test function. But you can also use PHPUnit Data Providers - it's splitting the test into 2 functions:
https://phpunit.de/manual/current/en/writing-tests-for-phpunit.html#writing-tests-for-phpunit.data-providers

The unit test in the ezfind extension are using that approach. There is a problem with the order of how the PHPUnit framework calls the functions:

1. Calls provider function
2. Calls setUp()
3. Calls test functions

Because of that order we don't have a valid DB connection when the provider functions are getting executed. The missing DB connection causes those provider function to throw a deprecated error - it's not a big deal, but it would be much cleaner if the provider functions would have a valid DB connection. The error message:

PHP Deprecated: mysql_escape_string(): This function is deprecated; use mysql_real_escape_string() instead. in /var/www/ezp/lib/ezdb/classes/ezmysqlidb.php on line 844

With this patch, we can implement a simple solution for the ezfind unit tests. I can the setDatabaseEnv() in the constructor method of the test and not wait for setUp() function. That way I already have a valid DB connection when the provider functions are getting executed.