### PR TITLE
Fix EZP-27474: Unable to add the same URL alias for other languages

### DIFF
--- a/kernel/classes/ezurlaliasml.php
+++ b/kernel/classes/ezurlaliasml.php
@@ -842,6 +842,15 @@ class eZURLAliasML extends eZPersistentObject
                         $curElementID = $curID;
                         break;
                     }
+
+                    // If the current node is the same action, but the language is different
+                    // (enables adding the same URL alias for other languages)
+                    if ( !( (int)$row['lang_mask'] & $languageID ) )
+                    {
+                        // We can reuse the element so record the ID
+                        $curElementID = $curID;
+                        break;
+                    }
                 }
                 else if ( $curAction == 'nop:' || $row['is_original'] == 0 )
                 {


### PR DESCRIPTION
[https://jira.ez.no/browse/EZP-27474](https://jira.ez.no/browse/EZP-27474)
#
Excerpt from the JIRA issue:
> When trying to add an URL alias to a node (content/urlalias/) where the same URL alias already exists in another language, the following error message is produced: The URL alias <</xxx>> already exists, and it points to <<content/view/full/xxx>>. As it is an alias for another language, it should be created anyway.

The solution proposed in this PR was originally proposed by @glye here: https://jira.ez.no/browse/EZP-16680. It was tested by me and it solves the issue.