### PR TITLE
Prevent fatal error

### DIFF
--- a/kernel/content/ezcontentoperationcollection.php
+++ b/kernel/content/ezcontentoperationcollection.php
@@ -128,6 +128,9 @@ class eZContentOperationCollection
     static public function setVersionStatus( $objectID, $versionNum, $status )
     {
         $object = eZContentObject::fetch( $objectID );
+        if (!$object) {
+            return;
+        }
 
         if ( !$versionNum )
         {


### PR DESCRIPTION
Under certain instances it can happen, that there is no contentobject with this id. In this case the setversionstatus would result in errors like 
`Fatal error: Call to a member function version() on null in /var/www/ezpublish_legacy/kernel/content/ezcontentoperationcollection.php on line 136`

Maybe some more work should be done here to check, why this function is called with a wrong objectId