### PR TITLE
EZP-29210: Fix admin UI anchor link scroll bug

### DIFF
--- a/design/admin/stylesheets/pagelayout.css
+++ b/design/admin/stylesheets/pagelayout.css
@@ -472,11 +472,10 @@ ul.leftmenu-items li.current a
 #widthcontrol-handler
 {
     position: absolute;
-    right: -30px;
-    top:-20px;
+    right: 20px;
+    top: 0;
     bottom: 0; /* strech div to full width of relative box */
     width: 10px;
-    height: 5000px;
     cursor: col-resize;
     z-index:11;
 /*    background: #f8f8f8;*/

--- a/design/admin/templates/pagelayout.tpl
+++ b/design/admin/templates/pagelayout.tpl
@@ -80,6 +80,9 @@ div#maincolumn {ldelim} padding-right: 20px; padding-left: 50px; {rdelim}
 
 <div id="left-panels-separator">
     <div class="panels-separator-top"></div>
+    <div id="widthcontrol-handler" class="hide">
+        <div class="widthcontrol-grippy"></div>
+    </div>
     <div class="panels-separator-bottom"></div>
 </div>
 

--- a/design/admin/templates/parts/content/menu.tpl
+++ b/design/admin/templates/parts/content/menu.tpl
@@ -55,8 +55,3 @@
 {/switch}
 </p>
 </div>
-
-{* This is the border placed to the left for draging width, js will handle disabling the one above and enabling this *}
-<div id="widthcontrol-handler" class="hide">
-<div class="widthcontrol-grippy"></div>
-</div>

--- a/design/admin/templates/parts/media/menu.tpl
+++ b/design/admin/templates/parts/media/menu.tpl
@@ -54,8 +54,3 @@
 {/switch}
 </p>
 </div>
-
-{* This is the border placed to the left for draging width, js will handle disabling the one above and enabling this *}
-<div id="widthcontrol-handler" class="hide">
-<div class="widthcontrol-grippy"></div>
-</div>

--- a/design/admin/templates/parts/my/menu.tpl
+++ b/design/admin/templates/parts/my/menu.tpl
@@ -62,8 +62,3 @@
 {/switch}
 </p>
 </div>
-
-{* This is the border placed to the left for draging width, js will handle disabling the one above and enabling this *}
-<div id="widthcontrol-handler" class="hide">
-<div class="widthcontrol-grippy"></div>
-</div>

--- a/design/admin/templates/parts/setup/menu.tpl
+++ b/design/admin/templates/parts/setup/menu.tpl
@@ -69,8 +69,3 @@
 {/switch}
 </p>
 </div>
-
-{* This is the border placed to the left for draging width, js will handle disabling the one above and enabling this *}
-<div id="widthcontrol-handler" class="hide">
-<div class="widthcontrol-grippy"></div>
-</div>

--- a/design/admin/templates/parts/shop/menu.tpl
+++ b/design/admin/templates/parts/shop/menu.tpl
@@ -45,8 +45,3 @@
 {/switch}
 </p>
 </div>
-
-{* This is the border placed to the left for draging width, js will handle disabling the one above and enabling this *}
-<div id="widthcontrol-handler" class="hide">
-<div class="widthcontrol-grippy"></div>
-</div>

--- a/design/admin/templates/parts/user/menu.tpl
+++ b/design/admin/templates/parts/user/menu.tpl
@@ -82,10 +82,4 @@
 {/switch}
 </p>
 </div>
-
-{* This is the border placed to the left for draging width, js will handle disabling the one above and enabling this *}
-<div id="widthcontrol-handler" class="hide">
-<div class="widthcontrol-grippy"></div>
-</div>
-
 {/if}{* if ne( $ui_context, 'edit' ) *}

--- a/design/admin/templates/parts/visual/menu.tpl
+++ b/design/admin/templates/parts/visual/menu.tpl
@@ -37,8 +37,3 @@
 {/switch}
 </p>
 </div>
-
-{* This is the border placed to the left for draging width, js will handle disabling the one above and enabling this *}
-<div id="widthcontrol-handler" class="hide">
-<div class="widthcontrol-grippy"></div>
-</div>


### PR DESCRIPTION
- fixed height on the width controller element causes the user to get
'stuck' and unable to scroll back to the top when clicking on a link
targeting an in page anchor

The bug is also noted in this Jira ticket:
https://jira.ez.no/browse/EZP-29210