### PR TITLE
Fix warning on counting NULL in PHP 7.2

### DIFF
--- a/kernel/classes/ezscript.php
+++ b/kernel/classes/ezscript.php
@@ -1072,7 +1072,7 @@ class eZScript
                 $this->setUseIncludeFiles( $useIncludeFiles );
                 $this->setDebugMessage( "\n\n" . str_repeat( '#', 36 ) . $cli->style( 'emphasize' ) . " DEBUG " . $cli->style( 'emphasize-end' )  . str_repeat( '#', 36 ) . "\n" );
             }
-            if ( count( $options['verbose'] ) > 0 )
+            if ( is_array( $options['verbose'] ) && count( $options['verbose'] ) > 0 )
             {
                 $this->setShowVerboseOutput( count( $options['verbose'] ) );
             }


### PR DESCRIPTION
Happens when running scripts:

```
eddie@abyss [~/www/ezpublish_legacy] ( ± master ) $ php bin/php/flatten.php all
PHP Warning:  count(): Parameter must be an array or an object that implements Countable in /media/eddie/data/html/ezpublish_legacy/kernel/classes/ezscript.php on line 1075
```

I'm sure there are more places where this happens, too :)