### PR TITLE
EZP-29703: Legacy LDAP users cause error message on login

### DIFF
--- a/kernel/classes/datatypes/ezuser/ezldapuser.php
+++ b/kernel/classes/datatypes/ezuser/ezldapuser.php
@@ -91,14 +91,15 @@ class eZLDAPUser extends eZUser
                         $exists = true;
                 }
 
-                eZDebugSetting::writeDebug( 'kernel-user', eZUser::createHash( $userRow['login'], $password, eZUser::site(),
-                                                                               $hashType ), "check hash" );
-                eZDebugSetting::writeDebug( 'kernel-user', $hash, "stored hash" );
                  // If current user has been disabled after a few failed login attempts.
                 $canLogin = eZUser::isEnabledAfterFailedLogin( $userID );
 
                 if ( $exists )
                 {
+                    eZDebugSetting::writeDebug( 'kernel-user', eZUser::createHash( $userRow['login'], $password, eZUser::site(),
+                                                                                   $hashType ), "check hash" );
+                    eZDebugSetting::writeDebug( 'kernel-user', $hash, "stored hash" );
+
                     // We should store userID for warning message.
                     $GLOBALS['eZFailedLoginAttemptUserID'] = $userID;
 

--- a/kernel/classes/datatypes/ezuser/ezldapuser.php
+++ b/kernel/classes/datatypes/ezuser/ezldapuser.php
@@ -822,7 +822,7 @@ class eZLDAPUser extends eZUser
         }
 
         $user->setAttribute( 'password_hash', "" );
-        $user->setAttribute( 'password_hash_type', 0 );
+        $user->setAttribute( 'password_hash_type', self::PASSWORD_HASH_EMPTY );
         $user->store();
 
         $debugArray = array( 'Updating user data',

--- a/kernel/classes/datatypes/ezuser/eztextfileuser.php
+++ b/kernel/classes/datatypes/ezuser/eztextfileuser.php
@@ -102,14 +102,15 @@ class eZTextFileUser extends eZUser
                         $exists = true;
                 }
 
-                eZDebugSetting::writeDebug( 'kernel-user', eZUser::createHash( $userRow['login'], $password, eZUser::site(),
-                                                                               $hashType ), "check hash" );
-                eZDebugSetting::writeDebug( 'kernel-user', $hash, "stored hash" );
                  // If current user has been disabled after a few failed login attempts.
                 $canLogin = eZUser::isEnabledAfterFailedLogin( $userID );
 
                 if ( $exists )
                 {
+                    eZDebugSetting::writeDebug( 'kernel-user', eZUser::createHash( $userRow['login'], $password, eZUser::site(),
+                                                                                   $hashType ), "check hash" );
+                    eZDebugSetting::writeDebug( 'kernel-user', $hash, "stored hash" );
+
                     // We should store userID for warning message.
                     $GLOBALS['eZFailedLoginAttemptUserID'] = $userID;
 
@@ -279,7 +280,7 @@ class eZTextFileUser extends eZUser
                             $user->setAttribute( 'login', $login );
                             $user->setAttribute( 'email', $email );
                             $user->setAttribute( 'password_hash', "" );
-                            $user->setAttribute( 'password_hash_type', 0 );
+                            $user->setAttribute( 'password_hash_type', self::PASSWORD_HASH_EMPTY );
                             $user->store();
 
                             eZUser::updateLastVisit( $userID );
@@ -318,7 +319,7 @@ class eZTextFileUser extends eZUser
                             $existUser = eZUser::fetch(  $userID );
                             $existUser->setAttribute('email', $email );
                             $existUser->setAttribute('password_hash', "" );
-                            $existUser->setAttribute('password_hash_type', 0 );
+                            $existUser->setAttribute('password_hash_type', self::PASSWORD_HASH_EMPTY );
                             $existUser->store();
 
                             if ( $defaultUserPlacement != $parentNodeID )

--- a/kernel/classes/datatypes/ezuser/ezuser.php
+++ b/kernel/classes/datatypes/ezuser/ezuser.php
@@ -1885,14 +1885,17 @@ WHERE user_id = '" . $userID . "' AND
         {
             $str = password_hash( $password, PASSWORD_DEFAULT );
         }
-        else if ( $type == self::PASSWORD_HASH_EMPTY )
-        {
-            eZDebug::writeError( "Cannot create hash of hash type 0 (PASSWORD_HASH_EMPTY)." );
-            return false;
-        }
         else
         {
-            eZDebug::writeError( "Password hash type ID '$type' is not recognized." );
+            if ( $type == self::PASSWORD_HASH_EMPTY )
+            {
+                eZDebug::writeError( "Cannot create hash of hash type 0 (PASSWORD_HASH_EMPTY)." );
+            }
+            else
+            {
+                eZDebug::writeError( "Password hash type ID '$type' is not recognized." );
+            }
+
             return false;
         }
 

--- a/kernel/classes/datatypes/ezuser/ezuser.php
+++ b/kernel/classes/datatypes/ezuser/ezuser.php
@@ -17,6 +17,8 @@
 
 class eZUser extends eZPersistentObject
 {
+    /// No hash, used by external handlers such as LDAP and TextFile
+    const PASSWORD_HASH_EMPTY = 0;
     /// MD5 of password
     const PASSWORD_HASH_MD5_PASSWORD = 1;
     /// MD5 of user and password
@@ -123,6 +125,10 @@ class eZUser extends eZPersistentObject
     {
         switch ( $id )
         {
+            case self::PASSWORD_HASH_EMPTY:
+            {
+                return 'empty';
+            } break;
             case self::PASSWORD_HASH_MD5_PASSWORD:
             {
                 return 'md5_password';
@@ -161,6 +167,10 @@ class eZUser extends eZPersistentObject
     {
         switch ( $identifier )
         {
+            case 'empty':
+            {
+                return self::PASSWORD_HASH_EMPTY;
+            } break;
             case 'md5_password':
             {
                 return self::PASSWORD_HASH_MD5_PASSWORD;
@@ -296,8 +306,14 @@ class eZUser extends eZPersistentObject
         if ( eZUser::validatePassword( $password ) and
              $password === $passwordConfirm ) // Cannot change login or password_hash without login and password
         {
-            $this->setAttribute( "password_hash", eZUser::createHash( $login, $password, eZUser::site(),
-                                                                      eZUser::hashType() ) );
+            if ( eZUser::hashType() !== self::PASSWORD_HASH_EMPTY )
+            {
+                $this->setAttribute(
+                    "password_hash",
+                    eZUser::createHash( $login, $password, eZUser::site(), eZUser::hashType() )
+                );
+            }
+
             $this->setAttribute( "password_hash_type", eZUser::hashType() );
         }
         else
@@ -869,14 +885,15 @@ WHERE user_id = '" . $userID . "' AND
 
                 }
 
-                eZDebugSetting::writeDebug( 'kernel-user', eZUser::createHash( $userRow['login'], $password, eZUser::site(),
-                                                                               $hashType, $hash ), "check hash" );
-                eZDebugSetting::writeDebug( 'kernel-user', $hash, "stored hash" );
                  // If current user has been disabled after a few failed login attempts.
                 $canLogin = eZUser::isEnabledAfterFailedLogin( $userID );
 
                 if ( $exists )
                 {
+                    eZDebugSetting::writeDebug( 'kernel-user', eZUser::createHash( $userRow['login'], $password, eZUser::site(),
+                                                                                   $hashType, $hash ), "check hash" );
+                    eZDebugSetting::writeDebug( 'kernel-user', $hash, "stored hash" );
+
                     // We should store userID for warning message.
                     $GLOBALS['eZFailedLoginAttemptUserID'] = $userID;
 
@@ -1715,6 +1732,11 @@ WHERE user_id = '" . $userID . "' AND
     */
     static function authenticateHash( $user, $password, $site, $type, $hash )
     {
+        if ( $user == '' || $password == '' || $type == self::PASSWORD_HASH_EMPTY )
+        {
+            return false;
+        }
+
         return eZUser::createHash( $user, $password, $site, $type, $hash ) === (string) $hash;
     }
 
@@ -1863,12 +1885,17 @@ WHERE user_id = '" . $userID . "' AND
         {
             $str = password_hash( $password, PASSWORD_DEFAULT );
         }
-        else // self::DEFAULT_PASSWORD_HASH
+        else if ( $type == self::PASSWORD_HASH_EMPTY )
         {
-            eZDebug::writeError( "Password hash type ID '$type' is not recognized. " .
-                                 'Defaulting to eZUser::DEFAULT_PASSWORD_HASH.' );
-            $str = self::createHash( $user, $password, $site, self::DEFAULT_PASSWORD_HASH, $hash );
+            eZDebug::writeError( "Cannot create hash of hash type 0 (PASSWORD_HASH_EMPTY)." );
+            return false;
         }
+        else
+        {
+            eZDebug::writeError( "Password hash type ID '$type' is not recognized." );
+            return false;
+        }
+
         eZDebugSetting::writeDebug( 'kernel-user', $str, "ezuser($type)" );
         return $str;
     }


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-29703
> Ready for review

Users created by the LDAP login handler have password_hash_type = 0 and password_hash is empty string. On login the standard login handler runs first. It currently doesn't recognise these users and logs an error: `Password hash type ID '0' is not recognized. Defaulting to eZUser::DEFAULT_PASSWORD_HASH.` We should accept this case without errors.

Resolved by adding new type `eZUser::PASSWORD_HASH_EMPTY = 0` and by not running `createHash()` for this hash type. Log error if it still happens.