### PR TITLE
EZP-27257: Handle non-numeric image size keys better

### DIFF
--- a/kernel/common/ezwordtoimageoperator.php
+++ b/kernel/common/ezwordtoimageoperator.php
@@ -268,7 +268,7 @@ class eZWordToImageOperator
                 }
                 else
                 {
-                    $size = $sizes[0];
+                    $size = reset($sizes);
                 }
 
                 $pathDivider = strpos( $size, ';' );


### PR DESCRIPTION
Currently the fallback when looking for icon sizes grabs the icon with the key `0`, but there are instances where there is nothing set at that key. I assume the author was meaning to grab the first icon size in the array, so I propose switching this to use reset.