### PR TITLE
EZP-27101: Remove recursion when retrieving search metadata for relation fields

### DIFF
--- a/doc/bc/5.90/relation_indexing.md
+++ b/doc/bc/5.90/relation_indexing.md
@@ -1,0 +1,13 @@
+# Relation search indexing changes 
+
+For the 2018.06 release, eZ Publish changed the way relations are indexed. Previously the relation metadata was loaded recursively, meaning that relations of relations etc. were also included. This behavior was changed to only include Objects one level deep so only direct relations are taken into account.
+
+The affected kernel Datatypes are eZObjectRelationType and eZObjectRelationListType.
+
+If you have your custom Datatype that stores relations to other Objects, you can make it behave similarly. Just add the following to your Datatype class:
+```php
+    public function isRelationType()
+    {
+        return true;
+    }
+```

--- a/doc/bc/5.90/relation_indexing.md
+++ b/doc/bc/5.90/relation_indexing.md
@@ -2,6 +2,8 @@
 
 For the 2018.06 release, eZ Publish changed the way relations are indexed. Previously the relation metadata was loaded recursively, meaning that relations of relations etc. were also included. This behavior was changed to only include Objects one level deep so only direct relations are taken into account.
 
+The change was done to avoid various recursion problems when relations are circular. Also, the new behavior allows for better (more relevant) search results.
+
 The affected kernel Datatypes are eZObjectRelationType and eZObjectRelationListType.
 
 If you have your custom Datatype that stores relations to other Objects, you can make it behave similarly. Just add the following to your Datatype class:

--- a/kernel/classes/datatypes/ezobjectrelation/ezobjectrelationtype.php
+++ b/kernel/classes/datatypes/ezobjectrelation/ezobjectrelationtype.php
@@ -25,6 +25,11 @@ class eZObjectRelationType extends eZDataType
                            array( 'serialize_supported' => true ) );
     }
 
+    public function isRelationType()
+    {
+        return true;
+    }
+
     /*!
      Initializes the class attribute with some data.
      */
@@ -639,24 +644,17 @@ class eZObjectRelationType extends eZDataType
         $object = $this->objectAttributeContent( $contentObjectAttribute );
         if ( $object )
         {
-            if ( eZContentObject::recursionProtect( $object->attribute( 'id' ) ) )
+            // Does the related object exist in the same language as the current content attribute ?
+            if ( in_array( $contentObjectAttribute->attribute( 'language_code' ), $object->attribute( 'current' )->translationList( false, false ) ) )
             {
-                // Does the related object exist in the same language as the current content attribute ?
-                if ( in_array( $contentObjectAttribute->attribute( 'language_code' ), $object->attribute( 'current' )->translationList( false, false ) ) )
-                {
-                    $attributes = $object->attribute( 'current' )->contentObjectAttributes( $contentObjectAttribute->attribute( 'language_code' ) );
-                }
-                else
-                {
-                    $attributes = $object->contentObjectAttributes();
-                }
-
-                return eZContentObjectAttribute::metaDataArray( $attributes );
+                $attributes = $object->attribute( 'current' )->contentObjectAttributes( $contentObjectAttribute->attribute( 'language_code' ) );
             }
             else
             {
-                return array();
+                $attributes = $object->contentObjectAttributes();
             }
+
+            return eZContentObjectAttribute::metaDataArray( $attributes, true );
         }
         return false;
     }

--- a/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
+++ b/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
@@ -32,6 +32,11 @@ class eZObjectRelationListType extends eZDataType
                            array( 'serialize_supported' => true ) );
     }
 
+    public function isRelationType()
+    {
+        return true;
+    }
+
     /*!
      Validates the input and returns true if the input was
      valid for this datatype.
@@ -1616,17 +1621,14 @@ class eZObjectRelationListType extends eZDataType
                     $subObjectVersionNum = $subCurrentVersionObject->attribute( 'version' );
                 }
 
-                if ( eZContentObject::recursionProtect( $subObjectID ) )
+                if ( !$subObject )
                 {
-                    if ( !$subObject )
-                    {
-                        continue;
-                    }
-                    $attributes = $subObject->contentObjectAttributes( true, $subObjectVersionNum, $language );
+                    continue;
                 }
+                $attributes = $subObject->contentObjectAttributes( true, $subObjectVersionNum, $language );
             }
 
-            $attributeMetaDataArray = eZContentObjectAttribute::metaDataArray( $attributes );
+            $attributeMetaDataArray = eZContentObjectAttribute::metaDataArray( $attributes, true );
             $metaDataArray = array_merge( $metaDataArray, $attributeMetaDataArray );
         }
 

--- a/kernel/classes/ezcontentobjectattribute.php
+++ b/kernel/classes/ezcontentobjectattribute.php
@@ -1182,7 +1182,7 @@ class eZContentObjectAttribute extends eZPersistentObject
             }
 
             $datatype = $attribute->dataType();
-            if( $skipRelationAttributes && $datatype->isRelationType() )
+            if ( $skipRelationAttributes && $datatype->isRelationType() )
             {
                 continue;
             }

--- a/kernel/classes/ezcontentobjectattribute.php
+++ b/kernel/classes/ezcontentobjectattribute.php
@@ -1168,7 +1168,7 @@ class eZContentObjectAttribute extends eZPersistentObject
      Goes trough all attributes and fetches metadata for the ones that is searchable.
      \return an array with metadata information.
     */
-    static function metaDataArray( &$attributes )
+    static function metaDataArray( &$attributes, $skipRelationAttributes = false )
     {
         $metaDataArray = array();
         if ( !is_array( $attributes ) )
@@ -1176,18 +1176,26 @@ class eZContentObjectAttribute extends eZPersistentObject
         foreach( $attributes as $attribute )
         {
             $classAttribute = $attribute->contentClassAttribute();
-            if ( $classAttribute->attribute( 'is_searchable' ) )
+            if ( !$classAttribute->attribute( 'is_searchable' ) )
             {
-                $attributeMetaData = $attribute->metaData();
-                if ( $attributeMetaData !== false )
+                continue;
+            }
+
+            $datatype = $attribute->dataType();
+            if($skipRelationAttributes && $datatype->isRelationType())
+            {
+                continue;
+            }
+
+            $attributeMetaData = $datatype->metaData($attribute);
+            if ( $attributeMetaData !== false )
+            {
+                if ( !is_array( $attributeMetaData ) )
                 {
-                    if ( !is_array( $attributeMetaData ) )
-                    {
-                        $attributeMetaData = array( array( 'id' => '',
-                                                           'text' => $attributeMetaData ) );
-                    }
-                    $metaDataArray = array_merge( $metaDataArray, $attributeMetaData );
+                    $attributeMetaData = array( array( 'id' => '',
+                                                       'text' => $attributeMetaData ) );
                 }
+                $metaDataArray = array_merge( $metaDataArray, $attributeMetaData );
             }
         }
         return $metaDataArray;

--- a/kernel/classes/ezcontentobjectattribute.php
+++ b/kernel/classes/ezcontentobjectattribute.php
@@ -1182,7 +1182,7 @@ class eZContentObjectAttribute extends eZPersistentObject
             }
 
             $datatype = $attribute->dataType();
-            if($skipRelationAttributes && $datatype->isRelationType())
+            if( $skipRelationAttributes && $datatype->isRelationType() )
             {
                 continue;
             }

--- a/kernel/classes/ezdatatype.php
+++ b/kernel/classes/ezdatatype.php
@@ -288,6 +288,16 @@ class eZDataType
         return false;
     }
 
+    /**
+     * Indicates if the datatype handles relations
+     *
+     * @return bool
+     */
+    public function isRelationType()
+    {
+        return false;
+    }
+
     /*!
      \virtual
      Inserts the HTTP file \a $httpFile to the content object attribute \a $objectAttribute.

--- a/kernel/search/plugins/ezsearchengine/ezsearchengine.php
+++ b/kernel/search/plugins/ezsearchengine/ezsearchengine.php
@@ -68,7 +68,6 @@ class eZSearchEngine implements ezpSearchEngine
         $placement = 0;
         $previousWord = '';
 
-        eZContentObject::recursionProtectionStart();
         foreach ( $currentVersion->contentObjectAttributes() as $attribute )
         {
             $metaData = array();
@@ -136,7 +135,6 @@ class eZSearchEngine implements ezpSearchEngine
                 }
             }
         }
-        eZContentObject::recursionProtectionEnd();
 
         $wordIDArray = $this->buildWordIDArray( array_keys( $indexArrayOnlyWords ) );
 

--- a/kernel/search/plugins/ezsearchengine/ezsearchengine.php
+++ b/kernel/search/plugins/ezsearchengine/ezsearchengine.php
@@ -68,6 +68,7 @@ class eZSearchEngine implements ezpSearchEngine
         $placement = 0;
         $previousWord = '';
 
+        eZContentObject::recursionProtectionStart();
         foreach ( $currentVersion->contentObjectAttributes() as $attribute )
         {
             $metaData = array();
@@ -135,6 +136,7 @@ class eZSearchEngine implements ezpSearchEngine
                 }
             }
         }
+        eZContentObject::recursionProtectionEnd();
 
         $wordIDArray = $this->buildWordIDArray( array_keys( $indexArrayOnlyWords ) );
 


### PR DESCRIPTION
JIRA issue: [EZP-27101](https://jira.ez.no/browse/EZP-27101)

When retrieving the search metadata from objects containing "Object relation" and "Object relations" field type, there is a recursion protection in place that ensures that there is no infinite recursion caused by circular references. However, it only checks if the certain object was already processed and this is causing problems when the same object is referenced from two different fields (as described in [EZP-27101](https://jira.ez.no/browse/EZP-27101)). 

This PR removes the recursion completely by making the relations load metadata only one level deep. By removing recursion, I was also able to remove the recursion protection, which solves the original issue.

This PR introduces a slight BC break because it changes logic (previously the metadata was loaded recursively and now it is loaded only one level deep), but the new behavior allows for better (more relevant) search results.
An alternative solution (without a BC break, but which keeps the broken logic of loading the metadata recursively) can be found here: https://github.com/ezsystems/ezpublish-legacy/pull/1371.