### PR TITLE
EZP-27460 proper solr indexing while moving content

### DIFF
--- a/kernel/classes/ezcontentobjecttreenodeoperations.php
+++ b/kernel/classes/ezcontentobjecttreenodeoperations.php
@@ -113,6 +113,7 @@ class eZContentObjectTreeNodeOperations
                 $nodeIDList = array( $nodeID );
                 eZSearch::removeNodeAssignment( $node->attribute( 'main_node_id' ), $newNode->attribute( 'main_node_id' ), $object->attribute( 'id' ), $nodeIDList );
                 eZSearch::addNodeAssignment( $newNode->attribute( 'main_node_id' ), $object->attribute( 'id' ), $nodeIDList, true );
+                eZSearch::refreshChildren( $node );
             }
 
             $result = true;

--- a/kernel/classes/ezsearch.php
+++ b/kernel/classes/ezsearch.php
@@ -671,7 +671,7 @@ class eZSearch
         {
             foreach ( $node->children() as $child )
             {
-                self::addNodeAssignment( $child->MainNodeID, $child->ContentObjectID, array( $child->MainNodeID ), true);
+                self::addNodeAssignment( $child->MainNodeID, $child->ContentObjectID, array( $child->MainNodeID ), true );
                 self::refreshChildren( $child );
             }
        }

--- a/kernel/classes/ezsearch.php
+++ b/kernel/classes/ezsearch.php
@@ -671,7 +671,7 @@ class eZSearch
         {
             foreach ( $node->children() as $child )
             {
-                self::addObject( $child->ContentObject );
+                self::addNodeAssignment( $child->MainNodeID, $child->ContentObjectID, array( $child->MainNodeID ), true);
                 self::refreshChildren( $child );
             }
        }

--- a/kernel/classes/ezsearch.php
+++ b/kernel/classes/ezsearch.php
@@ -659,6 +659,23 @@ class eZSearch
 
         return false;
     }
+
+    /**
+     * Notifies search engine to refresh information about children of given node
+     *
+     * @param eZContentObjectTreeNode $node
+     */
+    public static function refreshChildren( $node )
+    {
+        if ( $node->childrenCount( false ) > 0 )
+        {
+            foreach ( $node->children() as $child )
+            {
+                self::addObject( $child->ContentObject );
+                self::refreshChildren( $child );
+            }
+       }
+    }
 }
 
 ?>


### PR DESCRIPTION
This is a fix for https://jira.ez.no/browse/EZP-27460

## Description
While moving content in eZ there was no action taken to update information in search engine about children of node being moved.

This PR adds a method which recursively updates information in search about given node. 