### PR TITLE
Option to skip search engine indexing inside eZContentOperationCollection::updateSection

### DIFF
--- a/kernel/classes/ezcontentobjecttreenode.php
+++ b/kernel/classes/ezcontentobjecttreenode.php
@@ -2796,7 +2796,7 @@ class eZContentObjectTreeNode extends eZPersistentObject
      \note Transaction unsafe. If you call several transaction unsafe methods you must enclose
      the calls within a db transaction; thus within db->begin and db->commit.
     */
-    static function assignSectionToSubTree( $nodeID, $sectionID, $oldSectionID = false )
+    static function assignSectionToSubTree( $nodeID, $sectionID, $oldSectionID = false, $updateSearchIndexes = true )
     {
         $db = eZDB::instance();
         $node = eZContentObjectTreeNode::fetch( $nodeID );
@@ -2827,7 +2827,10 @@ class eZContentObjectTreeNode extends eZPersistentObject
         foreach ( array_chunk( $objectSimpleIDArray, 100 ) as $pagedObjectIDs )
         {
             $db->query( "UPDATE ezcontentobject SET section_id='$sectionID' WHERE $filterPart " . $db->generateSQLINStatement( $pagedObjectIDs, 'id', false, true, 'int' ) );
-            eZSearch::updateObjectsSection( $pagedObjectIDs, $sectionID );
+            if ( $updateSearchIndexes )
+            {
+                eZSearch::updateObjectsSection( $pagedObjectIDs, $sectionID );
+            }
         }
         $db->commit();
 

--- a/kernel/classes/ezsection.php
+++ b/kernel/classes/ezsection.php
@@ -240,7 +240,7 @@ class eZSection extends eZPersistentObject
             {
                 foreach ( $assignedNodes as $node )
                 {
-                    eZContentOperationCollection::updateSection( $node->attribute( "node_id" ), $sectionID );
+                    eZContentOperationCollection::updateSection( $node->attribute( "node_id" ), $sectionID, false );
                 }
             }
         }

--- a/kernel/content/ezcontentoperationcollection.php
+++ b/kernel/content/ezcontentoperationcollection.php
@@ -1154,7 +1154,7 @@ class eZContentOperationCollection
      * @param int $selectedSectionID
      * @param bool $updateSearchIndexes
      *
-     * @return void An array with operation status, always true
+     * @return void
      */
     static public function updateSection( $nodeID, $selectedSectionID, $updateSearchIndexes = true )
     {

--- a/kernel/content/ezcontentoperationcollection.php
+++ b/kernel/content/ezcontentoperationcollection.php
@@ -1152,12 +1152,13 @@ class eZContentOperationCollection
      *
      * @param int $nodeID
      * @param int $selectedSectionID
+     * @param bool $updateSearchIndexes
      *
-     * @return array An array with operation status, always true
+     * @return void An array with operation status, always true
      */
-    static public function updateSection( $nodeID, $selectedSectionID )
+    static public function updateSection( $nodeID, $selectedSectionID, $updateSearchIndexes = true )
     {
-        eZContentObjectTreeNode::assignSectionToSubTree( $nodeID, $selectedSectionID );
+        eZContentObjectTreeNode::assignSectionToSubTree( $nodeID, $selectedSectionID, false, $updateSearchIndexes );
     }
 
     /**


### PR DESCRIPTION
This PR is a follow up for https://github.com/ezsystems/ezpublish-legacy/pull/1378