### PR TITLE
EZP-29350: Make query compatible with strict MySQL

### DIFF
--- a/update/common/scripts/5.4/cleanuntranslatablerelations.php
+++ b/update/common/scripts/5.4/cleanuntranslatablerelations.php
@@ -82,7 +82,7 @@ do {
         "FROM ezcontentobject_attribute attr ".
         "INNER JOIN ezcontentclass_attribute classattr ON attr.contentclassattribute_id=classattr.id " .
         "WHERE classattr.data_type_string IN ( 'ezobjectrelation', 'ezobjectrelationlist' ) AND can_translate=0 " .
-        "GROUP BY contentobject_id, version, data_int"
+        "GROUP BY contentobject_id, version, data_int, attr_id, classattr.data_type_string, attr.data_text"
     );
 
     $count = count($rows);


### PR DESCRIPTION
MySQL 5.7 is strict by default and will error out on the incorrect GROUP BY in the update script (see diff).