### PR TITLE
[WIP] Testing filter_input() on ezurloperator

### DIFF
--- a/kernel/common/ezurloperator.php
+++ b/kernel/common/ezurloperator.php
@@ -796,7 +796,7 @@ CODEPIECE;
                         case eZURLOperator::HTTP_OPERATOR_TYPE_POST:
                         {
                             if ( $http->hasPostVariable( $httpName ) )
-                                $operatorValue = !$checkExistence ? $http->postVariable( $httpName ) : true;
+                                $operatorValue = !$checkExistence ? filter_input(INPUT_POST, $httpName, FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_LOW|FILTER_FLAG_NO_ENCODE_QUOTES) : true;
                             else
                             {
                                 // If only check for existence - return false
@@ -811,7 +811,7 @@ CODEPIECE;
                         case eZURLOperator::HTTP_OPERATOR_TYPE_GET:
                         {
                             if ( $http->hasGetVariable( $httpName ) )
-                                $operatorValue = !$checkExistence ? $http->getVariable( $httpName ) : true;
+                                $operatorValue = !$checkExistence ? filter_input(INPUT_GET, $httpName, FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_LOW|FILTER_FLAG_NO_ENCODE_QUOTES) : true;
                             else
                             {
                                 if ( $checkExistence )
@@ -848,7 +848,7 @@ CODEPIECE;
                         case eZURLOperator::HTTP_OPERATOR_TYPE_COOKIE:
                         {
                             if ( array_key_exists( $httpName, $_COOKIE ) )
-                                $operatorValue = !$checkExistence ? $_COOKIE[$httpName] : true;
+                                $operatorValue = !$checkExistence ? filter_input(INPUT_COOKIE, $httpName, FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_LOW|FILTER_FLAG_NO_ENCODE_QUOTES) : true;
                             else
                             {
                                 if ( $checkExistence )

--- a/kernel/common/ezurloperator.php
+++ b/kernel/common/ezurloperator.php
@@ -796,7 +796,7 @@ CODEPIECE;
                         case eZURLOperator::HTTP_OPERATOR_TYPE_POST:
                         {
                             if ( $http->hasPostVariable( $httpName ) )
-                                $operatorValue = !$checkExistence ? filter_input(INPUT_POST, $httpName, FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_LOW|FILTER_FLAG_NO_ENCODE_QUOTES) : true;
+                                $operatorValue = !$checkExistence ? filter_var($http->postVariable( $httpName ), FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_LOW|FILTER_FLAG_NO_ENCODE_QUOTES) : true;
                             else
                             {
                                 // If only check for existence - return false
@@ -811,7 +811,7 @@ CODEPIECE;
                         case eZURLOperator::HTTP_OPERATOR_TYPE_GET:
                         {
                             if ( $http->hasGetVariable( $httpName ) )
-                                $operatorValue = !$checkExistence ? filter_input(INPUT_GET, $httpName, FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_LOW|FILTER_FLAG_NO_ENCODE_QUOTES) : true;
+                                $operatorValue = !$checkExistence ? filter_var($http->getVariable( $httpName ), FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_LOW|FILTER_FLAG_NO_ENCODE_QUOTES) : true;
                             else
                             {
                                 if ( $checkExistence )
@@ -848,7 +848,7 @@ CODEPIECE;
                         case eZURLOperator::HTTP_OPERATOR_TYPE_COOKIE:
                         {
                             if ( array_key_exists( $httpName, $_COOKIE ) )
-                                $operatorValue = !$checkExistence ? filter_input(INPUT_COOKIE, $httpName, FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_LOW|FILTER_FLAG_NO_ENCODE_QUOTES) : true;
+                                $operatorValue = !$checkExistence ? filter_var($_COOKIE[$httpName], FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_LOW|FILTER_FLAG_NO_ENCODE_QUOTES) : true;
                             else
                             {
                                 if ( $checkExistence )


### PR DESCRIPTION
> Work in progress

Can we make the `ezhttp` operator safer by default without breaking BC?

Should improve the test to show what is being stripped.
```
$_COOKIE['foo'] = '!b.&>;\/(#$A"snæfø</p>tag<snafu';
print( $_COOKIE['foo'] . "\n" );
print( filter_var($_COOKIE['foo'], FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_LOW|FILTER_FLAG_NO_ENCODE_QUOTES) . "\n" );
```
Results in
```
!b.&>;\/(#$A"snæfø</p>tag<snafu
!b.&>;\/(#$A"snæføtag
```