### PR TITLE
EZP-27171: Fix escaping for custom tag attribute values

### DIFF
--- a/extension/ezoe/ezxmltext/handlers/input/ezoeinputparser.php
+++ b/extension/ezoe/ezxmltext/handlers/input/ezoeinputparser.php
@@ -262,7 +262,7 @@ class eZOEInputParser extends eZXMLInputParser
                     if ( isset( $this->Namespaces[$prefix] ) )
                     {
                         $URI = $this->Namespaces[$prefix];
-                        $element->setAttributeNS( $URI, $qualifiedName, $value );
+                        $element->setAttributeNS( $URI, $qualifiedName, htmlspecialchars_decode( $value ) );
                     }
                     else
                     {
@@ -271,7 +271,7 @@ class eZOEInputParser extends eZXMLInputParser
                 }
                 else
                 {
-                    $element->setAttribute( $qualifiedName, $value );
+                    $element->setAttribute( $qualifiedName, htmlspecialchars_decode( $value ) );
                 }
             }
         }

--- a/extension/ezoe/ezxmltext/handlers/input/ezoexmlinput.php
+++ b/extension/ezoe/ezxmltext/handlers/input/ezoexmlinput.php
@@ -1744,12 +1744,12 @@ class eZOEXMLInput extends eZXMLInputHandler
                 if ( $customAttributePart === '' )
                 {
                     $customAttributePart = ' customattributes="';
-                    $customAttributePart .= $attribute->name . '|' . $attribute->value;
+                    $customAttributePart .= $attribute->name . '|' . htmlspecialchars( $attribute->value );
                 }
                 else
                 {
                    $customAttributePart .= 'attribute_separation' . $attribute->name . '|' .
-                                           $attribute->value;
+                       htmlspecialchars( $attribute->value );
                 }
                 if ( isset( self::$customAttributeStyleMap[$attribute->name] ) )
                 {

--- a/extension/ezoe/tests/ezoexmltext_regression.php
+++ b/extension/ezoe/tests/ezoexmltext_regression.php
@@ -34,14 +34,35 @@ class eZOEXMLTextRegression extends ezpDatabaseTestCase
             array(
                 '<div type="custom" class="ezoeItemCustomTag factbox" customattributes="title|<a href=&quot;#test&quot;>Test</a>attribute_separationalign|right"><p>This is a fact</p></div>',
                 '<?xml version="1.0" encoding="utf-8"?>
-<section xmlns:image="http://ez.no/namespaces/ezpublish3/image/" xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/" xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/"><paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/"><custom name="factbox" custom:title="&lt;a href=&amp;quot;#test&amp;quot;&gt;Test&lt;/a&gt;"><paragraph>This is a fact</paragraph></custom></paragraph></section>',
+<section xmlns:image="http://ez.no/namespaces/ezpublish3/image/" xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/" xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/"><paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/"><custom name="factbox" custom:title="&lt;a href=&quot;#test&quot;&gt;Test&lt;/a&gt;"><paragraph>This is a fact</paragraph></custom></paragraph></section>',
             ),
             array(
                 '<div type="custom" class="ezoeItemCustomTag factbox" customattributes="title|<a href=&quot;#test&quot;>Test</a>attribute_separationalign|right"><p>This is a fact</p></div><p>Text between</p><div type="custom" class="ezoeItemCustomTag factbox" customattributes="title|<a href=&quot;#test&quot;>Test</a>attribute_separationalign|right"><p>This is a fact</p></div>',
                 '<?xml version="1.0" encoding="utf-8"?>
-<section xmlns:image="http://ez.no/namespaces/ezpublish3/image/" xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/" xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/"><paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/"><custom name="factbox" custom:title="&lt;a href=&amp;quot;#test&amp;quot;&gt;Test&lt;/a&gt;"><paragraph>This is a fact</paragraph></custom></paragraph><paragraph>Text between</paragraph><paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/"><custom name="factbox" custom:title="&lt;a href=&amp;quot;#test&amp;quot;&gt;Test&lt;/a&gt;"><paragraph>This is a fact</paragraph></custom></paragraph></section>',
+<section xmlns:image="http://ez.no/namespaces/ezpublish3/image/" xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/" xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/"><paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/"><custom name="factbox" custom:title="&lt;a href=&quot;#test&quot;&gt;Test&lt;/a&gt;"><paragraph>This is a fact</paragraph></custom></paragraph><paragraph>Text between</paragraph><paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/"><custom name="factbox" custom:title="&lt;a href=&quot;#test&quot;&gt;Test&lt;/a&gt;"><paragraph>This is a fact</paragraph></custom></paragraph></section>',
             ),
         );
+    }
+
+    /**
+     * Test for proper escaping for custom tag attribute values
+     */
+    public function testEscapeAttributeValue()
+    {
+        $xmlData = '<?xml version="1.0" encoding="utf-8"?>';
+        $xmlData .= '<section xmlns:image="http://ez.no/namespaces/ezpublish3/image/" xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/" xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/">';
+        $xmlData .= "<paragraph>";
+        $xmlData .= '<custom name="factbox" custom:title="&quot;fipsfuchs&quot;" custom:align="&amp;quot;fipsfuchs&amp;quot;"></custom>';
+        $xmlData .= "</paragraph>";
+        $xmlData .= "</section>";
+
+        $folder = new ezpObject( 'folder', 2 );
+        $folder->name = 'Escape Attribute Value';
+        $folder->short_description = '';
+
+        $oeHandler = new eZOEXMLInput( $xmlData, false,  $folder->short_description );
+        $xhtml = $oeHandler->attribute( 'input_xml' );
+        self::assertEquals( '&lt;div class=&quot;ezoeItemCustomTag factbox&quot; type=&quot;custom&quot; customattributes=&quot;title|&amp;quot;fipsfuchs&amp;quot;attribute_separationalign|&amp;amp;quot;fipsfuchs&amp;amp;quot;&quot;&gt;&lt;p&gt;factbox&lt;/p&gt;&lt;/div&gt;&lt;p&gt;&lt;br /&gt;&lt;/p&gt;', $xhtml );
     }
 
     /**

--- a/kernel/classes/datatypes/ezxmltext/ezxmlinputparser.php
+++ b/kernel/classes/datatypes/ezxmltext/ezxmlinputparser.php
@@ -708,7 +708,7 @@ class eZXMLInputParser
                     if ( isset( $this->Namespaces[$prefix] ) )
                     {
                         $URI = $this->Namespaces[$prefix];
-                        $element->setAttributeNS( $URI, $qualifiedName, $value );
+                        $element->setAttributeNS( $URI, $qualifiedName, htmlspecialchars_decode( $value ) );
                     }
                     else
                     {
@@ -717,7 +717,7 @@ class eZXMLInputParser
                 }
                 else
                 {
-                    $element->setAttribute( $qualifiedName, $value );
+                    $element->setAttribute( $qualifiedName,  htmlspecialchars_decode( $value ) );
                 }
             }
         }


### PR DESCRIPTION
The ezxmltext datatype allows editors to embed custom tags. For example the 'factbox'. A custom tag may have input fields allowing the editor to type in text. For example 'Title' for the 'factbox'.

If you type in a " (double-quote) char into the custom tag field, it is getting encoded twice before the value gets stored in the database. That's problematic because the template that renders the custom tag is not receiving the " char but '&quot;' instead.

Steps to reproduce the issue:
- you have a xmltext attribute (like article body)
- in this attribute you add a custom tag
- the custom tag has an field and you add some HTML code into this field - something like "<iframe src="http://www.mugo.ca"></iframe>"
- You save the content object (Send to publishing)
- On the public site, the HTML for the custom tag is broken. It renders something like
"<iframe src&quot;http://www.mugo.ca&quot;></iframe>"

More details where the problem is:

When you hit 'Send for publishing', the HTML form will send all attribute values of the content object to the server. In case of the xmltext attributes, it sends an HTML string. In my test I added a custom tag 'factbox' - the HTML string looks similar to:
```
<div type="custom" class="ezoeItemCustomTag factbox" customattributes="title|&quot;page.html&quot;attribute_separationalign|right">
<p>factbox</p>
</div>
```
For the title field, I typed in "page.html" (with quotes). You can see that those double-quotes are escaped. That's good, otherwise it would break the HTML string (doube-quote in an HTML attribute value).

This HTML string is send to:
`kernel/classes/datatypes/exzmltext/ezxmlinputparser.php`

That class turns the HTML into an XML format. That XML string is getting stored in the database. In case of my example, that's what you get in the DB:

```
<paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/">
    <custom name="factbox" custom:title="&amp;quot;page.html&amp;quot;" custom:align="right"/>
</paragraph>
```

Here you can see the problem: `&amp;quot;`

That " char gets encoded twice:
```
"         ->   &quot;
&quot;     -> $amp;quot;
```

There is no good reason for the double-encoding. In XML, you are allowed to have the string &quot; as an attribute value.

The double encoding happens in
`extension/ezoe/ezxmltext/handlers/input/ezoeinputparser.php Line: 274`

`$element->setAttribute( $qualifiedName, $value );`

setAttribute is escaping the given $value - see http://stackoverflow.com/questions/7294134/php-xml-dom-unwanted-escaping-characters-i-cannot-write-qnot

I changed it to
`$element->setAttribute( $qualifiedName, htmlspecialchars_decode( $value ) );`

That will avoid the double-encoding and will render the correct value in the templates.