### PR TITLE
RSS Export - Add support for eZContentObject 

### DIFF
--- a/kernel/classes/ezrssexport.php
+++ b/kernel/classes/ezrssexport.php
@@ -655,6 +655,25 @@ class eZRSSExport extends eZPersistentObject
                         $encItemURL  = $origImage['full_path'];
                         eZURI::transformURI( $encItemURL, true, 'full' );
                     }
+                    else if ($enclosureContent instanceof eZContentObject && $enclosureContent->contentClassIdentifier() === 'image')
+                    {
+                        $dataMap = $enclosureContent->dataMap();
+                        if (isset($dataMap['image'])) {
+                            $enclosureContent = $dataMap['image']->content();
+
+                            $origImage = $enclosureContent->attribute('original');
+
+                            // Url might be empty since the field "image" in the class "image" is not required
+                            if ($origImage['full_path'] !== '') {
+                                $enc = $item->add('enclosure');
+                                $enc->length = $origImage['filesize'];
+                                $enc->type = $origImage['mime_type'];
+                                $encItemURL = $origImage['full_path'];
+
+                                eZURI::transformURI($encItemURL, true, 'full');
+                            }
+                        }
+                    }
 
                     if ( $encItemURL )
                     {

--- a/kernel/classes/ezrssexport.php
+++ b/kernel/classes/ezrssexport.php
@@ -648,12 +648,14 @@ class eZRSSExport extends eZPersistentObject
                     }
                     else if ( $enclosureContent instanceof eZImageAliasHandler )
                     {
-                        $enc         = $item->add( 'enclosure' );
                         $origImage   = $enclosureContent->attribute( 'original' );
-                        $enc->length = $origImage['filesize'];
-                        $enc->type   = $origImage['mime_type'];
-                        $encItemURL  = $origImage['full_path'];
-                        eZURI::transformURI( $encItemURL, true, 'full' );
+                        if ($origImage['full_path'] !== '') {
+                            $enc         = $item->add( 'enclosure' );
+                            $enc->length = $origImage['filesize'];
+                            $enc->type = $origImage['mime_type'];
+                            $encItemURL = $origImage['full_path'];
+                            eZURI::transformURI($encItemURL, true, 'full');
+                        }
                     }
                     else if ($enclosureContent instanceof eZContentObject && $enclosureContent->contentClassIdentifier() === 'image')
                     {


### PR DESCRIPTION
When creating a RSS feed with a class that have an image field that is a relation, the enclosure item is not present in the feed.

This PR fix this behaviour by checking that the relation is an image and add the enclosure item for this case.
This PR also fix the case where there is an image a relation but the field "image" in the relation is empty. Leading to a empty <enclosure> in the feed

