### PR TITLE
https://jira.ez.no/browse/EZP-27298: search index not updated if main…

### DIFF
--- a/kernel/classes/ezcontentobjecttreenodeoperations.php
+++ b/kernel/classes/ezcontentobjecttreenodeoperations.php
@@ -113,7 +113,9 @@ class eZContentObjectTreeNodeOperations
                 $nodeIDList = array( $nodeID );
                 eZSearch::removeNodeAssignment( $node->attribute( 'main_node_id' ), $newNode->attribute( 'main_node_id' ), $object->attribute( 'id' ), $nodeIDList );
                 eZSearch::addNodeAssignment( $newNode->attribute( 'main_node_id' ), $object->attribute( 'id' ), $nodeIDList, true );
-            }
+            } else {
+				eZContentOperationCollection::registerSearchObject( $objectID, null, true );
+			}
 
             $result = true;
         }


### PR DESCRIPTION
Ticket: https://jira.ez.no/browse/EZP-27298
When moving the main location of a node, the object was not scheduled for reindexing - thus the index contained the old location of the object.