### PR TITLE
EZP-29085: Force to use integer keys in eZXMLOutputHandler->NodeArray

### DIFF
--- a/kernel/classes/datatypes/ezxmltext/ezxmloutputhandler.php
+++ b/kernel/classes/datatypes/ezxmltext/ezxmloutputhandler.php
@@ -275,14 +275,14 @@ class eZXMLOutputHandler
                 foreach( $nodes as $node )
                 {
                     $nodeID = $node->attribute( 'node_id' );
-                    $this->NodeArray["$nodeID"] = $node;
+                    $this->NodeArray[$nodeID] = $node;
                 }
             }
             elseif ( $nodes )
             {
                 $node = $nodes;
                 $nodeID = $node->attribute( 'node_id' );
-                $this->NodeArray["$nodeID"] = $node;
+                $this->NodeArray[$nodeID] = $node;
             }
         }
     }

--- a/kernel/classes/datatypes/ezxmltext/handlers/output/ezxhtmlxmloutput.php
+++ b/kernel/classes/datatypes/ezxmltext/handlers/output/ezxhtmlxmloutput.php
@@ -198,7 +198,7 @@ class eZXHTMLXMLOutput extends eZXMLOutputHandler
         }
         elseif ( $element->getAttribute( 'node_id' ) != null )
         {
-            $nodeID = $element->getAttribute( 'node_id' );
+            $nodeID = (int) $element->getAttribute( 'node_id' );
             $node = isset( $this->NodeArray[$nodeID] ) ? $this->NodeArray[$nodeID] : null;
 
             if ( $node != null )
@@ -288,7 +288,7 @@ class eZXHTMLXMLOutput extends eZXMLOutputHandler
         }
         else
         {
-            $nodeID = $element->getAttribute( 'node_id' );
+            $nodeID = (int) $element->getAttribute( 'node_id' );
             if ( $nodeID )
             {
                 if ( isset( $this->NodeArray[$nodeID] ) )


### PR DESCRIPTION
> Fix https://jira.ez.no/browse/EZP-29085
> Sent to QA

Copied from Slack:
Seems like nodeID is forced to convert to string at https://github.com/ezsystems/ezpublish-legacy/blob/master/kernel/classes/datatypes/ezxmltext/ezxmloutputhandler.php#L278 and https://github.com/ezsystems/ezpublish-legacy/blob/master/kernel/classes/datatypes/ezxmltext/ezxmloutputhandler.php#L285

But http://php.net/manual/en/language.types.array.php says:
_Additionally the following key casts will occur:
Strings containing valid decimal integers, unless the number is preceded by a + sign, will be cast to the integer type. E.g. the key “8” will actually be stored under 8. On the other hand “08" will not be cast, as it isn’t a valid decimal integer._

I.e. the string conversion is pointless, the array index will be an integer anyway.