### PR TITLE
EZP-28950: Add support for utf8mb4 charset to i18n

### DIFF
--- a/lib/ezi18n/classes/ezcharsetinfo.php
+++ b/lib/ezi18n/classes/ezcharsetinfo.php
@@ -150,7 +150,7 @@ class eZCharsetInfo
                                                            'cp849',
                                                            'cp850' ),
                                     'unicode' => array( 'unicode' ),
-                                    'utf-8' => array( 'utf-8' ) );
+                                    'utf-8' => array( 'utf-8', 'utf8mb4' ) );
         }
         return $encodingTable;
     }


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-28950

eZ legacy does not recognize `utf8mb4` charset, instead falling back to conversion to a single byte charset set by `eZTextCodec`, which results in the following beautiful error messages:

```
Query error (1064): You have an error in your SQL syntax; check the manual that
corresponds to your MySQL server version for the right syntax to use near '???????????????????????????????????????????????????????????
?????????????????????' at line 1. Query: ?????????????????????????????????????????????????????????????????
??????????????????????????????????????????????????????????????????????
[ May 23 2018 10:47:03 ] Unexpected error, the message was : Call to a member function
attribute() on null in vendor/ezsystems/legacy-bridge/bundle/LegacyMapper/Security.php on line 97
```

The effect of this PR is that `utf8mb4` is internally recognized as `utf-8`, resulting in no conversion from UTF8 taking place when used for example by the database layer.

Disclaimer: I'm not claiming that this is a proper fix, especially in this obscure part of legacy, but it seems logical :)

@glye @andrerom @gggeek @alongosz Any input on your side?