### PR TITLE
EZP-27714: Replaced wrong variable name in eZTemplateMultiPassParser class

### DIFF
--- a/lib/eztemplate/classes/eztemplatemultipassparser.php
+++ b/lib/eztemplate/classes/eztemplatemultipassparser.php
@@ -181,7 +181,7 @@ class eZTemplateMultiPassParser extends eZTemplateParser
                         $this->gotoEndPosition( $textPortion, $tagStartLine, $tagStartColumn, $tagEndLine, $tagEndColumn );
                         $tpl->error( "", "parser error @ $relatedTemplateName:$currentLine" . "[$currentColumn]" . "\n" .
                                      "Unterminated tag, needs a $rightDelimiter to end the tag.\n" . $leftDelimiter . $textPortion,
-                                     array( array( $tagStartLine, $tagStartColumn, $tagPosition ),
+                                     array( array( $tagStartLine, $tagStartColumn, $tagPos ),
                                               array( $tagEndLine, $tagEndColumn, $sourceLength - 1 ),
                                               $relatedTemplateName ) );
                         $textElements[] = array( "text" => $data,


### PR DESCRIPTION
Using $tagPosition brings a notice that it does not exists => the variable to use is $tagPos