### PR TITLE
EZP-27735 Solr index not updated immediately after change content priority

### DIFF
--- a/kernel/content/ezcontentoperationcollection.php
+++ b/kernel/content/ezcontentoperationcollection.php
@@ -1244,6 +1244,7 @@ class eZContentOperationCollection
              $db->commit();
              if ( !eZSearch::getEngine() instanceof eZSearchEngine )
              {
+                 eZContentCacheManager::clearContentCacheIfNeeded( $objectIDs );
                  foreach ( $objectIDs as $objectID )
                  {
                      eZContentOperationCollection::registerSearchObject( $objectID );


### PR DESCRIPTION
JIRA issue: [https://jira.ez.no/browse/EZP-27735](https://jira.ez.no/browse/EZP-27735)

# Description
First change of content priority was incorrectly indexed in Solr. Instead of new value, default 0 value was indexed. 

