### PR TITLE
datetime.ini: Inline doc added. Better examples

### DIFF
--- a/settings/datetime.ini
+++ b/settings/datetime.ini
@@ -46,6 +46,7 @@
 
 [ClassSettings]
 Formats[]
+Formats[all]=%a, %A, %d, %D, %F, %g, %G, %h, %H, %i, %j, %l, %m, %M, %n, %O, %s, %T, %U, %w, %W, %Y, %y, %z, %Z, %r, %c
 
 Formats[short_date]=%j.%n.%Y
 Formats[long_date]=%j %F %Y

--- a/settings/datetime.ini
+++ b/settings/datetime.ini
@@ -1,14 +1,56 @@
 #?ini charset="utf-8"?
 # eZ Publish configuration file for date and time handling.
 #
-# NOTE: It is not recommended to edit this files directly, instead
-#       a file in override should be created for setting the
-#       values that is required for your site. Either create
-#       a file called settings/override/datetime.ini.append or
-#       settings/override/datetime.ini.append.php for more security
-#       in non-virtualhost modes (the .php file may already be present
-#       and can be used for this purpose).
+# NOTE:  It is not recommended to edit this files directly, instead
+#        a file in override should be created for setting the
+#        values that is required for your site. Either create
+#        a file called settings/override/datetime.ini.append or
+#        settings/override/datetime.ini.append.php for more security
+#        in non-virtualhost modes (the .php file may already be present
+#        and can be used for this purpose).
+
+#  Element    Example                          Description
+#  -------    -------                          -----------
+#  %a         am                               Lowercase Ante meridiem and Post meridiem.
+#  %A         AM                               Uppercase Ante meridiem and Post meridiem.
+#  %c         2004-02-12T15:19:21+00:00        ISO 8601 date
+#  %d         08                               Day of the month, 2 digits with leading zeros.
+#  %D         Wed                              A short textual representation of a day, in accordance
+#                                              with the "[ShortDayNames]" section of the language .INI file
+#                                              located in the "share/locale" directory.
+#  %F         October                          A full textual representation of a month, such as January or March.
+#  %g         12                               12-hour format of an hour without leading zeros.
+#  %G         3                                24-hour format of an hour without leading zeros.
+#  %h         12                               12-hour format of an hour with leading zeros.
+#  %H         03                               24-hour format of an hour with leading zeros.
+#  %i         00                               Minutes with leading zeros
+#  %j         8                                Day of the month without leading zeros
+#  %l         Wednesday                        A full textual representation of the day of the week.
+#  %m         10                               Numeric representation of a month, with leading zeros.
+#  %M         Oct                              A short textual representation of a month, in accordance
+#                                              with the "[ShortMonthNames]" section of the language .INI file located
+#                                              in the "share/locale" directory.
+#  %n         10                               Numeric representation of a month, without leading zeros.
+#  %O         -0500                            Difference to Greenwich time (GMT) in hours.
+#  %r         Thu, 21 Dec 2000 16:01:07 +0200  RFC 2822 formatted date
+#  %s         00                               Seconds, with leading zeros.
+#  %T         CDT                              Timezone setting of this machine.
+#  %U         1065589200                       Seconds since the Unix Epoch (January 1 1970 00:00:00 GMT).
+#  %w         3                                Numeric representation of the day of the week.
+#  %W         41                               ISO-8601 week number of year, weeks starting on Monday.
+#  %Y         2003                             A full numeric representation of a year, 4 digits.
+#  %y         03                               A two digit representation of a year.
+#  %z         280                              The day of the year.
+#  %Z         -18000                           Timezone offset in seconds. The offset for timezones west of UTC is
+#                                              always negative, and for those east of UTC is always positive.
 
 [ClassSettings]
 Formats[]
-Formats[all]=%a, %A, %d, %D, %F, %g, %G, %h, %H, %i, %j, %l, %m, %M, %n, %O, %s, %T, %U, %w, %W, %Y, %y, %z, %Z, %r, %c
+
+Formats[short_date]=%j.%n.%Y
+Formats[long_date]=%j %F %Y
+
+Formats[short_date_usa]=%n/%j/%Y
+
+Formats[time_12]=%h:%i:%s %a
+Formats[time_24]=%H:%i:%s

--- a/settings/datetime.ini
+++ b/settings/datetime.ini
@@ -1,9 +1,9 @@
 #?ini charset="utf-8"?
 # eZ Publish configuration file for date and time handling.
 #
-# NOTE:  It is not recommended to edit this files directly, instead
+# NOTE:  It is not recommended to edit this file directly, instead
 #        a file in override should be created for setting the
-#        values that is required for your site. Either create
+#        values that are required for your site. Either create
 #        a file called settings/override/datetime.ini.append or
 #        settings/override/datetime.ini.append.php for more security
 #        in non-virtualhost modes (the .php file may already be present


### PR DESCRIPTION
I copied the documentation from the ez site into the ini file. Additionally I added a few more useful examples for dates and times.
