### PR TITLE
Atomic cache writes to prevent corrupt caches.

### DIFF
--- a/lib/ezi18n/classes/eztranslationcache.php
+++ b/lib/ezi18n/classes/eztranslationcache.php
@@ -196,7 +196,7 @@ class eZTranslationCache
         $php->addRawVariable( 'TranslationInfo', $cache['info'] );
         $php->addSpace();
         $php->addRawVariable( 'TranslationRoot', $cache['root'] );
-        $php->store();
+        $php->store( true );
     }
 
     /*!

--- a/lib/eztemplate/classes/eztemplatetreecache.php
+++ b/lib/eztemplate/classes/eztemplatetreecache.php
@@ -230,7 +230,7 @@ class eZTemplateTreeCache
         $php->addVariable( 'TemplateInfo', $cache['info'] );
         $php->addSpace();
         $php->addVariable( 'TemplateRoot', $cache['root'] );
-        $php->store();
+        $php->store( true );
     }
 }
 

--- a/lib/ezutils/classes/ezextension.php
+++ b/lib/ezutils/classes/ezextension.php
@@ -122,7 +122,7 @@ class eZExtension
             }
 
             $phpCache->addVariable( 'activeExtensions', self::$activeExtensionsCache[$cacheIdentifier] );
-            $phpCache->store();
+            $phpCache->store( true );
         }
         else
         {


### PR DESCRIPTION
Some caches doesn't use atomic writes when writing to disk. This can lead to corrupt cache files if multiple processes tries to write to the same file at the same time.