### PR TITLE
Workaround to the get the customer order view working with email addresses that include a "+" character

### DIFF
--- a/design/admin/templates/shop/orderlist.tpl
+++ b/design/admin/templates/shop/orderlist.tpl
@@ -73,7 +73,7 @@
     {if is_null($Orders.item.account_name)}
         <s><i>{'( removed )'|i18n( 'design/admin/shop/orderlist' )}</i></s>
     {else}
-        <a href={concat( '/shop/customerorderview/', $Orders.item.user_id, '/', $Orders.item.account_email )|ezurl}>{$Orders.item.account_name|wash}</a>
+        <a href={concat( '/shop/customerorderview/', $Orders.item.user_id, '?email=', $Orders.item.account_email|urlencode )|ezurl}>{$Orders.item.account_name|wash}</a>
     {/if}
     </td>
     

--- a/kernel/shop/customerorderview.php
+++ b/kernel/shop/customerorderview.php
@@ -15,7 +15,17 @@ $http = eZHTTPTool::instance();
 
 $tpl = eZTemplate::factory();
 
-$Email = urldecode( $Email );
+// allow usage of get parameter as well which is safer for some email formats
+if ( $Email )
+{
+    $Email = urldecode( $Email );
+}
+// workaround because it seems not possible to get an urlencoded "+" character accross $Params
+else if ( $http->hasGetVariable( "email" ) )
+{
+    $Email = $http->getVariable( "email" );
+}
+
 $productList = eZOrder::productList( $CustomerID, $Email );
 $orderList = eZOrder::orderList( $CustomerID, $Email );
 


### PR DESCRIPTION
This is a continuation of the closed pull request https://github.com/ezsystems/ezpublish-legacy/pull/1199 with suggested changes from @andrerom.