### PR TITLE
Skip tests that depend on critmon1.ez.no as it has been shut down

### DIFF
--- a/tests/tests/lib/ezsoap/ezsoapclient_test.php
+++ b/tests/tests/lib/ezsoap/ezsoapclient_test.php
@@ -70,6 +70,8 @@ class eZSOAPClientTest extends ezpTestCase
      */
     public function testSoapClientSend( $expectedSendResult, $server, $path, $port, $name, $namespace, $parameters = array() )
     {
+        self::markTestSkipped( "Test disabled as critmon has been shut down. Needs a different server or way of doing this." );
+
         $client = new eZSOAPClient( $server, $path, $port );
         $request = new eZSOAPRequest( $name, $namespace, $parameters );
         $response = $client->send( $request );

--- a/tests/tests/lib/ezutils/ezhttptool_test.php
+++ b/tests/tests/lib/ezutils/ezhttptool_test.php
@@ -30,6 +30,8 @@ class eZHTTPToolTest extends ezpTestCase
      */
     public function testGetDataByURL( $expectedDataResult, $url, $justCheckURL = false, $userAgent = false )
     {
+        self::markTestSkipped( "Test disabled as critmon has been shut down. Needs a different server or way of doing this." );
+
         $this->assertEquals( eZHTTPTool::getDataByURL( $url, $justCheckURL, $userAgent ), $expectedDataResult );
 
         // There's no way to test the whole method without refactoring it.


### PR DESCRIPTION
Whoops, forgot about these old tests when killing critmon.
As discovered in https://github.com/ezsystems/ezpublish-legacy/pull/1373