### PR TITLE
Fix EZP-27814: Support MySQL error codes in DB exceptions

### DIFF
--- a/kernel/private/classes/exceptions/database/exception.php
+++ b/kernel/private/classes/exceptions/database/exception.php
@@ -17,5 +17,30 @@
  */
 class eZDBException extends ezcBaseException
 {
+    /**
+     * Original message, before escaping
+     */
+    public $originalMessage;
+
+    /**
+     * Constructs a new eZDBException with $message and $code
+     *
+     * @param string $message
+     * @param int $code
+     */
+    public function __construct( $message, $code = 0 )
+    {
+        $this->originalMessage = $message;
+        $this->code = $code;
+
+        if ( php_sapi_name() == 'cli' )
+        {
+            $this->message = $message;
+        }
+        else
+        {
+            $this->message = htmlspecialchars( $message, ENT_QUOTES, 'UTF-8' );
+        }
+    }
 }
 ?>

--- a/lib/ezdb/classes/ezmysqlidb.php
+++ b/lib/ezdb/classes/ezmysqlidb.php
@@ -402,7 +402,8 @@ class eZMySQLiDB extends eZDBInterface
             }
             else
             {
-                $errorMessage = 'Query error (' . mysqli_errno( $connection ) . '): ' . mysqli_error( $connection ) . '. Query: ' . $sql;
+                $this->setError();
+                $errorMessage = 'Query error (' . $this->ErrorNumber . '): ' . $this->ErrorMessage . '. Query: ' . $sql;
                 eZDebug::writeError( $errorMessage, __CLASS__  );
                 $oldRecordError = $this->RecordError;
                 // Turn off error handling while we unlock


### PR DESCRIPTION
Bug report: https://jira.ez.no/browse/EZP-27814

Since eZ Publish 4.5, we can catch DB exceptions: https://github.com/ezsystems/ezpublish-legacy/blob/master/doc/features/4.5/ezdb_exception_based_error_handling.txt

However, the error code in the DB exception is always 0. This pull request logs the MySQL error code in the exception code so that you can specifically catch error codes (such as deadlocks) and act accordingly (such as retrying the transaction).

One of the reasons this is important is that the legacy API is prone to DB deadlock errors on concurrent object creation.

You can reproduce this quite easily by running multiple versions of this script at the same time:

```
<?php
for( $i = 0; $i < 100; ++$i )
{
    $params = array();
    $params['class_identifier'] = 'folder';
    $params['parent_node_id'] = 62;
    $params['attributes'] = array( 'name' => 'Test folder script 1' );
 
    $contentObject = eZContentFunctions::createAndPublishObject( $params );
}
```

By adding the DB exception code, we can catch a deadlock error and retry the creation rather than having the script crash.