### PR TITLE
EZP-29170: Custom tag attribute of "link" type should indicate what node is selected

### DIFF
--- a/extension/ezoe/design/standard/templates/ezoe/customattributes/link.tpl
+++ b/extension/ezoe/design/standard/templates/ezoe/customattributes/link.tpl
@@ -44,7 +44,7 @@ eZOEPopupUtils.settings.onInitDoneArray.push( function( editorElement )
         {
             var url = self.val().split('://'), id = eZOEPopupUtils.Int( url[1] );
             if ( id !== 0 && ( url[0] === 'eznode' || url[0] === 'ezobject' ) )
-                ezoeLinkAttribute.ajaxCheck.call( this, url[0] + '_' + id );
+                ezoeLinkAttribute.ajaxCheck.call( this, url[0] + '_' + id, ezoeLinkAttribute.lid( this.id, tagName ) );
         }
     });
 


### PR DESCRIPTION
See https://jira.ez.no/browse/EZP-29170

The first time you select a node in a custom tag "link" attribute, it shows you the name of the node selected. However, if you open the dialog again, it does not show you the name. To an editor, "eznode://66214" is not user-friendly at all. It should at the very least show the same information it did when the node was first selected.

Testing Notes (just a sample custom tag you can define so you can test this):

```
settings/override/content.ini.append.php

[CustomTagSettings]
....
AvailableCustomTags[]=test_link

...

[test_link]
CustomAttributes[]=name
CustomAttributes[]=link1
CustomAttributes[]=link2


settings/override/ezoe_attributes.ini.append.php


[CustomAttribute_test_link_name]
Name=Name
Title=Name
Type=text
Required=false
 

[CustomAttribute_test_link_link1]
Name=Link test
Title=Link test
Type=link
Required=false
 
[CustomAttribute_test_link_link2]
Name=Link test2
Title=Link test2
Type=link
Required=false


```








