### PR TITLE
Throw exception when module or view is not found.

### DIFF
--- a/kernel/private/classes/ezpkernelweb.php
+++ b/kernel/private/classes/ezpkernelweb.php
@@ -637,6 +637,14 @@ class ezpKernelWeb implements ezpWebBasedKernelHandler
             }
             else
             {
+                $moduleName = $this->uri->element();
+                $viewName = $this->uri->element(1);
+                $module = eZModule::findModule($moduleName);
+                if (null === $module) {
+                    throw new ezpModuleNotFound( $moduleName );
+                } elseif (!isset($module->Functions[$viewName])) {
+                    throw new ezpModuleViewNotFound( $moduleName, $viewName );
+                }
                 $moduleCheck = eZModule::accessAllowed( $this->uri );
             }
 


### PR DESCRIPTION
The legacy ezpublish does not return the 404 response code for any
request to a page that does not exist. It simply redirects all invalid
requests to the login page with a resonse code 200.

To fix this issue, method `ezpkernelweb::dispatchLoop()` has been
changed to throw exception when the requested module or view does not
exist.

| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | n/a
| **Bug**            | yes
| **New feature**    | no
| **Target version** | `2017.12`
| **BC breaks**      | yes
| **Tests pass**     | yes
| **Doc needed**     | no

**TODO**:
- [ ] Implement feature / fix a bug.
- [ ] Implement tests.
- [ ] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.