### PR TITLE
EZP-29021: User can't login using PASSWORD_HASH_MD5_PASSWORD

### DIFF
--- a/kernel/classes/datatypes/ezuser/ezuser.php
+++ b/kernel/classes/datatypes/ezuser/ezuser.php
@@ -1812,7 +1812,11 @@ WHERE user_id = '" . $userID . "' AND
         $password = self::trimAuthString( $password );
 
         $str = '';
-        if( $type == self::PASSWORD_HASH_MD5_USER )
+        if ( $type == self::PASSWORD_HASH_MD5_PASSWORD )
+        {
+            $str = md5( $password );
+        }
+        else if ( $type == self::PASSWORD_HASH_MD5_USER )
         {
             $str = md5( "$user\n$password" );
         }


### PR DESCRIPTION
> Fixes https://jira.ez.no/browse/EZP-29021
> QA

It seems the legacy part of https://jira.ez.no/browse/EZP-28214 broke `eZUser::PASSWORD_HASH_MD5_PASSWORD`. This fixes it.