### PR TITLE
EZP-27427 Cache generation performance improvement

### DIFF
--- a/kernel/classes/datatypes/ezuser/ezuser.php
+++ b/kernel/classes/datatypes/ezuser/ezuser.php
@@ -2474,7 +2474,7 @@ WHERE user_id = '" . $userID . "' AND
             {
                 $this->GroupsAsObjects = array();
 
-                foreach ($this->groups() as $group)
+                foreach ( $this->groups() as $group )
                 {
                     $this->GroupsAsObjects[] = new eZContentObject( $group );
                 }

--- a/kernel/classes/datatypes/ezuser/ezuser.php
+++ b/kernel/classes/datatypes/ezuser/ezuser.php
@@ -1415,7 +1415,8 @@ WHERE user_id = '" . $userID . "' AND
                                         'password_hash'      => $user->attribute( 'password_hash' ),
                                         'password_hash_type' => $user->attribute( 'password_hash_type' ) );
 
-        // setting caching enabled flag to false is a protection against infinite recursion.
+        // function groups relies on caching. The function generateUserCacheData relies on function groups.
+        // To avoid an infinitive loop, the code is disabling caching in function generateUserCacheData.
         // At the end of this method flag is set to previous value again
         $previousCachingState = $user->setCachingEnabled( false );
         // user groups list (session: eZUserGroupsCache)

--- a/kernel/classes/datatypes/ezuser/ezuser.php
+++ b/kernel/classes/datatypes/ezuser/ezuser.php
@@ -1415,6 +1415,8 @@ WHERE user_id = '" . $userID . "' AND
                                         'password_hash'      => $user->attribute( 'password_hash' ),
                                         'password_hash_type' => $user->attribute( 'password_hash_type' ) );
 
+        // setting caching enabled flag to false is a protection against infinite recursion.
+        // At the end of this method flag is set to previous value again
         $previousCachingState = $user->setCachingEnabled( false );
         // user groups list (session: eZUserGroupsCache)
         $data['groups'] = $user->groups();


### PR DESCRIPTION
This is a proposed solution for https://jira.ez.no/browse/EZP-27427

## Description
A problem of deadlock / lock timeout came up in https://jira.ez.no/browse/EZP-25916. It occurs on high load environments with DFS cache setup with mysql as a cache metadata repository.  While handling of mysql lock errors is handled in #1301 this work tries to speed up things to reduce the dead lock situations in the first place.

Basically what I have done here is a strip down of @joaoinacio work to do as few code modifications as possible since we are in legacy.

Up to now `generateUserCacheData` method resulted in querying mysql 4 times for group ids:
[First](https://github.com/ezsystems/ezpublish-legacy/blob/master/kernel/classes/datatypes/ezuser/ezuser.php#L1419)
[Second](https://github.com/ezsystems/ezpublish-legacy/blob/master/kernel/classes/datatypes/ezuser/ezuser.php#L2377) - as `limitList` was called with `false` flag (I'm bit unsure why)
[Third](https://github.com/ezsystems/ezpublish-legacy/blob/master/kernel/classes/datatypes/ezuser/ezuser.php#L1923)
[Fourth](https://github.com/ezsystems/ezpublish-legacy/blob/master/kernel/classes/datatypes/ezuser/ezuser.php#L2473)

By limiting those redundant queries we should have a bit better performance of user cache generation which hopefully can lead to fewer deadlock occurences.