### PR TITLE
Fix EZP-29418: Wrong Session Name after EZP-29390

### DIFF
--- a/lib/ezsession/classes/ezsession.php
+++ b/lib/ezsession/classes/ezsession.php
@@ -269,9 +269,11 @@ class eZSession
             return false;
 
         $ini = eZINI::instance();
-        if ( $sessionName !== false && $sessionName !== session_name() )
+        if ( $sessionName !== false )
         {
-            session_name( $sessionName );
+            if ( $sessionName !== session_name() ) {
+                session_name( $sessionName );
+            }
         }
         else if ( $ini->variable( 'Session', 'SessionNameHandler' ) === 'custom' )
         {


### PR DESCRIPTION
Question | Answer
-- | --
JIRA issue | [EZP-29418](https://jira.ez.no/browse/EZP-29418)
Bug | yes
New feature | no
Target version | 2017.12

Regression from https://github.com/ezsystems/ezpublish-legacy/pull/1373
When a sessionName is set, it will generate a new one in the else if section.