### PR TITLE
Enable/disable the generation of the "Content-Length" response header

### DIFF
--- a/kernel/private/classes/ezpkernelweb.php
+++ b/kernel/private/classes/ezpkernelweb.php
@@ -582,6 +582,11 @@ class ezpKernelWeb implements ezpWebBasedKernelHandler
         eZDisplayResult( $templateResult );
         $content .= ob_get_clean();
 
+        if( $ini->variable( 'HTTPHeaderSettings', 'SetContentLengthHeader' ) == 'enabled' )
+        {
+            header( 'Content-Length: '. strlen( $content ) );
+        }
+
         $this->shutdown();
 
         return new ezpKernelResult( $content, array( 'module_result' => $moduleResult ) );

--- a/settings/site.ini
+++ b/settings/site.ini
@@ -1469,6 +1469,9 @@ ModuleViewAccessMode[layout/*]=keep
 
 
 [HTTPHeaderSettings]
+# Enable/disable the generation of the 'Content-Length' response header
+SetContentLengthHeader=disabled
+
 # Enable/disable custom HTTP header data.
 CustomHeader=disabled
 


### PR DESCRIPTION
Allows to have ezp sending the Content-Length header - controlled by a setting.
With the Content-Length header, it is possible to enable compression (gzip) for CloudFront - compare:

http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/ServingCompressedFiles.html

I'm not sure if there are any downsides to send the Content-Length header, that's why I have that functionality controlled by a setting.