### PR TITLE
EZP-27993: Support quality override by image alias

### DIFF
--- a/settings/image.ini
+++ b/settings/image.ini
@@ -76,6 +76,11 @@ AliasList[]=rss
 # to use image/jpeg for screenshot but rather image/png or image/gif.
 # MIMEType=image/png
 #
+# Override quality by MIME type for this alias only
+# This follows the pattern from the global [MIMETypeSettings] settings 
+# Quality[]
+# Quality[]=image/jpeg;80
+#
 # A list of filters to run, each filter must be supported by the active image converters
 # Filters[]=geometry/scale=300;300
 


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-27993

In eZ Publish legacy, we can set a global image quality in image.ini, but cannot override this per alias.
This is the reverse problem as eZ Platform / new stack, where you can set the quality by alias but cannot set a global value (https://github.com/liip/LiipImagineBundle/pull/909).

This way, you can set something like this in image.ini to override the global setting:

```
[medium]
Quality[]
Quality[]=image/jpeg;80
```