### PR TITLE
PHP 5.3, 5.5, 5.6 and 7.0 deprecation fixes

### DIFF
--- a/cronjobs/linkcheck.php
+++ b/cronjobs/linkcheck.php
@@ -79,7 +79,7 @@ foreach ( $linkList as $link )
               // Check if it is a valid internal link.
               foreach ( $siteURLs as $siteURL )
               {
-                  $siteURL = preg_replace("/\/$/e", "", $siteURL );
+                  $siteURL = preg_replace("/\/$/", "", $siteURL );
                   $fp = @fopen( $siteURL . "/". $url, "r" );
                   if ( !$fp )
                   {

--- a/design/admin/templates/setup/datatype_code.tpl
+++ b/design/admin/templates/setup/datatype_code.tpl
@@ -26,7 +26,7 @@ class {$full_class_name} extends eZDataType
     */
     function {$full_class_name}()
     {literal}{{/literal}
-        $this->eZDataType( self::{$constant_name}, "{$desc_name}" );
+        parent::__construct( self::{$constant_name}, "{$desc_name}" );
     {literal}}{/literal}
 
 {if $class_input}

--- a/design/standard/templates/setup/datatype_code.tpl
+++ b/design/standard/templates/setup/datatype_code.tpl
@@ -26,7 +26,7 @@ class {$full_class_name} extends eZDataType
     */
     function {$full_class_name}()
     {literal}{{/literal}
-        $this->eZDataType( self::{$constant_name}, "{$desc_name}" );
+        parent::__construct( self::{$constant_name}, "{$desc_name}" );
     {literal}}{/literal}
 
 {if $class_input}

--- a/extension/ezoe/ezxmltext/handlers/input/ezoexmlinput.php
+++ b/extension/ezoe/ezxmltext/handlers/input/ezoexmlinput.php
@@ -658,7 +658,7 @@ class eZOEXMLInput extends eZXMLInputHandler
     */
 
     // Get section level and reset curent xml node according to input header.
-    function &sectionLevel( &$sectionLevel, $headerLevel, &$TagStack, &$currentNode, &$domDocument )
+    function sectionLevel( &$sectionLevel, $headerLevel, &$TagStack, &$currentNode, &$domDocument )
     {
         if ( $sectionLevel < $headerLevel )
         {
@@ -774,7 +774,7 @@ class eZOEXMLInput extends eZXMLInputHandler
      \private
      \return the user input format for the given section
     */
-    function &inputSectionXML( &$section, $currentSectionLevel, $tdSectionLevel = null )
+    function inputSectionXML( &$section, $currentSectionLevel, $tdSectionLevel = null )
     {
         $output = '';
 
@@ -895,7 +895,7 @@ class eZOEXMLInput extends eZXMLInputHandler
      \private
      \return the user input format for the given list item
     */
-    function &inputListXML( &$listNode, $currentSectionLevel, $listSectionLevel = null, $noParagraphs = true )
+    function inputListXML( &$listNode, $currentSectionLevel, $listSectionLevel = null, $noParagraphs = true )
     {
         $output = '';
         $tagName = $listNode instanceof DOMNode ? $listNode->nodeName : '';
@@ -933,7 +933,7 @@ class eZOEXMLInput extends eZXMLInputHandler
      \private
      \return the user input format for the given table cell
     */
-    function &inputTdXML( &$tdNode, $currentSectionLevel, $tdSectionLevel = null )
+    function inputTdXML( &$tdNode, $currentSectionLevel, $tdSectionLevel = null )
     {
         $output = '';
         $tagName = $tdNode instanceof DOMNode ? $tdNode->nodeName : '';
@@ -962,7 +962,7 @@ class eZOEXMLInput extends eZXMLInputHandler
     /*!
      \return the input xml of the given paragraph
     */
-    function &inputParagraphXML( &$paragraph,
+    function inputParagraphXML( &$paragraph,
                                   $currentSectionLevel,
                                   $tdSectionLevel = null,
                                   $noRender = false )
@@ -1046,7 +1046,7 @@ class eZOEXMLInput extends eZXMLInputHandler
      \return the input xml for the given tag
      \as in the xhtml used inside the editor
     */
-    function &inputTagXML( &$tag, $currentSectionLevel, $tdSectionLevel = null )
+    function inputTagXML( &$tag, $currentSectionLevel, $tdSectionLevel = null )
     {
         $output       = '';
         $tagName      = $tag instanceof DOMNode ? $tag->nodeName : '';

--- a/extension/ezoe/modules/ezoe/classes/GoogleSpell.php
+++ b/extension/ezoe/modules/ezoe/classes/GoogleSpell.php
@@ -105,8 +105,8 @@ class GoogleSpell extends SpellChecker {
 	}
 
 	function _unhtmlentities($string) {
-		$string = preg_replace('~&#x([0-9a-f]+);~ei', 'chr(hexdec("\\1"))', $string);
-		$string = preg_replace('~&#([0-9]+);~e', 'chr(\\1)', $string);
+		$string = preg_replace_callback('~&#x([0-9a-f]+);~i', function($m) {return chr(hexdec($m[1]));}, $string);
+		$string = preg_replace_callback('~&#([0-9]+);~', function($m) {return chr($m[1]);}, $string);
 
 		$trans_tbl = get_html_translation_table(HTML_ENTITIES);
 		$trans_tbl = array_flip($trans_tbl);

--- a/extension/ezoe/modules/ezoe/classes/SpellChecker.php
+++ b/extension/ezoe/modules/ezoe/classes/SpellChecker.php
@@ -12,7 +12,7 @@ class SpellChecker {
 	 *
 	 * @param $config Configuration name/value array.
 	 */
-	function SpellChecker(&$config) {
+	function __construct(&$config) {
 		$this->_config = $config;
 	}
 

--- a/extension/ezoe/modules/ezoe/classes/utils/mcejson.php
+++ b/extension/ezoe/modules/ezoe/classes/utils/mcejson.php
@@ -36,7 +36,7 @@ class Moxiecode_JSONReader
 	private $_lastLocations;
 	private $_needProp;
 
-	function Moxiecode_JSONReader($data) {
+	function __construct($data) {
 		$this->_data = $data;
 		$this->_len = strlen($data);
 		$this->_pos = -1;
@@ -367,7 +367,7 @@ class Moxiecode_JSONReader
  * @package MCManager.utils
  */
 class Moxiecode_JSON {
-	function Moxiecode_JSON() {
+	function __construct() {
 	}
 
 	function decode($input) {

--- a/extension/ezoe/modules/ezoe/spellcheck_rpc.php
+++ b/extension/ezoe/modules/ezoe/spellcheck_rpc.php
@@ -78,8 +78,8 @@ if (isset($_POST["json_data"]))
 // Try globals array
 if (!$raw && isset($_GLOBALS["HTTP_RAW_POST_DATA"]))
     $raw = $_GLOBALS["HTTP_RAW_POST_DATA"];
-else if (!$raw && isset($HTTP_RAW_POST_DATA))
-    $raw = $HTTP_RAW_POST_DATA;
+else if (!$raw)
+    $raw = file_get_contents("php://input");;
 
 // Try stream
 if (!$raw)

--- a/kernel/classes/datatypes/ezxmltext/ezxmloutputhandler.php
+++ b/kernel/classes/datatypes/ezxmltext/ezxmloutputhandler.php
@@ -136,7 +136,7 @@ class eZXMLOutputHandler
      \pure
      \return the suffix for the attribute template, if false it is ignored.
     */
-    function &viewTemplateSuffix( &$contentobjectAttribute )
+    function viewTemplateSuffix( &$contentobjectAttribute )
     {
         $suffix = false;
         return $suffix;

--- a/kernel/url/view.php
+++ b/kernel/url/view.php
@@ -50,7 +50,7 @@ else
     $preFix = $protocol . "://" . $domain;
     $preFix .= eZSys::wwwDir();
 
-    $link = preg_replace("/^\//e", "", $link );
+    $link = preg_replace("/^\//", "", $link );
     $link = $preFix . "/" . $link;
 }
 

--- a/lib/ezdb/classes/ezmysqlidb.php
+++ b/lib/ezdb/classes/ezmysqlidb.php
@@ -844,7 +844,7 @@ class eZMySQLiDB extends eZDBInterface
         else
         {
             eZDebug::writeDebug( 'escapeString called before connection is made', __METHOD__ );
-            return mysql_escape_string( $str );
+            return mysqli_real_escape_string( $str );
         }
     }
 

--- a/lib/ezdbschema/classes/ezmysqlschema.php
+++ b/lib/ezdbschema/classes/ezmysqlschema.php
@@ -655,7 +655,7 @@ class eZMysqlSchema extends eZDBSchemaInterface
             return $this->DBInstance->escapeString( $value );
         }
 
-        return mysql_escape_string( $value );
+        return mysqli_real_escape_string( $value );
     }
 
     function schemaType()

--- a/lib/ezfile/classes/ezgzipzlibcompressionhandler.php
+++ b/lib/ezfile/classes/ezgzipzlibcompressionhandler.php
@@ -51,11 +51,15 @@ class eZGZIPZLIBCompressionHandler extends eZCompressionHandler
     static function isAvailable()
     {
         $extensionName = 'zlib';
+
+        // dl() is removed in PHP 7.0, see https://secure.php.net/manual/en/function.dl.php
+        /*
         if ( !extension_loaded( $extensionName ) )
         {
             $dlExtension = ( eZSys::osType() == 'win32' ) ? '.dll' : '.so';
             @dl( $extensionName . $dlExtension );
         }
+        */
         return extension_loaded( $extensionName );
     }
 

--- a/lib/ezpdf/classes/class.ezpdftable.php
+++ b/lib/ezpdf/classes/class.ezpdftable.php
@@ -33,7 +33,7 @@ class eZPDFTable extends Cezpdf
      * @param string $paper
      * @param string $orientation
      */
-    function eZPDFTable($paper='a4',$orientation='portrait')
+    function __construct($paper='a4',$orientation='portrait')
     {
         parent::__construct( $paper, $orientation );
         $this->TOC = array();
@@ -1516,7 +1516,7 @@ class eZPDFTable extends Cezpdf
         return '';
     }
 
-    function &fixWhitespace( &$text )
+    function fixWhitespace( &$text )
     {
         $text = str_replace( array( self::SPACE,
                                     self::TAB,

--- a/lib/ezpdf/classes/class.pdf.php
+++ b/lib/ezpdf/classes/class.pdf.php
@@ -2014,10 +2014,10 @@ class Cpdf
                     // note that pdf supports only binary format type 1 font files, though there is a
                     // simple utility to convert them from pfa to pfb.
                     $fp = fopen( $fbfile, 'rb' );
-                    $tmp = get_magic_quotes_runtime();
-                    set_magic_quotes_runtime( 0 );
+//                    $tmp = get_magic_quotes_runtime();
+//                    set_magic_quotes_runtime( 0 );
                     $data = fread( $fp, filesize( $fbfile ) );
-                    set_magic_quotes_runtime( $tmp );
+//                    set_magic_quotes_runtime( $tmp );
                     fclose( $fp );
 
                     // create the font descriptor
@@ -3564,8 +3564,8 @@ class Cpdf
     {
         // read in a png file, interpret it, then add to the system
         $error = 0;
-        $tmp = get_magic_quotes_runtime();
-        set_magic_quotes_runtime(0);
+//        $tmp = get_magic_quotes_runtime();
+//        set_magic_quotes_runtime(0);
         $fp = @fopen( $file, 'rb' );
         if ( $fp )
         {
@@ -3581,7 +3581,7 @@ class Cpdf
             $error = 1;
             $errormsg = 'trouble opening file: '.$file;
         }
-        set_magic_quotes_runtime( $tmp );
+//        set_magic_quotes_runtime( $tmp );
 
         if ( !$error )
         {
@@ -3832,10 +3832,10 @@ class Cpdf
 
         $fp = fopen( $img, 'rb' );
 
-        $tmp = get_magic_quotes_runtime();
-        set_magic_quotes_runtime( 0 );
+//        $tmp = get_magic_quotes_runtime();
+//        set_magic_quotes_runtime( 0 );
         $data = fread( $fp, filesize( $img ) );
-        set_magic_quotes_runtime( $tmp );
+//        set_magic_quotes_runtime( $tmp );
 
         fclose( $fp );
 
@@ -3888,8 +3888,8 @@ class Cpdf
         imagejpeg( $img, $tmpName, $quality );
         $fp = fopen( $tmpName, 'rb' );
 
-        $tmp = get_magic_quotes_runtime();
-        set_magic_quotes_runtime( 0 );
+//        $tmp = get_magic_quotes_runtime();
+//        set_magic_quotes_runtime( 0 );
         $fp = @fopen( $tmpName, 'rb' );
         if ( $fp )
         {
@@ -3906,7 +3906,7 @@ class Cpdf
             $errormsg = 'trouble opening file';
         }
     //  $data = fread($fp,filesize($tmpName));
-        set_magic_quotes_runtime( $tmp );
+//        set_magic_quotes_runtime( $tmp );
     //  fclose( $fp );
         unlink( $tmpName );
         $this->addJpegImage_common( $data, $x, $y, $w, $h, $imageWidth, $imageHeight );

--- a/lib/ezsoap/classes/ezsoapserver.php
+++ b/lib/ezsoap/classes/ezsoapserver.php
@@ -50,8 +50,7 @@ class eZSOAPServer
 {
     public function __construct()
     {
-        global $HTTP_RAW_POST_DATA;
-        $this->RawPostData = $HTTP_RAW_POST_DATA;
+        $this->RawPostData = file_get_contents( "php://input" );
     }
 
 

--- a/tests/toolkit/extras/tests-files/workflowevent_regression_fetchtemplaterepeat.php
+++ b/tests/toolkit/extras/tests-files/workflowevent_regression_fetchtemplaterepeat.php
@@ -13,7 +13,7 @@ class WorkflowEventRegressionFetchTemplateRepeatType extends eZWorkflowEventType
     const WORKFLOW_TYPE_STRING = 'fetchtemplaterepeat';
     function __construct()
     {
-        $this->eZWorkflowEventType( WorkflowEventRegressionFetchTemplateRepeatType::WORKFLOW_TYPE_STRING, "WorkflowEventRegressionFetchTemplateRepeatType test" );
+        parent::__construct( WorkflowEventRegressionFetchTemplateRepeatType::WORKFLOW_TYPE_STRING, "WorkflowEventRegressionFetchTemplateRepeatType test" );
         $this->setTriggerTypes( array( 'content' => array( 'publish' => array( 'before' ) ) ) );
     }
 


### PR DESCRIPTION
Fixes all that can be fixed of:

```
 PHP | File:Line                                                                                          |             Type | Issue
 5.3 | /extension/ezoe/ezxmltext/handlers/input/ezoexmlinput.php:661                                      | function_usage   | Function usage sectionLevel() (@call_with_passing_by_reference) is deprecated. 
 5.3 | /extension/ezoe/ezxmltext/handlers/input/ezoexmlinput.php:777                                      | function_usage   | Function usage inputSectionXML() (@call_with_passing_by_reference) is deprecated. 
 5.3 | /extension/ezoe/ezxmltext/handlers/input/ezoexmlinput.php:898                                      | function_usage   | Function usage inputListXML() (@call_with_passing_by_reference) is deprecated. 
 5.3 | /extension/ezoe/ezxmltext/handlers/input/ezoexmlinput.php:936                                      | function_usage   | Function usage inputTdXML() (@call_with_passing_by_reference) is deprecated. 
 5.3 | /extension/ezoe/ezxmltext/handlers/input/ezoexmlinput.php:965                                      | function_usage   | Function usage inputParagraphXML() (@call_with_passing_by_reference) is deprecated. 
 5.3 | /extension/ezoe/ezxmltext/handlers/input/ezoexmlinput.php:1049                                     | function_usage   | Function usage inputTagXML() (@call_with_passing_by_reference) is deprecated. 
 5.3 | /kernel/classes/datatypes/ezxmltext/ezxmloutputhandler.php:139                                     | function_usage   | Function usage viewTemplateSuffix() (@call_with_passing_by_reference) is deprecated. 
 5.3 | /lib/ezfile/classes/ezgzipzlibcompressionhandler.php:57                                            | function         | Function dl() is deprecated. 
 5.3 | /lib/ezpdf/classes/class.ezpdftable.php:1519                                                       | function_usage   | Function usage fixWhitespace() (@call_with_passing_by_reference) is deprecated. 
 5.3 | /lib/ezpdf/classes/class.pdf.php:2018                                                              | function         | Function set_magic_quotes_runtime() is deprecated. 
 5.3 | /lib/ezpdf/classes/class.pdf.php:2020                                                              | function         | Function set_magic_quotes_runtime() is deprecated. 
 5.3 | /lib/ezpdf/classes/class.pdf.php:3568                                                              | function         | Function set_magic_quotes_runtime() is deprecated. 
 5.3 | /lib/ezpdf/classes/class.pdf.php:3584                                                              | function         | Function set_magic_quotes_runtime() is deprecated. 
 5.3 | /lib/ezpdf/classes/class.pdf.php:3836                                                              | function         | Function set_magic_quotes_runtime() is deprecated. 
 5.3 | /lib/ezpdf/classes/class.pdf.php:3838                                                              | function         | Function set_magic_quotes_runtime() is deprecated. 
 5.3 | /lib/ezpdf/classes/class.pdf.php:3892                                                              | function         | Function set_magic_quotes_runtime() is deprecated. 
 5.3 | /lib/ezpdf/classes/class.pdf.php:3909                                                              | function         | Function set_magic_quotes_runtime() is deprecated. 
 5.5 | /cronjobs/linkcheck.php:82                                                                         | function_usage   | Function usage preg_replace() (@preg_replace_e_modifier) is deprecated. 
 5.5 | /extension/ezoe/modules/ezoe/classes/GoogleSpell.php:108                                           | function_usage   | Function usage preg_replace() (@preg_replace_e_modifier) is deprecated. 
 5.5 | /extension/ezoe/modules/ezoe/classes/GoogleSpell.php:109                                           | function_usage   | Function usage preg_replace() (@preg_replace_e_modifier) is deprecated. 
 5.5 | /kernel/url/view.php:53                                                                            | function_usage   | Function usage preg_replace() (@preg_replace_e_modifier) is deprecated. 
 5.5 | /lib/ezdb/classes/ezmysqlidb.php:847                                                               | function         | Function mysql_escape_string() is deprecated. 
 5.5 | /lib/ezdbschema/classes/ezmysqlschema.php:658                                                      | function         | Function mysql_escape_string() is deprecated. 
 5.6 | /extension/ezoe/modules/ezoe/spellcheck_rpc.php:81                                                 | variable         | Variable $HTTP_RAW_POST_DATA is deprecated. 
 5.6 | /extension/ezoe/modules/ezoe/spellcheck_rpc.php:82                                                 | variable         | Variable $HTTP_RAW_POST_DATA is deprecated. 
 5.6 | /lib/ezsoap/classes/ezsoapserver.php:53                                                            | variable         | Variable $HTTP_RAW_POST_DATA is deprecated. 
 5.6 | /lib/ezsoap/classes/ezsoapserver.php:54                                                            | variable         | Variable $HTTP_RAW_POST_DATA is deprecated. 
 7.0 | /extension/ezoe/modules/ezoe/classes/SpellChecker.php:15                                           | method_name      | Method name SpellChecker:SpellChecker (@php4_constructors) is deprecated. 
 7.0 | /extension/ezoe/modules/ezoe/classes/utils/mcejson.php:39                                          | method_name      | Method name Moxiecode_JSONReader:Moxiecode_JSONReader (@php4_constructors) is deprecated. 
 7.0 | /extension/ezoe/modules/ezoe/classes/utils/mcejson.php:370                                         | method_name      | Method name Moxiecode_JSON:Moxiecode_JSON (@php4_constructors) is deprecated. 
 7.0 | /kernel/classes/ezdatatype.php:86                                                                  | method_name      | Method name eZDataType:eZDataType (@php4_constructors) is deprecated. 
 7.0 | /kernel/classes/ezpersistentobject.php:64                                                          | method_name      | Method name eZPersistentObject:eZPersistentObject (@php4_constructors) is deprecated. 
 7.0 | /kernel/classes/ezsiteinstaller.php:40                                                             | method_name      | Method name eZSiteInstaller:eZSiteInstaller (@php4_constructors) is deprecated. 
 7.0 | /kernel/classes/ezworkflowevent.php:29                                                             | method_name      | Method name eZWorkflowEvent:eZWorkflowEvent (@php4_constructors) is deprecated. 
 7.0 | /kernel/classes/ezworkfloweventtype.php:35                                                         | method_name      | Method name eZWorkflowEventType:eZWorkflowEventType (@php4_constructors) is deprecated. 
 7.0 | /kernel/classes/ezworkflowtype.php:67                                                              | method_name      | Method name eZWorkflowType:eZWorkflowType (@php4_constructors) is deprecated. 
 7.0 | /lib/ezpdf/classes/class.ezpdftable.php:36                                                         | method_name      | Method name eZPDFTable:eZPDFTable (@php4_constructors) is deprecated. 
```

What remains cannot be fixed because of external dependencies:

```
 PHP | File:Line                                                                                          |             Type | Issue
 7.0 | /kernel/classes/ezdatatype.php:86                                                                  | method_name      | Method name eZDataType:eZDataType (@php4_constructors) is deprecated. 
 7.0 | /kernel/classes/ezpersistentobject.php:64                                                          | method_name      | Method name eZPersistentObject:eZPersistentObject (@php4_constructors) is deprecated. 
 7.0 | /kernel/classes/ezsiteinstaller.php:40                                                             | method_name      | Method name eZSiteInstaller:eZSiteInstaller (@php4_constructors) is deprecated. 
 7.0 | /kernel/classes/ezworkflowevent.php:29                                                             | method_name      | Method name eZWorkflowEvent:eZWorkflowEvent (@php4_constructors) is deprecated. 
 7.0 | /kernel/classes/ezworkfloweventtype.php:35                                                         | method_name      | Method name eZWorkflowEventType:eZWorkflowEventType (@php4_constructors) is deprecated. 
 7.0 | /kernel/classes/ezworkflowtype.php:67                                                              | method_name      | Method name eZWorkflowType:eZWorkflowType (@php4_constructors) is deprecated. 
```

Todo:
- [ ] Travis _(AR: potentially unrelated so should be solved by someone in different 
PR, but in order to merge such a change like this we need CI running again)_