### PR TITLE
EZP-29039: Image aliases expiry on draft discard

### DIFF
--- a/kernel/classes/datatypes/ezimage/ezimagefile.php
+++ b/kernel/classes/datatypes/ezimage/ezimagefile.php
@@ -248,7 +248,7 @@ class eZImageFile extends eZPersistentObject
                 AND ezcontentobject_attribute.id = %d
                 AND ( ezcontentobject_attribute.version != %d OR ezcontentobject_attribute.language_code != '%s' )
                 ",
-                $filepath, $filepath,
+                $filepath, htmlspecialchars($filepath),
                 $attributeId,
                 $attributeVersion,
                 $languageCode

--- a/kernel/classes/datatypes/ezimage/ezimagefile.php
+++ b/kernel/classes/datatypes/ezimage/ezimagefile.php
@@ -248,7 +248,7 @@ class eZImageFile extends eZPersistentObject
                 AND ezcontentobject_attribute.id = %d
                 AND ( ezcontentobject_attribute.version != %d OR ezcontentobject_attribute.language_code != '%s' )
                 ",
-                $filepath, htmlspecialchars($filepath),
+                $filepath, htmlspecialchars($filepath, ENT_XML1 | ENT_COMPAT),
                 $attributeId,
                 $attributeVersion,
                 $languageCode


### PR DESCRIPTION
JIRA issue: https://jira.ez.no/browse/EZP-29039

## Description

As described in JIRA issue, the image aliases are always set as expired in DFS `ezdfsfile` table during draft rejection under two conditions existing simultaneously:
* Image parent node (folder/gallery) has to has special characters in the name/title (for instance quotes)
* `[URLTranslator]` setting needs to be set as `TransformationGroup=urlalias_iri`

Due to `TransformationGroup=urlalias_iri` setting names of directories on the filesystem also contain special characters.

An image is saved to the `ezcontentobject_attribute`.`data_text` as XML. Each XML node which represents image/image alias has attribute `url`. Under the mentioned conditions, during the conversion phase, the value of this attribute is created from the file path and all special characters are converted to HTML entities (in this case `"` to `&quot;`). 

During draft discarding, `eZImageFile::isReferencedByOtherAttributes` method is invoked. All special characters in the XML `url` attribute value mentioned before should be also converted to the HTML entities. Otherwise, that method returns `0` what means, that there are no more references and the file can be safely removed. 