### PR TITLE
EZP-27746: Obsolete object relations not cleaned up

### DIFF
--- a/kernel/classes/datatypes/ezobjectrelation/ezobjectrelationtype.php
+++ b/kernel/classes/datatypes/ezobjectrelation/ezobjectrelationtype.php
@@ -250,7 +250,7 @@ class eZObjectRelationType extends eZDataType
                             continue;
 
                         if ( $attributeTranslation->attribute( 'data_int' ) )
-                            $existingRelations[$attributeTranslation->languageCode] = (int)$attributeTranslation->attribute( 'data_int' );
+                            $existingRelations[$attributeTranslation->LanguageCode] = (int)$attributeTranslation->attribute( 'data_int' );
                     }
                 }
 
@@ -261,7 +261,7 @@ class eZObjectRelationType extends eZDataType
                         continue;
 
                     if ( $attributeTranslation->attribute( 'data_int' ) )
-                        $existingRelations[$attributeTranslation->languageCode] = (int)$attributeTranslation->attribute( 'data_int' );
+                        $existingRelations[$attributeTranslation->LanguageCode] = (int)$attributeTranslation->attribute( 'data_int' );
                 }
 
                 // re-add existing or new relations for other languages

--- a/kernel/classes/datatypes/ezobjectrelation/ezobjectrelationtype.php
+++ b/kernel/classes/datatypes/ezobjectrelation/ezobjectrelationtype.php
@@ -223,32 +223,52 @@ class eZObjectRelationType extends eZDataType
         $contentClassAttributeID = $contentObjectAttribute->ContentClassAttributeID;
         $contentObjectID = $contentObjectAttribute->ContentObjectID;
         $contentObjectVersion = $contentObjectAttribute->Version;
+        $languageCode = $contentObjectAttribute->attribute( 'language_code' );
 
         /** @var eZContentObject */
         $contentObject = $contentObjectAttribute->object();
 
-        // check if previous relation(s) can be removed according to existing translations
+        // cleanup previous relations
+        $contentObject->removeContentObjectRelation( false, $contentObjectVersion, $contentClassAttributeID, eZContentObject::RELATION_ATTRIBUTE );
+
+        // if translatable, we need to re-add the relations for other languages of (previously) published version.
         if ( $contentObjectAttribute->contentClassAttributeCanTranslate() )
         {
-            /** @var eZContentObjectVersion */
-            $currVerobj = $contentObject->version( $contentObjectVersion );
-            // get array of language codes
-            $transList = $currVerobj->translations( false );
-            $removeRelation = ( count( $transList ) == 1 );
-        }
-        else
-        {
-            // not translatable, replace/remove previous relation
-            $removeRelation = true;
+            $existingRelations = array();
+
+            // get published translations of this attribute
+            $pubAttribute = eZContentObjectAttribute::fetch($contentObjectAttribute->ID, $contentObject->publishedVersion() );
+            if ( $pubAttribute )
+            {
+                foreach( $pubAttribute->fetchAttributeTranslations() as $attributeTranslation )
+                {
+                    // skip if language is the one being saved
+                    if ( $attributeTranslation->LanguageCode === $languageCode )
+                        continue;
+
+                    if ( $attributeTranslation->attribute( 'data_int' ) )
+                        $existingRelations[$attributeTranslation->languageCode] = (int)$attributeTranslation->attribute( 'data_int' );
+                }
+            }
+
+            // fetch existing attribute translations for current editing version
+            foreach( $contentObjectAttribute->fetchAttributeTranslations() as $attributeTranslation )
+            {
+                if ( $attributeTranslation->LanguageCode === $languageCode )
+                    continue;
+
+                if ( $attributeTranslation->attribute( 'data_int' ) )
+                    $existingRelations[$attributeTranslation->languageCode] = (int)$attributeTranslation->attribute( 'data_int' );
+            }
+
+            // re-add existing or new relations for other languages
+            foreach( array_unique($existingRelations) as $existingObjectId )
+            {
+                $contentObject->addContentObjectRelation( $existingObjectId, $contentObjectVersion, $contentClassAttributeID, eZContentObject::RELATION_ATTRIBUTE );
+            }
         }
 
-        if ( $removeRelation )
-        {
-             $contentObject->removeContentObjectRelation( false, $contentObjectVersion, $contentClassAttributeID, eZContentObject::RELATION_ATTRIBUTE );
-        }
-
-        $objectID = $contentObjectAttribute->attribute( "data_int" );
-
+        $objectID = $contentObjectAttribute->attribute( 'data_int' );
         if ( $objectID )
         {
             $contentObject->addContentObjectRelation( $objectID, $contentObjectVersion, $contentClassAttributeID, eZContentObject::RELATION_ATTRIBUTE );

--- a/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
+++ b/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
@@ -433,7 +433,7 @@ class eZObjectRelationListType extends eZDataType
                             continue;
 
                         $relationList = $attributeTranslation->value();
-                        foreach ($relList['relation_list'] as $relationItem) {
+                        foreach ($relationList['relation_list'] as $relationItem) {
                             $existingRelations[] = $relationItem['contentobject_id'];
                         }
                     }

--- a/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
+++ b/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
@@ -386,46 +386,35 @@ class eZObjectRelationListType extends eZDataType
         return $newObjectInstance->attribute( 'id' );
     }
 
-    function storeObjectAttribute( $attribute )
+    function storeObjectAttribute( $contentObjectAttribute )
     {
-        $content = $attribute->content();
+        $content = $contentObjectAttribute->content();
         if ( isset( $content['new_object'] ) )
         {
-            $newID = $this->createNewObject( $attribute, $content['new_object'] );
+            $newID = $this->createNewObject( $contentObjectAttribute, $content['new_object'] );
             // if this is a single element selection mode (radio or dropdown), then the newly created item is the only one selected
             if ( $newID )
             {
                 if ( isset( $content['singleselect'] ) )
                     $content['relation_list'] = array();
-                $content['relation_list'][] = $this->appendObject( $newID, 0, $attribute );
+                $content['relation_list'][] = $this->appendObject( $newID, 0, $contentObjectAttribute );
             }
             unset( $content['new_object'] );
-            $attribute->setContent( $content );
+            $contentObjectAttribute->setContent( $content );
         }
 
-        $contentClassAttributeID = $attribute->ContentClassAttributeID;
-        $contentObjectID = $attribute->ContentObjectID;
-        $contentObjectVersion = $attribute->Version;
+        $contentClassAttributeID = $contentObjectAttribute->ContentClassAttributeID;
+        $contentObjectID = $contentObjectAttribute->ContentObjectID;
+        $contentObjectVersion = $contentObjectAttribute->Version;
 
-        $obj = $attribute->object();
-        //get eZContentObjectVersion
-        $currVerobj = $obj->version( $contentObjectVersion );
+        /** @var eZContentObject */
+        $contentObject = $contentObjectAttribute->object();
 
-        // create translation List
-        // $translationList will contain for example eng-GB, ita-IT etc.
-        $translationList = $currVerobj->translations( false );
-
-        // get current language_code
-        $langCode = $attribute->attribute( 'language_code' );
-        // get count of LanguageCode in translationList
-        $countTsl = count( $translationList );
-        // order by asc
-        sort( $translationList );
 
         // check if previous relation(s) should first be removed
-        if ( !$attribute->contentClassAttributeCanTranslate() )
+        if ( !$contentObjectAttribute->contentClassAttributeCanTranslate() )
         {
-             $obj->removeContentObjectRelation( false, $contentObjectVersion, $contentClassAttributeID, eZContentObject::RELATION_ATTRIBUTE );
+            $contentObject->removeContentObjectRelation( false, $contentObjectVersion, $contentClassAttributeID, eZContentObject::RELATION_ATTRIBUTE );
         }
 
         foreach( $content['relation_list'] as $relationItem )
@@ -462,7 +451,7 @@ class eZObjectRelationListType extends eZDataType
                 }
             }
         }
-        return $this->storeObjectAttributeContent( $attribute, $content );
+        return $this->storeObjectAttributeContent( $contentObjectAttribute, $content );
     }
 
     function onPublish( $contentObjectAttribute, $contentObject, $publishedNodes )


### PR DESCRIPTION
> Issue: https://jira.ez.no/browse/EZP-27746

### Summary:

When editing (translatable) relation(s), only the relations for the published versions (of any language) should remain in the object relations table.

### Contains fixes for:
- [EZP-25396](https://jira.ez.no/browse/EZP-25396): Clean obsolete object relations (list) on publish
- [EZP-25848](https://jira.ez.no/browse/EZP-25848): PostgreSQL regression in objectrelation/list
- [EZP-27493](https://jira.ez.no/browse/EZP-27493): Typos in eZObjectRelation[List]Type