### PR TITLE
EZP-26013 cache update on trash restoration

### DIFF
--- a/kernel/content/restore.php
+++ b/kernel/content/restore.php
@@ -163,9 +163,10 @@ if ( $module->isCurrentAction( 'AddLocation' ) )
         }
     }
 
+    $db->commit();
+
     eZContentObject::fixReverseRelations( $objectID, 'restore' );
 
-    $db->commit();
     $module->redirectToView( 'view', array( 'full', $mainNodeID ) );
     return;
 }


### PR DESCRIPTION
This is a fix for https://jira.ez.no/browse/EZP-26013

## Description
While restoring object from trash it's cache was not refreshed. The issue here was that when logic which is meant to clear the cache was run it was [called](https://github.com/ezsystems/LegacyBridge/blob/master/bundle/Cache/PersistenceCachePurger.php#L129) with array of locationIds 



One of ids passed to this method was a locationId after restoration of object. Because this method was run before performing mysql commit it threw an exception as content could not be found.

So easy fix for this is just doing commit before trying to restore caches.  