### PR TITLE
Prevent ImagealiasHandler from storing invalid chars

### DIFF
--- a/kernel/classes/datatypes/ezimage/ezimagealiashandler.php
+++ b/kernel/classes/datatypes/ezimage/ezimagealiashandler.php
@@ -1451,6 +1451,13 @@ class eZImageAliasHandler
         $this->ContentObjectAttributeData['DataTypeCustom']['dom_tree'] = $domTree;
         $this->ContentObjectAttributeData['DataTypeCustom']['is_storage_required'] = false;
         $xmlString = $domTree->saveXML();
+
+        // Remove chars that are invalid for XML 1.0, see https://www.w3.org/TR/2008/REC-xml-20081126/#charsets
+        $xmlString = preg_replace(
+            '/[^\x{0009}\x{000A}\x{000D}\x{0020}-\x{D7FF}\x{E000}-\x{FFFD}\x{10000}-\x{10FFFF}]+/u', 
+            '', $xmlString
+        );
+
         $this->ContentObjectAttributeData['data_text'] = $xmlString;
 
         if ( $storeAttribute )


### PR DESCRIPTION
Some exif data may contain invalid chars which result in fatal errors when trying to update this content. This PR removes this chars and fixes this issue.

See as example the char at COMPUTED['UserComment']
![image](https://user-images.githubusercontent.com/4090694/36898459-358ee6aa-1e1b-11e8-9f6e-3b4a8347a5c0.png)

Without this fix `\eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\ImageConverter::parseLegacyXml`would run into this fatal error:

> Fatal error: Call to a member function hasAttribute() on null in /var/www/ez/source/ez-publish/vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/ImageConverter.php on line 189
