### PR TITLE
FIX EZP-27306: Display modifier of published version in edit view and in version view

### DIFF
--- a/design/admin/templates/content/parts/object_information.tpl
+++ b/design/admin/templates/content/parts/object_information.tpl
@@ -29,9 +29,13 @@
 <p>
 <label>{'Modified'|i18n( 'design/admin/content/history' )}:</label>
 {if $object.modified}
-{def $latest_version=$object.versions|extract_right(1)[0]}
 {$object.modified|l10n( shortdatetime )}<br />
-{$latest_version.creator.name|wash}
+{foreach $object.versions as $version}
+{if eq($version.version, $object.published_version)}
+{$version.creator.name|wash}
+{break}
+{/if}
+{/foreach}
 {else}
 {'Not yet published'|i18n( 'design/admin/content/history' )}
 {/if}


### PR DESCRIPTION
> [EZP-27306](http://jira.ez.no/browse/EZP-27306)
#
When an object info shows incorrect "modifier" name (displaying the modifier of the latest version instead, which is a draft created by modifying an object, which means that modifier name always shows the name of the current user).

This bug was introduced by this PR: https://github.com/ezsystems/ezpublish-legacy/pull/1114.

To make it work in edit view and version view, I suggest using published version instead of the latest version to retrieve the name of modifier. It seems logical modifier to me in both situations. We can't use the latest version, because of the reason mentioned above. We also can't use "object.current", because it introduces bug [EZP-23672](http://jira.ez.no/browse/EZP-23672).

I used "foreach" to retrieve published version because I couldn't find any shortcut.