### PR TITLE
fixed fatal error in eZUserType::objectAttributeContent

### DIFF
--- a/kernel/classes/datatypes/ezuser/ezusertype.php
+++ b/kernel/classes/datatypes/ezuser/ezusertype.php
@@ -364,6 +364,11 @@ class eZUserType extends eZDataType
         $user = eZUser::fetch( $userID );
         eZDebugSetting::writeDebug( 'kernel-user', $user, 'user' );
 
+        // return if user object wasn't found to avoid a fatal error in eZUserType::updateUserDraft
+        if ( !( $user instanceof eZUser ) ) {
+            return null;
+        }
+
         // Looking for a "draft" and loading it's content
         $serializedDraft = $contentObjectAttribute->attribute( 'data_text' );
 


### PR DESCRIPTION
Fixed a fatal error in eZUserType::objectAttributeContent because user object could not be loaded