### PR TITLE
EZP-27121: Fix double-encoding of preview image URLs in the admin interface

### DIFF
--- a/design/admin/javascript/ezajaxsubitems_datatable.js
+++ b/design/admin/javascript/ezajaxsubitems_datatable.js
@@ -60,7 +60,7 @@ var sortableSubitems = function () {
         }
 
         var thumbView = function(cell, record, column, data) {
-            var url = encodeURI(record.getData('thumbnail_url'));
+            var url = record.getData('thumbnail_url');
             if (url) {
                 var thBack = 'background: url(\'' + url.replace(/'/g, "\\'") + '\') no-repeat;';
                 var thWidth = ' width: ' + record.getData('thumbnail_width') + 'px;';


### PR DESCRIPTION
<img width="299" alt="831021dc-f766-11e6-8fcb-a364721040c3" src="https://cloud.githubusercontent.com/assets/971684/23250166/31137714-f9a8-11e6-90c5-b47a48c329f9.png">

The URL for this preview image is getting encoded twice:

encodeURI(record.getData('thumbnail_url')); in design/admin/javascript/ezajaxsubitems_datatable.js
in https://github.com/mugoweb/ezpublish-legacy/blob/master/extension/ezjscore/classes/ezjscajaxcontent.php#L317 -- transformURI does the encoding
That issue never surfaced because the image datatype in ezp is escaping special characters if it's creating the file name for the image file. So an image name "test{{dd}}test" results in a file name like this "test-dd-test". So there is never the need to encode anything for image URLs.

But this the double-encoding will cause issues if the image URL is coming from other systems like the mugo_dam which is not simplifying the image file name - and needs URL encoding (just not twice).