### PR TITLE
EZP-28881: Add a field to support "date object was trashed"

### DIFF
--- a/bin/php/trashpurge.php
+++ b/bin/php/trashpurge.php
@@ -27,12 +27,13 @@ $script = eZScript::instance(
 $script->startup();
 
 $options = $script->getOptions(
-    "[iteration-sleep:][iteration-limit:][memory-monitoring]",
+    "[iteration-sleep:][iteration-limit:][memory-monitoring][trashed-days:]",
     "",
     array(
         'iteration-sleep' => 'Amount of seconds to sleep between each iteration when performing a purge operation, can be a float. Default is one second.',
         'iteration-limit' => 'Amount of items to remove in each iteration when performing a purge operation. Default is 100.',
-        'memory-monitoring' => 'If set, memory usage will be logged in var/log/trashpurge.log.'
+        'memory-monitoring' => 'If set, memory usage will be logged in var/log/trashpurge.log.',
+        'trashed-days'      => 'If set, only objects that has been trashed for at least the specified amount of days will be purged.'
     )
 );
 
@@ -45,7 +46,8 @@ $purgeHandler = new eZScriptTrashPurge( eZCLI::instance(), false, (bool)$options
 if (
     $purgeHandler->run(
         $options['iteration-limit'] ? (int)$options['iteration-limit'] : null,
-        $options['iteration-sleep'] ? (int)$options['iteration-sleep'] : null
+        $options['iteration-sleep'] ? (int)$options['iteration-sleep'] : null,
+        $options['trashed-days']    ? strtotime( "-{$options['trashed-days']} days" ) : null
     )
 )
 {

--- a/kernel/classes/ezcontentobjecttrashnode.php
+++ b/kernel/classes/ezcontentobjecttrashnode.php
@@ -80,6 +80,10 @@ class eZContentObjectTrashNode extends eZContentObjectTreeNode
                                          'is_invisible' => array( 'name' => 'IsInvisible',
                                                                   'datatype' => 'integer',
                                                                   'default' => 0,
+                                                                  'required' => true ),
+                                         'trashed' => array( 'name' => 'Trashed',
+                                                                  'datatype' => 'integer',
+                                                                  'default' => 0,
                                                                   'required' => true )
                                           ),
 
@@ -130,7 +134,8 @@ class eZContentObjectTrashNode extends eZContentObjectTreeNode
                       'path_identification_string' => $node->attribute( 'path_identification_string' ),
                       'remote_id' => $node->attribute( 'remote_id' ),
                       'is_hidden' => $node->attribute( 'is_hidden' ),
-                      'is_invisible' => $node->attribute( 'is_invisible' ) );
+                      'is_invisible' => $node->attribute( 'is_invisible' ),
+                      'trashed' => time() );
 
         $trashNode = new eZContentObjectTrashNode( $row );
         return $trashNode;
@@ -207,6 +212,7 @@ class eZContentObjectTrashNode extends eZContentObjectTreeNode
                              'Limit'                    => false,
                              'SortBy'                   => false,
                              'AttributeFilter'          => false,
+                             'Trashed'                  => false,
                              );
         }
 
@@ -215,6 +221,7 @@ class eZContentObjectTrashNode extends eZContentObjectTreeNode
         $asObject         = ( isset( $params['AsObject']          ) )                         ? $params['AsObject']           : true;
         $objectNameFilter = ( isset( $params['ObjectNameFilter']  ) )                         ? $params['ObjectNameFilter']   : false;
         $sortBy           = ( isset( $params['SortBy']  ) && is_array( $params['SortBy']  ) ) ? $params['SortBy']              : array( array( 'name' ) );
+        $trashed          = ( isset( $params['Trashed']  ) && is_int( $params['Trashed'] )  ) ? " AND trashed <= {$params['Trashed']}"   : '';
 
         if ( $asCount )
         {
@@ -269,7 +276,8 @@ class eZContentObjectTrashNode extends eZContentObjectTreeNode
                         " . eZContentLanguage::sqlFilter( 'ezcontentobject_name', 'ezcontentobject' ) . "
                         $sqlPermissionChecking[where]
                         $objectNameFilterSQL
-                        AND " . eZContentLanguage::languagesSQLFilter( 'ezcontentobject' );
+                        AND " . eZContentLanguage::languagesSQLFilter( 'ezcontentobject' )
+                        . $trashed;
 
         if ( !$asCount && $sortingInfo['sortingFields'] && strlen( $sortingInfo['sortingFields'] ) > 5  )
             $query .= " ORDER BY $sortingInfo[sortingFields]";

--- a/kernel/sql/mysql/kernel_schema.sql
+++ b/kernel/sql/mysql/kernel_schema.sql
@@ -497,6 +497,7 @@ CREATE TABLE ezcontentobject_trash (
   remote_id varchar(100) NOT NULL default '',
   sort_field int(11) default '1',
   sort_order int(11) default '1',
+  trashed int(11) NOT NULL default '0',
   PRIMARY KEY  (node_id),
   KEY ezcobj_trash_co_id (contentobject_id),
   KEY ezcobj_trash_depth (depth),

--- a/kernel/sql/postgresql/kernel_schema.sql
+++ b/kernel/sql/postgresql/kernel_schema.sql
@@ -1650,7 +1650,8 @@ CREATE TABLE ezcontentobject_trash (
     priority integer DEFAULT 0 NOT NULL,
     remote_id character varying(100) DEFAULT ''::character varying NOT NULL,
     sort_field integer DEFAULT 1,
-    sort_order integer DEFAULT 1
+    sort_order integer DEFAULT 1,
+    trashed integer DEFAULT 0 NOT NULL
 );
 
 


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-28881

**Updated:** eZ Platform equivalent update: https://github.com/ezsystems/ezpublish-kernel/pull/2379

The eZ Publish trash can really fill and make it difficult to find something in the trash. It would be nice to be able to have a script that periodically clears out items that are older than "n days" (for example). In order to do this, we would need a field for objects in the trash that saves the "date object was trashed". It has been often requested by clients.

This pull request changes the eZContentObjectTrashNode so it stores the date the object has been trashed and then we can run the trashpurge script like:

php bin/php/trashpurge.php -s manage  --trashed-days=1

By default trashed days will be 0, so all content will be purged, if set, only objects that has been trashed for at least the specified amount of days will be purged.

For existing installations it is necessary to update the mysql table:

ALTER TABLE ezcontentobject_trash ADD trashed int(11) NOT NULL DEFAULT 0;

So, all existing trashed objects will have the trashed timestamp set to 0 and the script will be backcompatible.

SQL update has been added to https://github.com/ezsystems/ezpublish-kernel/pull/2261