### PR TITLE
EZP-28404: Execution of "Approve" workflow event type doesn't clear SPI cache

### DIFF
--- a/kernel/classes/workflowtypes/event/ezapprove/ezapprovetype.php
+++ b/kernel/classes/workflowtypes/event/ezapprove/ezapprovetype.php
@@ -772,6 +772,12 @@ class eZApproveType extends eZWorkflowEventType
             $status = eZWorkflowType::STATUS_WORKFLOW_CANCELLED;
         }
         $contentObjectVersion->sync();
+
+        ezpEvent::getInstance()->notify(
+            'content/cache/version',
+            array( $contentObjectVersion->attribute( 'contentobject_id' ), $contentObjectVersion->attribute( 'version' ) )
+        );
+
         if ( $approvalStatus != eZApproveCollaborationHandler::STATUS_DEFERRED )
             $db->query( 'DELETE FROM ezapprove_items WHERE workflow_process_id = ' . $process->attribute( 'id' )  );
         return $status;


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28404

## Description 

This PR adds a missing dispatching of `content/cache/version` event after execution of "Approve" workflow event type. Without it, SPI cache in PAPI is out of date after workflow execution, which is cause issues described in JIRA issue. 