### PR TITLE
Purge preview cache in `attribute_edit.php`

### DIFF
--- a/kernel/content/attribute_edit.php
+++ b/kernel/content/attribute_edit.php
@@ -325,6 +325,11 @@ if ( $storingAllowed && $hasObjectInput)
             'content/cache/version',
             array( $object->attribute( 'id' ), $version->attribute( 'version' ) )
         );
+
+        ezpEvent::getInstance()->notify(
+            'content/cache/translations',
+            array( $object->attribute( 'id' ), $version->attribute( 'version' ) , [$EditLanguage])
+        );
     }
 
     $validation['processed'] = true;


### PR DESCRIPTION
The admin preview function does not work as expected: it always fetches
content from the view cache, so the draft content being edited never
shows up.

To fix this issue, view cache should be purged by triggering listeners
attached to `content/cache/translations`.

This PR is related to ezsystems/LegacyBridge#153

| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | n/a
| **Bug**            | yes
| **New feature**    | no
| **Target version** | `2017.12`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

**TODO**:
- [ ] Implement feature / fix a bug.
- [ ] Implement tests.
- [ ] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.