### PR TITLE
Fix EZP-28750: Draft preview displays wrong Version information

### DIFF
--- a/design/admin/templates/content/parts/object_information.tpl
+++ b/design/admin/templates/content/parts/object_information.tpl
@@ -30,9 +30,9 @@
 <label>{'Modified'|i18n( 'design/admin/content/history' )}:</label>
 {if $object.modified}
 {$object.modified|l10n( shortdatetime )}<br />
-{foreach $object.versions as $version}
-{if eq($version.version, $object.published_version)}
-{$version.creator.name|wash}
+{foreach $object.versions as $tmp_version}
+{if eq($tmp_version.version, $object.published_version)}
+{$tmp_version.creator.name|wash}
 {break}
 {/if}
 {/foreach}


### PR DESCRIPTION
> JIRA ticket: [EZP-28750](https://jira.ez.no/browse/EZP-28750)

Excerpt from JIRA:
> When trying to access preview for a draft, the "Version information" section contains information about the last published version (instead of the draft that is being previewed). Additionally, the "Back to edit" and "Publish" buttons are disabled.

The issue was introduced in https://github.com/ezsystems/ezpublish-legacy/pull/1296.
It turns out that `$version` variable is used by other templates and it shouldn't be changed, so I renamed it to something more temporary.