### PR TITLE
Fix eZDebug::exceptionErrorHandler

### DIFF
--- a/lib/ezutils/classes/ezdebug.php
+++ b/lib/ezutils/classes/ezdebug.php
@@ -1968,6 +1968,9 @@ class eZDebug
      */
     public static function exceptionErrorHandler( $errno, $errstr, $errfile, $errline )
     {
+        if (!(error_reporting() & $errno)) {            
+            return;
+        }
         throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
     }
 


### PR DESCRIPTION
With this fix eZDebug::exceptionErrorHandler ignores error code which is not included in error_reporting