### PR TITLE
FIX cache not cleared on node visibility change

### DIFF
--- a/kernel/content/ezcontentoperationcollection.php
+++ b/kernel/content/ezcontentoperationcollection.php
@@ -1014,7 +1014,9 @@ class eZContentOperationCollection
                 $action = 'show';
             }
             else
+            {
                 eZContentObjectTreeNode::hideSubTree( $curNode );
+            }
 
             // Notify cache system about visibility change
             ezpEvent::getInstance()->notify('content/cache', [

--- a/kernel/content/ezcontentoperationcollection.php
+++ b/kernel/content/ezcontentoperationcollection.php
@@ -1015,6 +1015,12 @@ class eZContentOperationCollection
             }
             else
                 eZContentObjectTreeNode::hideSubTree( $curNode );
+
+            // Notify cache system about visibility change
+            ezpEvent::getInstance()->notify('content/cache', [
+                [(int)$nodeID],
+                [(int)$curNode->attribute('contentobject_id')]
+            ]);
         }
 
         //call appropriate method from search engine


### PR DESCRIPTION
Fix issue with cache not cleared on node visibility change.
Search index takes wrong visibility status from cache.


Todo:
- [x] 2017.12
- [x] JIRA issue - https://jira.ez.no/browse/EZP-30493