### PR TITLE
EZP-27091: Added a settings to mark data collections as a "containing sensitive data"

### DIFF
--- a/kernel/classes/ezinformationcollection.php
+++ b/kernel/classes/ezinformationcollection.php
@@ -728,6 +728,30 @@ class eZInformationCollection extends eZPersistentObject
         $db->query( "DELETE FROM ezinfocollection" );
         $db->commit();
     }
+
+    /*!
+     \static
+     \return \c true if the information collection contains sensitive data.
+    */
+    static function isCollectingSensitiveData( $contentObject )
+    {
+        if ( !$contentObject )
+            return false;
+        $type = eZInformationCollection::typeForObject( $contentObject );
+
+        $ini = eZINI::instance( 'collect.ini' );
+        $collectSensitiveDataList = $ini->variable( 'CollectionSettings', 'CollectSensitiveDataList' );
+
+        $collectSensitiveData = false;
+
+        if ( isset( $collectSensitiveDataList[$type] ) )
+            $collectSensitiveData = $collectSensitiveDataList[$type];
+
+        if ( !$collectSensitiveData )
+            $collectSensitiveData = $ini->variable( 'CollectionSettings', 'CollectSensitiveData' );
+
+        return $collectSensitiveData === 'true';
+    }
 }
 
 ?>

--- a/kernel/classes/ezinformationcollection.php
+++ b/kernel/classes/ezinformationcollection.php
@@ -735,20 +735,18 @@ class eZInformationCollection extends eZPersistentObject
     */
     static function isCollectingSensitiveData( $contentObject )
     {
-        if ( !$contentObject )
-            return false;
-        $type = eZInformationCollection::typeForObject( $contentObject );
-
         $ini = eZINI::instance( 'collect.ini' );
-        $collectSensitiveDataList = $ini->variable( 'CollectionSettings', 'CollectSensitiveDataList' );
 
-        $collectSensitiveData = false;
+        $collectSensitiveData = $ini->variable( 'CollectionSettings', 'CollectSensitiveData' );
 
-        if ( isset( $collectSensitiveDataList[$type] ) )
-            $collectSensitiveData = $collectSensitiveDataList[$type];
+        if ( $contentObject instanceof eZContentObject )
+        {
+            $type = eZInformationCollection::typeForObject( $contentObject );
+            $collectSensitiveDataList = $ini->variable( 'CollectionSettings', 'CollectSensitiveDataList' );
 
-        if ( !$collectSensitiveData )
-            $collectSensitiveData = $ini->variable( 'CollectionSettings', 'CollectSensitiveData' );
+            if ( isset( $collectSensitiveDataList[$type] ) )
+                $collectSensitiveData = $collectSensitiveDataList[$type];
+        }
 
         return $collectSensitiveData === 'true';
     }

--- a/kernel/content/collectedinfo.php
+++ b/kernel/content/collectedinfo.php
@@ -45,7 +45,7 @@ if ( $http->hasSessionVariable( 'InformationCollectionMap' ) ) {
         $icID = $icMap[$object->attribute( 'id' )];
     }
 }
-if ( !$icID )
+if ( !$icID && eZInformationCollection::isCollectingSensitiveData( $object ) )
     return $module->handleError( eZError::KERNEL_NOT_AVAILABLE, 'kernel' );
 
 $informationCollectionTemplate = eZInformationCollection::templateForObject( $object );

--- a/settings/collect.ini
+++ b/settings/collect.ini
@@ -53,6 +53,12 @@ CollectAnonymousData=enabled
 CollectAnonymousDataList[]
 CollectAnonymousDataList[poll]=enabled
 CollectAnonymousDataAttribute=collection_anonymous
+# Does collected data are sensitive ?
+CollectSensitiveData=true
+# Same as CollectSensitiveData bu is a list with of IC types and
+# their override settings, if specified it will override default setting
+CollectSensitiveDataList[]
+CollectSensitiveDataList[poll]=false
 # How information collection is handled in terms of user identification
 #
 # multiple  - each user can submit multiple data

--- a/settings/collect.ini
+++ b/settings/collect.ini
@@ -53,9 +53,10 @@ CollectAnonymousData=enabled
 CollectAnonymousDataList[]
 CollectAnonymousDataList[poll]=enabled
 CollectAnonymousDataAttribute=collection_anonymous
-# Does collected data are sensitive ?
+# Are collected data sensitive? If true then user will be able to view collected
+# data only when previously submit a form
 CollectSensitiveData=true
-# Same as CollectSensitiveData bu is a list with of IC types and
+# Same as CollectSensitiveData but is a list with of IC types and
 # their override settings, if specified it will override default setting
 CollectSensitiveDataList[]
 CollectSensitiveDataList[poll]=false


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-27091

# Description

Currently, to be able to view collected information on frontend e.g. poll results, a user must submit a form in a current session (introduced in 3929217). This behavior is expected for forms with sensitive data (e.g. contact form, abuse report), but not necessarily in others use cases (e.g polls).

This PR adds a "CollectSensitiveData" and "CollectSensitiveDataList" settings to mark data collections as a "containing sensitive data". Depending on those settings user is allowed (or not), to view collected information without a previously form submit. 
