### PR TITLE
EZP-28174: Improved error message when target of eznode:// and ezobject:// links doesn't exist

### DIFF
--- a/extension/ezoe/ezxmltext/handlers/input/ezoeinputparser.php
+++ b/extension/ezoe/ezxmltext/handlers/input/ezoeinputparser.php
@@ -1250,9 +1250,9 @@ class eZOEInputParser extends eZXMLInputParser
                 if ( !eZContentObject::exists( $objectID ))
                 {
                     $this->Messages[] = ezpI18n::tr( 'design/standard/ezoe/handler',
-                                                'Object %1 does not exist.',
+                                                'Invalid link: "%1". Target object does not exist.',
                                                 false,
-                                                array( $objectID ) );
+                                                array( $matches[0] ) );
                 }
             }
             /*
@@ -1273,9 +1273,9 @@ class eZOEInputParser extends eZXMLInputParser
                     if ( !$node instanceOf eZContentObjectTreeNode )
                     {
                         $this->Messages[] = ezpI18n::tr( 'design/standard/ezoe/handler',
-                                                    'Node %1 does not exist.',
+                                                    'Invalid link: "%1". Target node does not exist.',
                                                     false,
-                                                    array( $nodeID ) );
+                                                    array( $matches[0] ) );
                     }
                 }
                 else
@@ -1284,9 +1284,9 @@ class eZOEInputParser extends eZXMLInputParser
                     if ( !$node instanceOf eZContentObjectTreeNode )
                     {
                         $this->Messages[] = ezpI18n::tr( 'design/standard/ezoe/handler',
-                                                    'Node &apos;%1&apos; does not exist.',
+                                                    'Invalid link: "%1". Target node does not exist.',
                                                     false,
-                                                    array( $nodePath ) );
+                                                    array( $matches[0] ) );
                     }
                     else
                     {


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28174

# Description 

This PR improves an error message when target of `eznode://` and `ezobject://` links don't exist.

![zrzut ekranu 2017-11-29 o 12 45 54](https://user-images.githubusercontent.com/211967/33373723-790c1242-d503-11e7-9b0c-6c3fc48477b9.png)
