### PR TITLE
Fix EZP-27254: "Unknown relation type 0." error when access content o…

### DIFF
--- a/kernel/classes/ezcontentobject.php
+++ b/kernel/classes/ezcontentobject.php
@@ -2873,7 +2873,7 @@ class eZContentObject extends eZPersistentObject
                   WHERE  from_contentobject_id=$fromObjectID AND
                          from_contentobject_version=$fromObjectVersion AND
                          to_contentobject_id=$toObjectID AND
-                         $relationTypeMatch != 0 AND
+                         $relationTypeMatch >= 0 AND
                          contentclassattribute_id=$attributeID";
         $count = $db->arrayQuery( $query );
         // if current relation does not exist


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-27254

# Steps to reproduce

> 1. Create an article;
> 2. Add an existing image to an XML block field. Used "Summary";
> 3. Add a different image to another XML block field. Used "Body";
> 4. Publish;
> 5. Edit the article, and publish;
> 6. Access the REST API via cURL: 
> curl -u "admin:admin" -v -H "Accept: application/vnd.ez.api.Content+json" http://example.com/api/ezp/v2/content/objects/136

# Problem description 

Problem is diagnosed in content classes with two or more XML block attributes. After second object update in ezcontentobject_link table there is created additional row with relation_type column equal 0 which causes "Unknown relation type 0." exception when object is accessed via API. 

# Backporting

~~~Patch can be also applied to 5.3 and probably in older versions of ezpublish-legacy (additional tests are required).~~~

Patch can be applied to all maintained releases. Originally the relationType condition was introduced in 71cd745ba0e71ea73683edc41bd20f69ce041c7b (line no. 2371) and wasn't modified until now. 

# TODO
- [x] ~~~Tests~~~
- [x] Backporting

