### PR TITLE
Fix EZP-28165: Incorrect increment of object_count in ezsearch_word

### DIFF
--- a/kernel/search/plugins/ezsearchengine/ezsearchengine.php
+++ b/kernel/search/plugins/ezsearchengine/ezsearchengine.php
@@ -168,7 +168,6 @@ class eZSearchEngine implements ezpSearchEngine
         $trans = eZCharTransform::instance();
 
         $wordCount = count( $indexArrayOnlyWords );
-        $wordIDArray = array();
         $wordArray = array();
         // store the words in the index and remember the ID
         $dbName = $db->databaseName();
@@ -185,16 +184,17 @@ class eZSearchEngine implements ezpSearchEngine
                 // Build a has of the existing words
                 $wordResCount = count( $wordRes );
                 $existingWordArray = array();
+                $wordIDArrayChuck = array();
                 for ( $i = 0; $i < $wordResCount; $i++ )
                 {
-                    $wordIDArray[] = $wordRes[$i]['id'];
+                    $wordIDArrayChuck[] = $wordRes[$i]['id'];
                     $existingWordArray[] = $wordRes[$i]['word'];
                     $wordArray[$wordRes[$i]['word']] = $wordRes[$i]['id'];
                 }
 
                 // Update the object count of existing words by one
-                $wordIDString = implode( ',', $wordIDArray );
-                if ( count( $wordIDArray ) > 0 )
+                $wordIDString = implode( ',', $wordIDArrayChuck );
+                if ( count( $wordIDArrayChuck ) > 0 )
                     $db->query( "UPDATE ezsearch_word SET object_count=( object_count + 1 ) WHERE id IN ( $wordIDString )" );
 
                 // Insert if there is any news words

--- a/kernel/search/plugins/ezsearchengine/ezsearchengine.php
+++ b/kernel/search/plugins/ezsearchengine/ezsearchengine.php
@@ -184,17 +184,17 @@ class eZSearchEngine implements ezpSearchEngine
                 // Build a has of the existing words
                 $wordResCount = count( $wordRes );
                 $existingWordArray = array();
-                $wordIDArrayChuck = array();
+                $wordIDArray = array();
                 for ( $i = 0; $i < $wordResCount; $i++ )
                 {
-                    $wordIDArrayChuck[] = $wordRes[$i]['id'];
+                    $wordIDArray[] = $wordRes[$i]['id'];
                     $existingWordArray[] = $wordRes[$i]['word'];
                     $wordArray[$wordRes[$i]['word']] = $wordRes[$i]['id'];
                 }
 
                 // Update the object count of existing words by one
-                $wordIDString = implode( ',', $wordIDArrayChuck );
-                if ( count( $wordIDArrayChuck ) > 0 )
+                $wordIDString = implode( ',', $wordIDArray );
+                if ( count( $wordIDArray ) > 0 )
                     $db->query( "UPDATE ezsearch_word SET object_count=( object_count + 1 ) WHERE id IN ( $wordIDString )" );
 
                 // Insert if there is any news words


### PR DESCRIPTION
When updating object_count in ezsearch_word, eZSearchEngine splits the list of words in chunks of 500. But in every cycle of the loop not only the current chunk but all of the previous chunks are incremented. Which means that if there are, lets say 3 chunks, the first chunk gets an increment of +3, the second of +2, and the third of +1.

Steps to reproduce:
1. Create a new object with an attribute that has (plenty) more than 500 indexable words.
2. Pick any word that is mentioned at the beginning of that attribute.
3. Publish the object
4. Find that word in ezsearch_word and watch the object_count value.
5. Edit the object created in step 1 and publish it without modifying it.
6. Find again the word in ezsearch_word and watch the object_count value.

Result:
The object_count has a larger value than it should.

Fix:
Simply move `$wordIDArray` from outside the `for` to inside, so that it is reset on every loop. I also renamed the variable to `$wordIDArrayChuck`, to make it consistent with `$wordArrayChuck`, but that's not necessary.