### PR TITLE
EZP-27101: Recursion protection for retrieving metadata doesn't work properly

### DIFF
--- a/kernel/classes/datatypes/ezobjectrelation/ezobjectrelationtype.php
+++ b/kernel/classes/datatypes/ezobjectrelation/ezobjectrelationtype.php
@@ -639,7 +639,7 @@ class eZObjectRelationType extends eZDataType
         $object = $this->objectAttributeContent( $contentObjectAttribute );
         if ( $object )
         {
-            if ( eZContentObject::recursionProtect( $object->attribute( 'id' ) ) )
+            if ( eZContentObject::stackRecursionProtect( $contentObjectAttribute->attribute( 'id' ), $object->attribute( 'id' ) ) )
             {
                 // Does the related object exist in the same language as the current content attribute ?
                 if ( in_array( $contentObjectAttribute->attribute( 'language_code' ), $object->attribute( 'current' )->translationList( false, false ) ) )
@@ -651,7 +651,11 @@ class eZObjectRelationType extends eZDataType
                     $attributes = $object->contentObjectAttributes();
                 }
 
-                return eZContentObjectAttribute::metaDataArray( $attributes );
+                eZContentObject::stackRecursionProtectionPush();
+                $metaDataArray = eZContentObjectAttribute::metaDataArray( $attributes );
+                eZContentObject::stackRecursionProtectionPop();
+
+                return $metaDataArray;
             }
             else
             {

--- a/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
+++ b/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
@@ -1616,7 +1616,7 @@ class eZObjectRelationListType extends eZDataType
                     $subObjectVersionNum = $subCurrentVersionObject->attribute( 'version' );
                 }
 
-                if ( eZContentObject::recursionProtect( $subObjectID ) )
+                if ( eZContentObject::stackRecursionProtect( $contentObjectAttribute->attribute( 'id' ), $subObjectID ) )
                 {
                     if ( !$subObject )
                     {
@@ -1626,7 +1626,10 @@ class eZObjectRelationListType extends eZDataType
                 }
             }
 
+            eZContentObject::stackRecursionProtectionPush();
             $attributeMetaDataArray = eZContentObjectAttribute::metaDataArray( $attributes );
+            eZContentObject::stackRecursionProtectionPop();
+
             $metaDataArray = array_merge( $metaDataArray, $attributeMetaDataArray );
         }
 

--- a/kernel/classes/ezcontentobject.php
+++ b/kernel/classes/ezcontentobject.php
@@ -2644,6 +2644,57 @@ class eZContentObject extends eZPersistentObject
         unset( $GLOBALS["ez_content_object_recursion_protect"] );
     }
 
+    private static $recursionProtectionStack;
+    private static $recursionProtectionCurrent;
+
+    public static function stackRecursionProtectionStart()
+    {
+        self::$recursionProtectionStack = [];
+        self::$recursionProtectionCurrent = [];
+    }
+
+    public static function stackRecursionProtect($key, $value)
+    {
+        if (self::stackRecursionExistsOnStack($key, $value))
+        {
+            return false;
+        }
+
+        self::$recursionProtectionCurrent[$key][] = $value;
+
+        return true;
+    }
+
+    private static function stackRecursionExistsOnStack($key, $value)
+    {
+        foreach (self::$recursionProtectionStack as $stackItem)
+        {
+            if (array_key_exists($key, $stackItem) && in_array($value, $stackItem[$key], true))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static function stackRecursionProtectionPush()
+    {
+        self::$recursionProtectionStack[] = self::$recursionProtectionCurrent;
+        self::$recursionProtectionCurrent = [];
+    }
+
+    public static function stackRecursionProtectionPop()
+    {
+        self::$recursionProtectionCurrent = array_pop(self::$recursionProtectionStack);
+    }
+
+    public static function stackRecursionProtectionEnd()
+    {
+        self::$recursionProtectionStack = null;
+        self::$recursionProtectionCurrent = null;
+    }
+
     /**
      * Transaction unsafe. If you call several transaction unsafe methods you must enclose
      * the calls within a db transaction; thus within db->begin and db->commit.

--- a/kernel/search/plugins/ezsearchengine/ezsearchengine.php
+++ b/kernel/search/plugins/ezsearchengine/ezsearchengine.php
@@ -68,7 +68,7 @@ class eZSearchEngine implements ezpSearchEngine
         $placement = 0;
         $previousWord = '';
 
-        eZContentObject::recursionProtectionStart();
+        eZContentObject::stackRecursionProtectionStart();
         foreach ( $currentVersion->contentObjectAttributes() as $attribute )
         {
             $metaData = array();
@@ -136,7 +136,7 @@ class eZSearchEngine implements ezpSearchEngine
                 }
             }
         }
-        eZContentObject::recursionProtectionEnd();
+        eZContentObject::stackRecursionProtectionEnd();
 
         $wordIDArray = $this->buildWordIDArray( array_keys( $indexArrayOnlyWords ) );
 


### PR DESCRIPTION
JIRA issue: [EZP-27101](https://jira.ez.no/browse/EZP-27101)

When retrieving the search metadata from objects containing "Object relation" and "Object relations" field type, there is a recursion protection in place that ensures that there is no infinite recursion caused by circular references. However, it only checks if the certain object was already processed and this is causing problems when the same object is referenced from two different fields (as described in [EZP-27101](https://jira.ez.no/browse/EZP-27101)). To fix that I introduced new recursion protection that differs in two aspects:
* Besides object id, it also stores the field id which contains this object. Circular reference only happens if we are processing the same object from the same field as before. 
* It works like a stack instead of a one-dimensional array, meaning that only references above in the recursion chain are taken into the account when detecting circular references.

There is another PR which tries to fix this issue (https://github.com/ezsystems/ezpublish-legacy/pull/1288), but it can cause an infinite recursion (as described in https://github.com/ezsystems/ezpublish-legacy/pull/1288#issuecomment-292988830).