### PR TITLE
EZP-29033: [Legacy] Don't remove links user has no access to

### DIFF
--- a/kernel/classes/datatypes/ezxmltext/handlers/output/ezxhtmlxmloutput.php
+++ b/kernel/classes/datatypes/ezxmltext/handlers/output/ezxhtmlxmloutput.php
@@ -187,6 +187,7 @@ class eZXHTMLXMLOutput extends eZXMLOutputHandler
     function initHandlerLink( $element, &$attributes, &$siblingParams, &$parentParams )
     {
         $ret = array();
+        $ezxmlIni = eZINI::instance('ezxml.ini');
 
         // Set link parameters for rendering children of link tag
         $href='';
@@ -206,7 +207,8 @@ class eZXHTMLXMLOutput extends eZXMLOutputHandler
                 $view = $element->getAttribute( 'view' );
                 if ( $view )
                     $href = 'content/view/' . $view . '/' . $nodeID;
-                else if ( !$node->object()->canRead() )
+                else if ( !$node->object()->canRead() &&
+                          $ezxmlIni->variable( 'ezxhtml', 'ShowURLAliasForProtectedLinks' ) !== 'enabled' )
                 {
                     eZDebug::writeWarning( "Current user does not have read access to the object of node #$nodeID",
                         'XML output handler: link' );
@@ -234,7 +236,8 @@ class eZXHTMLXMLOutput extends eZXMLOutputHandler
                     $view = $element->getAttribute( 'view' );
                     if ( $view )
                         $href = 'content/view/' . $view . '/' . $nodeID;
-                    else if ( !$object->canRead() )
+                    else if ( !$object->canRead() &&
+                              $ezxmlIni->variable( 'ezxhtml', 'ShowURLAliasForProtectedLinks' ) !== 'enabled' )
                     {
                         eZDebug::writeWarning( "Current user does not have read access to the object #$objectID",
                             'XML output handler: link' );

--- a/kernel/classes/datatypes/ezxmltext/handlers/output/ezxhtmlxmloutput.php
+++ b/kernel/classes/datatypes/ezxmltext/handlers/output/ezxhtmlxmloutput.php
@@ -203,16 +203,15 @@ class eZXHTMLXMLOutput extends eZXMLOutputHandler
 
             if ( $node != null )
             {
-                if ( !$node->object()->canRead() )
-                {
-                    eZDebug::writeWarning( "Current user does not have read access to the object of node #$nodeID",
-                        'XML output handler: link' );
-                    return $ret;
-                }
-
                 $view = $element->getAttribute( 'view' );
                 if ( $view )
                     $href = 'content/view/' . $view . '/' . $nodeID;
+                else if ( !$node->object()->canRead() )
+                {
+                    eZDebug::writeWarning( "Current user does not have read access to the object of node #$nodeID",
+                        'XML output handler: link' );
+                    $href = 'content/view/full/' . $nodeID;
+                }
                 else
                     $href = $node->attribute( 'url_alias' );
             }
@@ -227,13 +226,6 @@ class eZXHTMLXMLOutput extends eZXMLOutputHandler
             if ( isset( $this->ObjectArray["$objectID"] ) )
             {
                 $object = $this->ObjectArray["$objectID"];
-                if ( !$object->canRead() )
-                {
-                    eZDebug::writeWarning( "Current user does not have read access to the object #$objectID",
-                        'XML output handler: link' );
-                    return $ret;
-                }
-
                 $node = $object->attribute( 'main_node' );
                 if ( $node )
                 {
@@ -242,6 +234,12 @@ class eZXHTMLXMLOutput extends eZXMLOutputHandler
                     $view = $element->getAttribute( 'view' );
                     if ( $view )
                         $href = 'content/view/' . $view . '/' . $nodeID;
+                    else if ( !$object->canRead() )
+                    {
+                        eZDebug::writeWarning( "Current user does not have read access to the object #$objectID",
+                            'XML output handler: link' );
+                        $href = 'content/view/full/' . $nodeID;
+                    }
                     else
                         $href = $node->attribute( 'url_alias' );
                 }

--- a/settings/ezxml.ini
+++ b/settings/ezxml.ini
@@ -50,3 +50,6 @@ TagPresets[]
 # Determines to insert <p> tag inside a table cell in the output or not
 # if there is only one <paragraph> tag inside a cell.
 RenderParagraphInTableCells=enabled
+# Show URL alias for links the current user does not have read access to.
+# If disabled (recommended) the link will be /content/view/full/[nodeID] instead.
+ShowURLAliasForProtectedLinks=disabled


### PR DESCRIPTION
> Fix https://jira.ez.no/browse/EZP-29033
> QA

The security fix EZSA-2018-001 ensured that the names of protected content could not be leaked by making content/node links to it. The links would normally be rendered as URL aliases, which leaks the content name. After the fix, links are rendered empty, making them non-functional.

This fixes it: When the user doesn't have read access to the linked node/object, show a `/content/view/full/<nodeId>` link rather than nothing. So the link is functional, the user is told they don't have access, while not leaking the content name. This is the new default behaviour. You can set `ezxml.ini [ezxhtml] ShowURLAliasForProtectedLinks=enabled` to get the old, pre-security-fix behaviour (always URL alias).

This affects only eznode/ezobject links in XML text, not related objects.