### PR TITLE
Fix EZP-26832: Enabling editor causes error on links with "&"

### DIFF
--- a/kernel/classes/datatypes/ezxmltext/ezxmlinputparser.php
+++ b/kernel/classes/datatypes/ezxmltext/ezxmlinputparser.php
@@ -629,7 +629,11 @@ class eZXMLInputParser
             $code .= '/';
         }
         $code .= '>';
-        $code = '<' . str_replace( '<', '&lt;', substr( $code, 1 ) );
+        $code = '<' . str_replace(
+            array( '<', '&' ),
+            array( '&lt;', '&amp;' ),
+            substr( $code, 1 )
+        );
         $errorHanding = libxml_use_internal_errors( true );
         $simpleXml = simplexml_load_string( $code );
         libxml_use_internal_errors( $errorHanding );

--- a/tests/tests/kernel/datatypes/ezxmltext/handlers/input/ezsimplifiedxmlinputparser_regression.php
+++ b/tests/tests/kernel/datatypes/ezxmltext/handlers/input/ezsimplifiedxmlinputparser_regression.php
@@ -105,4 +105,23 @@ Right Thoughts, Right Words, Right Action</header>';
         self::assertEquals( 1, $header->length );
         self::assertEquals( "Franz Ferdinand - Love Illumination", $header->item( 0 )->textContent );
     }
+
+    /**
+     * Test for EZP-26832
+     *
+     * & might not be escaped but the user typing some simplified XML and before
+     * the fix for EZP-26832, this broke the XML parsing.
+     *
+     * @link https://jira.ez.no/browse/EZP-26832
+     */
+    public function testParseAttributeWithAmpersand()
+    {
+        $parser = new eZSimplifiedXMLInputParser(0, eZXMLInputParser::ERROR_SYNTAX);
+        $this->assertNotEquals(
+            false,
+            $parser->process(
+                '<link href="http://google.com/?this=that&something=nothing">link</link>'
+            )
+        );
+    }
 }


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26832

# Description

This patch fixes a regression caused by https://github.com/ezsystems/ezpublish-legacy/pull/1249 where the eZSimplifiedXMLInputParser does not accept URL with non XML encoded ampersand (so containing `&` instead of `&amp;`)

# Tests

manual tests + unit test