### PR TITLE
EZP-29573: Legacy installer should allow utf8mb4 charset

### DIFF
--- a/kernel/setup/steps/ezstep_installer.php
+++ b/kernel/setup/steps/ezstep_installer.php
@@ -489,12 +489,11 @@ class eZStepInstaller
             $checkedCharset = $db->checkCharset( $charsetsList, $currentCharset );
             if ( $checkedCharset === false )
             {
-                // If the current charset is utf-8 we use that instead
-                // since it can represent any character possible in the chosen languages
-                if ( $currentCharset == 'utf-8' )
+                // If the current charset is utf-8 or utf8mb4 we use that instead
+                // since they can represent any character possible in the chosen languages
+                if ( in_array( $currentCharset, array( 'utf-8', 'utf8mb4' ) ) )
                 {
-                    $charset = 'utf-8';
-                    $result['site_charset'] = $charset;
+                    $result['site_charset'] = $currentCharset;
                 }
                 else
                 {

--- a/kernel/setup/steps/ezstep_installer.php
+++ b/kernel/setup/steps/ezstep_installer.php
@@ -493,7 +493,7 @@ class eZStepInstaller
                 // since they can represent any character possible in the chosen languages
                 if ( in_array( $currentCharset, array( 'utf-8', 'utf8mb4' ) ) )
                 {
-                    $result['site_charset'] = $currentCharset;
+                    $result['site_charset'] = 'utf-8';
                 }
                 else
                 {


### PR DESCRIPTION
> Fixes https://jira.ez.no/browse/EZP-29573
> Ready for review

When creating a database in `utf8mb4`, the legacy installer complains that only `utf-8` is supported. Since `utf8mb4` is recommended now we should support both.

`utf8mb4` is not available in every database eZ Publish 5.x supports, but then people won't be able to create such a DB, so it won't be a problem.

**NB:** Since we have not backported the utf8mb4 schema changes, in order for this to work one has to first create the database, then apply the changes in the [advisory](http://share.ez.no/community-project/security-advisories/ezsa-2018-003-4-byte-utf-8-in-mysql-mariadb), and then run the installer.