### PR TITLE
EZP-29390: [Legacy] PHP Warning: Cannot change session name when session is active

### DIFF
--- a/lib/ezsession/classes/ezsession.php
+++ b/lib/ezsession/classes/ezsession.php
@@ -262,6 +262,9 @@ class eZSession
      *
      * @since 4.1
      * @return bool Depending on if eZSession is registrated as session handler.
+     *
+     * @since v2018.06.0
+     * @return false if session is already active since PHP 7.2 onwards emits a warning about this.
     */
     static protected function registerFunctions( $sessionName = false, ezpSessionHandler $handler = null )
     {

--- a/lib/ezsession/classes/ezsession.php
+++ b/lib/ezsession/classes/ezsession.php
@@ -261,16 +261,15 @@ class eZSession
      * {@link eZSession::start()}, so only call this if you don't start the session.
      *
      * @since 4.1
-     * @since v2018.06.0 Return false if session is already active since PHP 7.2 onwards emits a warning about this.
      * @return bool Depending on if eZSession is registrated as session handler.
     */
     static protected function registerFunctions( $sessionName = false, ezpSessionHandler $handler = null )
     {
-        if ( self::$hasStarted || self::$handlerInstance !== null || session_status() === PHP_SESSION_ACTIVE )
+        if ( self::$hasStarted || self::$handlerInstance !== null )
             return false;
 
         $ini = eZINI::instance();
-        if ( $sessionName !== false )
+        if ( $sessionName !== false && $sessionName !== session_name() )
         {
             session_name( $sessionName );
         }
@@ -283,7 +282,9 @@ class eZSession
                 // Use md5 to make sure name is only consistent of alphanumeric characters
                 $sessionName .=  md5( $access['name'] );
             }
-            session_name( $sessionName );
+            if ( $sessionName !== session_name() ) {
+                session_name( $sessionName );
+            }
         }
         else
         {

--- a/lib/ezsession/classes/ezsession.php
+++ b/lib/ezsession/classes/ezsession.php
@@ -261,10 +261,8 @@ class eZSession
      * {@link eZSession::start()}, so only call this if you don't start the session.
      *
      * @since 4.1
+     * @since v2018.06.0 Return false if session is already active since PHP 7.2 onwards emits a warning about this.
      * @return bool Depending on if eZSession is registrated as session handler.
-     *
-     * @since v2018.06.0
-     * @return false if session is already active since PHP 7.2 onwards emits a warning about this.
     */
     static protected function registerFunctions( $sessionName = false, ezpSessionHandler $handler = null )
     {

--- a/lib/ezsession/classes/ezsession.php
+++ b/lib/ezsession/classes/ezsession.php
@@ -265,7 +265,7 @@ class eZSession
     */
     static protected function registerFunctions( $sessionName = false, ezpSessionHandler $handler = null )
     {
-        if ( self::$hasStarted || self::$handlerInstance !== null )
+        if ( self::$hasStarted || self::$handlerInstance !== null || session_status() === PHP_SESSION_ACTIVE )
             return false;
 
         $ini = eZINI::instance();


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29390](https://jira.ez.no/browse/EZP-29390)
| **Bug**| yes
| **New feature**    | no
| **Target version** | `master` 

PHP 7.2 emits warning `PHP Warning:  session_name(): Cannot change session name when session is active`. In the previous versions, it was not possible to change session name when a session already exists too, but there was no warning.

More info: http://php.net/manual/en/function.session-name.php#refsect1-function.session-name-changelog & https://stackoverflow.com/questions/47700336/php-7-2-warning-cannot-change-session-name-when-session-is-active