### PR TITLE
Fix EZP-27588: Warning shown when renaming files in concurrency situations

### DIFF
--- a/lib/ezfile/classes/ezfile.php
+++ b/lib/ezfile/classes/ezfile.php
@@ -169,7 +169,7 @@ class eZFile
         	    eZDebug::writeWarning( "$srcFile could not be renamed to $destFile", __METHOD__ );
 
             if ( $flags & self::CLEAN_ON_FAILURE )
-        	    unlink( $srcFile );
+        	    @unlink( $srcFile );
         }
 
         return $status;


### PR DESCRIPTION
> [EZP-27588](https://jira.ez.no/browse/EZP-27588)
#
Excerpt from JIRA:
> The following warning is shown in rare situations on the customer's page: "Warning: unlink(var/log/error.log.1): No such file or directory in /var/www/xxx/ezpublish_legacy/lib/ezfile/classes/ezfile.php".
Unfortunately, I wasn't able to reproduce it on local installation but based on this information I think I know why it is happening and I have a good idea what can be done to fix it.
In my opinion, the warning is the result of the log rotation. Theoretically, if two rotations for the same file are run simultaneously, there could be a case that a file is already moved. If that's the case, there actually could be a warning thrown from this line: https://github.com/ezsystems/ezpublish-legacy/blob/master/lib/ezfile/classes/ezfile.php#L172. 
The easiest fix would be to add the error suppression operator "@" before the unlink function, just like it is done above (https://github.com/ezsystems/ezpublish-legacy/blob/master/lib/ezfile/classes/ezfile.php#L157).

This is the easiest fix mentioned above, meaning it suppresses warnings coming from the unlink function like it is done already in another place in the same function.