### PR TITLE
Fix warnings about continue inside switch on PHP 7.3

### DIFF
--- a/kernel/classes/ezcollaborationgroup.php
+++ b/kernel/classes/ezcollaborationgroup.php
@@ -226,7 +226,7 @@ class eZCollaborationGroup extends eZPersistentObject
                         default:
                         {
                             eZDebug::writeWarning( 'Unknown sort field: ' . $sortField, __METHOD__ );
-                            continue;
+                            continue 2;
                         }
                     }
                     $sortOrder = true; // true is ascending

--- a/kernel/classes/ezcollaborationitem.php
+++ b/kernel/classes/ezcollaborationitem.php
@@ -389,7 +389,7 @@ class eZCollaborationItem extends eZPersistentObject
                             default:
                             {
                                 eZDebug::writeWarning( 'Unknown sort field: ' . $sortField, __METHOD__ );
-                                continue;
+                                continue 2;
                             }
                         }
                         $sortOrder = true; // true is ascending

--- a/kernel/classes/ezcontentobjecttreenode.php
+++ b/kernel/classes/ezcontentobjecttreenode.php
@@ -731,7 +731,7 @@ class eZContentObjectTreeNode extends eZPersistentObject
                             else
                             {
                                 eZDebug::writeWarning( 'Unknown sort field: ' . $sortField, __METHOD__ );
-                                continue;
+                                continue 2;
                             }
                         }
                     }

--- a/kernel/classes/ezsiteaccess.php
+++ b/kernel/classes/ezsiteaccess.php
@@ -157,7 +157,7 @@ class eZSiteAccess
                         return $access;
                     }
                     else
-                        continue;
+                        continue 2;
                 } break;
                 case 'port':
                 {
@@ -168,7 +168,7 @@ class eZSiteAccess
                         return $access;
                     }
                     else
-                        continue;
+                        continue 2;
                 } break;
                 case 'uri':
                 {
@@ -222,7 +222,7 @@ class eZSiteAccess
                         $match_num = $ini->variable( 'SiteAccessSettings', 'URIMatchRegexpItem' );
                     }
                     else
-                        continue;
+                        continue 2;
                 } break;
                 case 'host':
                 {
@@ -264,7 +264,7 @@ class eZSiteAccess
                         $match_num = $ini->variable( 'SiteAccessSettings', 'HostMatchRegexpItem' );
                     }
                     else
-                        continue;
+                        continue 2;
                 } break;
                 case 'host_uri':
                 {
@@ -353,7 +353,7 @@ class eZSiteAccess
                         $match_num = $ini->variable( 'SiteAccessSettings', 'IndexMatchRegexpItem' );
                     }
                     else
-                        continue;
+                        continue 2;
                 } break;
                 default:
                 {

--- a/kernel/package/ezpackagefunctioncollection.php
+++ b/kernel/package/ezpackagefunctioncollection.php
@@ -67,7 +67,6 @@ class eZPackageFunctionCollection
                         default:
                         {
                             eZDebug::writeWarning( 'Unknown package filter name: ' . $filterName );
-                            continue;
                         }
                     }
                 }
@@ -158,7 +157,6 @@ class eZPackageFunctionCollection
                         default:
                         {
                             eZDebug::writeWarning( 'Unknown package filter name: ' . $filterName );
-                            continue;
                         }
                     }
                 }

--- a/kernel/search/plugins/ezsearchengine/ezsearchengine.php
+++ b/kernel/search/plugins/ezsearchengine/ezsearchengine.php
@@ -1206,7 +1206,7 @@ class eZSearchEngine implements ezpSearchEngine
                         default:
                         {
                             eZDebug::writeWarning( 'Unknown sort field: ' . $sortField, __METHOD__ );
-                            continue;
+                            continue 2;
                         }
                     }
                     $sortOrder = true; // true is ascending

--- a/lib/ezutils/classes/ezmoduleoperationinfo.php
+++ b/lib/ezutils/classes/ezmoduleoperationinfo.php
@@ -455,8 +455,7 @@ class eZModuleOperationInfo
                     if ( !$this->UseTriggers )
                     {
                         $bodyReturnValue['status'] = eZModuleOperationInfo::STATUS_CONTINUE;
-                        continue;
-
+                        continue 2;
                     }
 
                     $triggerName = $body['name'];


### PR DESCRIPTION
```
$ php7.3 -v ; find . -name '*.php' -exec php7.3 -l {} \;| grep -v '^No syntax errors'
```

Results in:

```
PHP Warning:  "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in ./kernel/classes/ezcollaborationitem.php on line 392
PHP Warning:  "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in ./kernel/classes/ezcontentobjecttreenode.php on line 734
PHP Warning:  "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in ./kernel/classes/ezcollaborationgroup.php on line 229
PHP Warning:  "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in ./kernel/classes/ezsiteaccess.php on line 160
PHP Warning:  "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in ./kernel/classes/ezsiteaccess.php on line 171
PHP Warning:  "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in ./kernel/classes/ezsiteaccess.php on line 225
PHP Warning:  "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in ./kernel/classes/ezsiteaccess.php on line 267
PHP Warning:  "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in ./kernel/classes/ezsiteaccess.php on line 356
PHP Warning:  "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in ./kernel/package/ezpackagefunctioncollection.php on line 70
PHP Warning:  "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in ./kernel/package/ezpackagefunctioncollection.php on line 161
PHP Warning:  "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in ./kernel/search/plugins/ezsearchengine/ezsearchengine.php on line 1209
PHP Warning:  "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in ./lib/ezutils/classes/ezmoduleoperationinfo.php on line 458
```

I tried to figure out what the code does and act accordingly to what I thought indended behaviour was supposed to be, but I'm not sure if it will break anything since this PR actually changes behavior (by replacing `continue;` with `continue 2;` instead of `break;` as the warning suggests)