### PR TITLE
EZP-28010: Update password hash type to current default when changing the user password

### DIFF
--- a/kernel/user/ezuseroperationcollection.php
+++ b/kernel/user/ezuseroperationcollection.php
@@ -311,10 +311,11 @@ class eZUserOperationCollection
         if ( $user instanceof eZUser )
         {
             $login   = $user->attribute( 'login' );
-            $type    = $user->attribute( 'password_hash_type' );
+            $type    = eZUser::hashType();
             $site    = $user->site();
             $newHash = $user->createHash( $login, $newPassword, $site, $type );
             $user->setAttribute( 'password_hash', $newHash );
+            $user->setAttribute( 'password_hash_type', $type );
             $user->store();
 
             // "Draft" must be in sync with the PersistentObject


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-28010

Now that #1322 is implemented, it would be wise to update the hash to the new default whenever a user changes the password.