### PR TITLE
Add compat layer for constructor for eZSiteInstaller

### DIFF
--- a/kernel/classes/ezsiteinstaller.php
+++ b/kernel/classes/ezsiteinstaller.php
@@ -39,7 +39,7 @@ class eZSiteInstaller
      */
     public function eZSiteInstaller( $parameters = false )
     {
-        self::__construct( $row );
+        self::__construct( $parameters );
     }
 
     function &instance( $params )

--- a/kernel/classes/ezsiteinstaller.php
+++ b/kernel/classes/ezsiteinstaller.php
@@ -37,7 +37,7 @@ class eZSiteInstaller
      * @deprecated Use eZSiteInstaller::__construct() instead
      * @param bool $parameters
      */
-    public function eZSiteInstaller( $parameters = false )
+    function eZSiteInstaller( $parameters = false )
     {
         self::__construct( $parameters );
     }

--- a/kernel/classes/ezsiteinstaller.php
+++ b/kernel/classes/ezsiteinstaller.php
@@ -33,6 +33,15 @@ class eZSiteInstaller
         $this->LastErrorCode = eZSiteInstaller::ERR_OK;
     }
 
+    /**
+     * @deprecated Use eZSiteInstaller::__construct() instead
+     * @param bool $parameters
+     */
+    public function eZSiteInstaller( $parameters = false )
+    {
+        self::__construct( $row );
+    }
+
     function &instance( $params )
     {
         eZDebug::writeWarning( "Your installer doesn't implement 'instance' function", __METHOD__ );


### PR DESCRIPTION
> Regression from #1233

Given this is used by existing packages we need to make sure it still works with old style.