### PR TITLE
EZP-28736: SPI cache not cleared when a content is published via a delayed publication workflow

### DIFF
--- a/kernel/classes/ezcontentcachemanager.php
+++ b/kernel/classes/ezcontentcachemanager.php
@@ -696,7 +696,7 @@ class eZContentCacheManager
 
         eZDebug::accumulatorStop( 'node_cleanup_list' );
 
-        return self::clearNodeViewCacheArray( $nodeList );
+        return self::clearNodeViewCacheArray( $nodeList, array( $objectID ) );
     }
 
     /**
@@ -728,16 +728,17 @@ class eZContentCacheManager
 
         eZDebug::accumulatorStop( 'node_cleanup_list' );
 
-        return self::clearNodeViewCacheArray( $nodeList );
+        return self::clearNodeViewCacheArray( $nodeList, $objectIDList );
     }
 
     /**
      * Clears view caches for an array of nodes.
      *
      * @param  array   $nodeList List of node IDs to clear
+     * @param  array|null   $contentObjectList List of content object IDs to clear
      * @return boolean returns true on success
      */
-    public static function clearNodeViewCacheArray( array $nodeList )
+    public static function clearNodeViewCacheArray( array $nodeList, array $contentObjectList = null )
     {
         if ( count( $nodeList ) == 0 )
         {
@@ -769,7 +770,7 @@ class eZContentCacheManager
 
         if ( eZContentCache::inCleanupThresholdRange( $cleanupValue ) )
         {
-            $nodeList = ezpEvent::getInstance()->filter( 'content/cache', $nodeList );
+            $nodeList = ezpEvent::getInstance()->filter( 'content/cache', $nodeList, $contentObjectList );
             eZContentCache::cleanup( $nodeList );
         }
         else

--- a/kernel/content/ezcontentoperationcollection.php
+++ b/kernel/content/ezcontentoperationcollection.php
@@ -905,7 +905,7 @@ class eZContentOperationCollection
         }
 
         // Triggering content/cache filter for Http cache purge
-        ezpEvent::getInstance()->filter( 'content/cache', $removeNodeIdList );
+        ezpEvent::getInstance()->filter( 'content/cache', $removeNodeIdList, array_keys( $objectIdList ) );
         // we don't clear template block cache here since it's cleared in eZContentObjectTreeNode::removeNode()
 
         return array( 'status' => true );


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28404
> Depends on https://github.com/ezsystems/LegacyBridge/pull/140

## Description

This PR adjusts legacy to the changes are introduced in https://github.com/ezsystems/LegacyBridge/pull/140 (see for more details). 

- [X] `ezcontentcachemanager::clearNodeViewCacheArray`
- [x] `eZContentOperationCollection::removeNodes`

