### PR TITLE
Fix admin UI anchor link scroll bug

### DIFF
--- a/design/admin/stylesheets/pagelayout.css
+++ b/design/admin/stylesheets/pagelayout.css
@@ -476,7 +476,7 @@ ul.leftmenu-items li.current a
     top:-20px;
     bottom: 0; /* strech div to full width of relative box */
     width: 10px;
-    height: 5000px;
+    height: auto;
     cursor: col-resize;
     z-index:11;
 /*    background: #f8f8f8;*/


### PR DESCRIPTION
- fixed height on the width controller element causes the user to get
  'stuck' and unable to scroll back to the top when clicking on a link
targeting an in page anchor

The bug is also referenced in this Jira ticket:
https://jira.ez.no/browse/EZP-29210