### PR TITLE
Avoid double decoding of URL

### DIFF
--- a/lib/ezutils/classes/ezuri.php
+++ b/lib/ezutils/classes/ezuri.php
@@ -576,7 +576,10 @@ class eZURI
         {
             if ( !isset( $GLOBALS['eZURIRequestInstance'] ) )
             {
-                $GLOBALS['eZURIRequestInstance'] = new eZURI( eZSys::requestURI() );
+                // Why urlencode? Because, eZURI expects an encoded URI but eZSYS returns a non-encoded URI
+                $uri = urlencode( eZSys::requestURI() );
+                
+                $GLOBALS['eZURIRequestInstance'] = new eZURI( $uri );
             }
             return $GLOBALS['eZURIRequestInstance'];
         }


### PR DESCRIPTION
eZSYS::requestURI is already decoding the URL. The eZURI class does it a 2nd time.

Example of the problem. Given URL:
http://<sitedomain>/(foo)/bar%2Bbar

Double decoded version is is /(foo)/bar bar (that's a space in between)
But the correct value is /(foo)/bar+bar

You can test this by adding following into your pagelayout.tpl:
{$view_parameters|dump()}

Use following URL and look at the dump output:
http://<sitedomain>/(foo)/bar%2Bbar

The correct value is " /(foo)/bar+bar" - the pull request should produce the correct output.