### PR TITLE
[Composer] Avoid conflict with dev-master of kernel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
         "zetacomponents/php-generator": "~1.1"
     },
     "conflict": {
-        "ezsystems/ezpublish-kernel": "<6.11@dev || >=2014.11"
+        "ezsystems/ezpublish-kernel": "<6.11 || >=2014.11"
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
         "zetacomponents/php-generator": "~1.1"
     },
     "conflict": {
-        "ezsystems/ezpublish-kernel": "<6.11 || >=2014.11"
+        "ezsystems/ezpublish-kernel": "<6.11 || >=2014.11 <2017.08"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Because of bug in composer (composer/composer#5505), where alias of dev-master _(and possible other dev branches)_ is not resolved on `conflicts` statements, we need to keep the comparison here under dev-master version number (9999999-dev).

Upper bound could have been set to 9999, but in case of future community releases of kernel, opted for 2017.08 which means 6.11 here.