### PR TITLE
[Composer] Specify conflict with kernel older then 6.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,5 +61,8 @@
     "require-dev": {
         "phpunit/phpunit": "3.7.*",
         "zetacomponents/php-generator": "~1.1"
+    },
+    "conflict": {
+        "ezsystems/ezpublish-kernel": "<6.11@dev || >=2014.11"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -64,5 +64,10 @@
     },
     "conflict": {
         "ezsystems/ezpublish-kernel": "<6.11@dev || >=2014.11"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2017.08.x-dev"
+        }
     }
 }


### PR DESCRIPTION
As part of [2017.08](https://github.com/ezsystems/ezpublish-legacy/milestone/1) milestone we are currently merging a few new features to keep legacy compatible with latests version of eZ Platform, which will cause issues if they it is used together with older kernel installs like 6.7 and 5.4.

This was suggested by @emodric in [ongoing](https://github.com/ezsystems/LegacyBridge/pull/103) work to simplify legacy bridge install, where simplifying also tries to avoid people ending up in non working package combinations.