### PR TITLE
EZP-25916: fixing deadlock issues on clustering cache

### DIFF
--- a/kernel/private/classes/clusterfilehandlers/dfsbackends/mysqli.php
+++ b/kernel/private/classes/clusterfilehandlers/dfsbackends/mysqli.php
@@ -1638,8 +1638,11 @@ class eZDFSFileHandlerMySQLiBackend implements eZClusterEventNotifier
         if ( !$this->_query( $query, "_startCacheGeneration( $filePath )", false ) )
         {
             $errno = mysqli_errno( $this->db );
+
             //once deadlock found / lock wait timeout found, we return ko status which will force read from stale cache
             //'remaining' item is irrelevant in this case, but it needs to be set
+            //1205 is 'Lock wait timeout exceeded; try restarting transaction'
+            //1213 is 'Deadlock found when trying to get lock; try restarting transaction'
             if ( in_array( $errno, array( 1205, 1213 ) ) )
             {
                 return array( 'result' => 'ko', 'remaining' => 0 );

--- a/kernel/private/classes/clusterfilehandlers/dfsbackends/mysqli.php
+++ b/kernel/private/classes/clusterfilehandlers/dfsbackends/mysqli.php
@@ -1653,7 +1653,7 @@ class eZDFSFileHandlerMySQLiBackend implements eZClusterEventNotifier
                 eZDebug::writeError( "Unexpected error #$errno when trying to start cache generation on $filePath (".mysqli_error( $this->db ).")", __METHOD__ );
                 eZDebug::writeDebug( $query, '$query' );
 
-                // @todo Make this an actual error, maybe an exception
+                // @todo throw an exception
                 return array( 'result' => 'error' );
             }
             // error 1062 is expected, since it means duplicate key (file is being generated)

--- a/kernel/private/classes/clusterfilehandlers/dfsbackends/mysqli.php
+++ b/kernel/private/classes/clusterfilehandlers/dfsbackends/mysqli.php
@@ -1654,7 +1654,7 @@ class eZDFSFileHandlerMySQLiBackend implements eZClusterEventNotifier
                 eZDebug::writeDebug( $query, '$query' );
 
                 // @todo Make this an actual error, maybe an exception
-                return array( 'res' => 'ko' );
+                return array( 'result' => 'error' );
             }
             // error 1062 is expected, since it means duplicate key (file is being generated)
             else

--- a/kernel/private/classes/clusterfilehandlers/dfsbackends/mysqli.php
+++ b/kernel/private/classes/clusterfilehandlers/dfsbackends/mysqli.php
@@ -1639,10 +1639,10 @@ class eZDFSFileHandlerMySQLiBackend implements eZClusterEventNotifier
         {
             $errno = mysqli_errno( $this->db );
 
-            //once deadlock found / lock wait timeout found, we return ko status which will force read from stale cache
-            //'remaining' item is irrelevant in this case, but it needs to be set
-            //1205 is 'Lock wait timeout exceeded; try restarting transaction'
-            //1213 is 'Deadlock found when trying to get lock; try restarting transaction'
+            // once deadlock found / lock wait timeout found, we return ko status which will force read from stale cache
+            // 'remaining' item is irrelevant in this case, but it needs to be set
+            // 1205 is 'Lock wait timeout exceeded; try restarting transaction'
+            // 1213 is 'Deadlock found when trying to get lock; try restarting transaction'
             if ( in_array( $errno, array( 1205, 1213 ) ) )
             {
                 return array( 'result' => 'ko', 'remaining' => 0 );


### PR DESCRIPTION
This is a fix for https://jira.ez.no/browse/EZP-25916 

## Description
In high load environments it is possible that multiple processes are trying to perform the same operation (cache generation) on mysql database which may result in one of [Lock wait timeout exceeded; try restarting transaction](https://dev.mysql.com/doc/refman/5.5/en/error-messages-server.html#error_er_lock_wait_timeout) (error number 1205) or [Deadlock found when trying to get lock; try restarting transaction](https://dev.mysql.com/doc/refman/5.5/en/error-messages-server.html#error_er_lock_deadlock) (error number 1213)

Currently those errors aren't handled and are treated as a `Unexpected error` resulting with a crash.

The idea behind this solution is to treat those errors similar as [1062](https://dev.mysql.com/doc/refman/5.5/en/error-messages-server.html#error_er_dup_entry) error is treated already, by returning array result which will force DFS cache to read from stale cache file. 
