### PR TITLE
EZP-26013 moving commit before method which publishes content

### DIFF
--- a/kernel/classes/ezcontentobject.php
+++ b/kernel/classes/ezcontentobject.php
@@ -1762,8 +1762,9 @@ class eZContentObject extends eZPersistentObject
      *
      * @param int $objectID
      * @param string|bool $mode See eZObjectRelationListType::fixRelatedObjectItem() for valid modes
+     * @param bool $clearCacheIfEnabled If set to false cache won't be cleared
      */
-    static function fixReverseRelations( $objectID, $mode = false )
+    static function fixReverseRelations( $objectID, $mode = false, $clearCacheIfEnabled = true )
     {
         $db = eZDB::instance();
         $objectID = (int) $objectID;
@@ -1786,7 +1787,7 @@ class eZContentObject extends eZPersistentObject
                 $dataType->fixRelatedObjectItem( $attr, $objectID, $mode );
                 $objectIDList[] = $attr->attribute( 'contentobject_id' );
             }
-            if ( eZINI::instance()->variable( 'ContentSettings', 'ViewCaching' ) === 'enabled' )
+            if ( $clearCacheIfEnabled && eZINI::instance()->variable( 'ContentSettings', 'ViewCaching' ) === 'enabled' )
                 eZContentCacheManager::clearObjectViewCacheArray( $objectIDList );
         }
     }

--- a/kernel/content/restore.php
+++ b/kernel/content/restore.php
@@ -134,11 +134,7 @@ if ( $module->isCurrentAction( 'AddLocation' ) )
     $version->store();
 
     $object->restoreObjectAttributes();
-
     $user = eZUser::currentUser();
-
-    $db->commit();
-
     $operationResult = eZOperationHandler::execute( 'content', 'publish', array( 'object_id' => $objectID,
                                                                                  'version' => $version->attribute( 'version' ) ) );
     if ( ( array_key_exists( 'status', $operationResult ) && $operationResult['status'] != eZModuleOperationInfo::STATUS_CONTINUE ) )
@@ -166,7 +162,11 @@ if ( $module->isCurrentAction( 'AddLocation' ) )
         }
     }
 
-    eZContentObject::fixReverseRelations( $objectID, 'restore' );
+    eZContentObject::fixReverseRelations( $objectID, 'restore', false );
+    $db->commit();
+
+    // we need to clear cache again after db transcation is commited
+    eZContentCacheManager::clearContentCacheIfNeeded( $objectID,  $version->attribute( 'version' ) );
 
     $module->redirectToView( 'view', array( 'full', $mainNodeID ) );
     return;

--- a/kernel/content/restore.php
+++ b/kernel/content/restore.php
@@ -134,6 +134,7 @@ if ( $module->isCurrentAction( 'AddLocation' ) )
     $version->store();
 
     $object->restoreObjectAttributes();
+
     $user = eZUser::currentUser();
     $operationResult = eZOperationHandler::execute( 'content', 'publish', array( 'object_id' => $objectID,
                                                                                  'version' => $version->attribute( 'version' ) ) );
@@ -163,6 +164,7 @@ if ( $module->isCurrentAction( 'AddLocation' ) )
     }
 
     eZContentObject::fixReverseRelations( $objectID, 'restore', false );
+
     $db->commit();
 
     // we need to clear cache again after db transcation is commited

--- a/kernel/content/restore.php
+++ b/kernel/content/restore.php
@@ -136,6 +136,9 @@ if ( $module->isCurrentAction( 'AddLocation' ) )
     $object->restoreObjectAttributes();
 
     $user = eZUser::currentUser();
+
+    $db->commit();
+
     $operationResult = eZOperationHandler::execute( 'content', 'publish', array( 'object_id' => $objectID,
                                                                                  'version' => $version->attribute( 'version' ) ) );
     if ( ( array_key_exists( 'status', $operationResult ) && $operationResult['status'] != eZModuleOperationInfo::STATUS_CONTINUE ) )
@@ -162,8 +165,6 @@ if ( $module->isCurrentAction( 'AddLocation' ) )
             eZUser::purgeUserCacheByUserId( $object->attribute( 'id' ) );
         }
     }
-
-    $db->commit();
 
     eZContentObject::fixReverseRelations( $objectID, 'restore' );
 


### PR DESCRIPTION
This is a fix for https://jira.ez.no/browse/EZP-26013 and follow up to #1306 

Previous PR was only partial fix. It worked only in case item restored from trash was an object of reverse relation. 
In order to fix it for all cases `commit` need to go further up, before method which is doing content publish.

//CC @lserwatka 