### PR TITLE
Typo in variable name results in PHP Notice and unneeded file deletion checks on ezbinaryfile store/publish.

### DIFF
--- a/kernel/classes/datatypes/ezbinaryfile/ezbinaryfiletype.php
+++ b/kernel/classes/datatypes/ezbinaryfile/ezbinaryfiletype.php
@@ -332,8 +332,8 @@ class eZBinaryFileType extends eZDataType
             else
             {
                 // if storing a different file for the same version, see if the existing file can be removed.
-                $newfilename = basename( $httpBinaryFile->attribute( "filename" ) );
-                if ( $newFilename != $binary->Filename )
+                $newFileName = basename( $httpBinaryFile->attribute( "filename" ) );
+                if ( $newFileName != $binary->Filename )
                 {
                     $this->deleteStoredObjectAttribute( $contentObjectAttribute, $version );
                 }


### PR DESCRIPTION
Messes up the error.log on every store/publish action with any contenttype including ezbinaryfile.

Additionally does some unneeded checks for removing the binary file, but that is rather theoretically.

Aligned the new variable name with the one above.