### PR TITLE
Impossible to use embed when there are duplicate AvailableViewModes

### DIFF
--- a/extension/ezoe/modules/ezoe/relations.php
+++ b/extension/ezoe/modules/ezoe/relations.php
@@ -270,7 +270,7 @@ if ( isset( $xmlTagAliasList[$tagName] ) )
 else
     $tpl->setVariable( 'tag_name_alias', $tagName );
 
-$tpl->setVariable( 'view_list', json_encode( array( 'embed' => $viewList, 'embed-inline' => $viewListInline ) ) );
+$tpl->setVariable( 'view_list', json_encode( array( 'embed' => array_values( $viewList ), 'embed-inline' => array_values( $viewListInline ) ) ) );
 $tpl->setVariable( 'class_list', json_encode( array( 'embed' => $classList, 'embed-inline' => $classListInline ) ) );
 $tpl->setVariable( 'attribute_defaults', json_encode( array( 'embed' => $attributeDefaults, 'embed-inline' => $attributeDefaultsInline ) ) );
 


### PR DESCRIPTION
1. Install https://github.com/ezsystems/ezpublish-legacy
2. `settings/override/content.ini.append.php`:
```
...
[embed]
AvailableViewModes[]
AvailableViewModes[]=embed
AvailableViewModes[]=embed-inline
AvailableViewModes[]=full
AvailableViewModes[]=line
AvailableViewModes[]=embed
AvailableViewModes[]=custom
```
3. Edit any object in admin: try to add embed with `custom` view (or any other view).
4. Disable editor and check content of embed object:
```
<embed view="5" size="medium" custom:offset="0" custom:limit="5" href="ezobject://59" />
```

Expected result:
```
<embed view="custom" size="medium" custom:offset="0" custom:limit="5" href="ezobject://59" />
```

https://jira.ez.no/browse/EZEE-2042