### PR TITLE
Making the constructor parameter $row optional

### DIFF
--- a/kernel/classes/ezpersistentobject.php
+++ b/kernel/classes/ezpersistentobject.php
@@ -49,7 +49,7 @@ class eZPersistentObject
      *
      * @param int|array $row
      */
-    public function __construct( $row )
+    public function __construct( $row = null )
     {
         $this->PersistentDataDirty = false;
         if ( is_numeric( $row ) )
@@ -59,9 +59,9 @@ class eZPersistentObject
 
     /**
      * @deprecated Use eZPersistentObject::__construct() instead
-     * @param array $row
+     * @param int|array $row
      */
-    public function eZPersistentObject( $row )
+    public function eZPersistentObject( $row = null )
     {
         self::__construct( $row );
     }


### PR DESCRIPTION
That's another issue caused by
https://github.com/ezsystems/ezpublish-legacy/pull/1233

It will avoid warnings like:

```Unexpected error, the message was : Too few arguments to function eZPersistentObject::__construct(), 0 passed in /var/www/website/kernel/content/versionview.php on line 191 and exactly 1 expected in /var/www/website/kernel/classes/ezpersistentobject.php on line 52```

It will allow to initiate eZPersistentObjects without any $row values. For example:
https://github.com/mugoweb/ezpublish-legacy/blob/master/kernel/content/versionview.php#L191

*Reproduce the issue*
In the admin interface, go to a versionview page. For example under the 'Manage versions' screen.
