### PR TITLE
EZP-29798: Legacy transaction handling: Discard draft

### DIFF
--- a/kernel/content/removeeditversion.php
+++ b/kernel/content/removeeditversion.php
@@ -28,9 +28,6 @@ if ( $isConfirmed )
     if ( $object === null )
         return $Module->handleError( eZError::KERNEL_NOT_AVAILABLE, 'kernel' );
 
-    $db = eZDB::instance();
-    $db->begin();
-
     $versionObject = $object->version( $version );
     if ( is_object( $versionObject ) and
          in_array( $versionObject->attribute( 'status' ), array( eZContentObjectVersion::STATUS_DRAFT, eZContentObjectVersion::STATUS_INTERNAL_DRAFT ) ) )
@@ -49,22 +46,13 @@ if ( $isConfirmed )
                 $allowEdit = false;
 
             if ( !$allowEdit )
-            {
-                $db->rollback();
                 return $Module->handleError( eZError::KERNEL_ACCESS_DENIED, 'kernel', array( 'AccessList' => $object->accessList( 'edit' ) ) );
-            }
         }
 
         $versionCount= $object->getVersionCount();
         $nodeID = $versionCount == 1 ? $versionObject->attribute( 'main_parent_node_id' ) : $object->attribute( 'main_node_id' );
         $versionObject->removeThis();
-        $db->commit();
     }
-    else
-    {
-        $db->rollback();
-    }
-
     $hasRedirected = false;
     if ( $http->hasSessionVariable( 'RedirectIfDiscarded' ) )
     {

--- a/kernel/content/removeeditversion.php
+++ b/kernel/content/removeeditversion.php
@@ -7,6 +7,7 @@
  */
 $Module = $Params['Module'];
 $http = eZHTTPTool::instance();
+$db = eZDB::instance();
 $objectID = (int) $http->sessionVariable( "DiscardObjectID" );
 $version = (int) $http->sessionVariable( "DiscardObjectVersion" );
 $editLanguage = $http->sessionVariable( "DiscardObjectLanguage" );
@@ -28,7 +29,16 @@ if ( $isConfirmed )
     if ( $object === null )
         return $Module->handleError( eZError::KERNEL_NOT_AVAILABLE, 'kernel' );
 
-    $versionObject = $object->version( $version );
+    $db->begin();
+
+    $versionRes = $db->query( "SELECT * FROM ezcontentobject_version WHERE version = $version AND contentobject_id = $objectID FOR UPDATE" );
+    $versionRow = $versionRes->fetch_array(MYSQLI_ASSOC);
+    if ( !is_array( $versionRow ) )
+    {
+        $db->commit(); // We haven't made any changes, but commit here to avoid affecting any outer transactions.
+        return $Module->handleError( eZError::KERNEL_NOT_AVAILABLE, 'kernel' );
+    }
+    $versionObject = eZContentObjectVersion::fetch( $versionRow['id'] );
     if ( is_object( $versionObject ) and
          in_array( $versionObject->attribute( 'status' ), array( eZContentObjectVersion::STATUS_DRAFT, eZContentObjectVersion::STATUS_INTERNAL_DRAFT ) ) )
     {
@@ -46,13 +56,19 @@ if ( $isConfirmed )
                 $allowEdit = false;
 
             if ( !$allowEdit )
+            {
+                $db->commit(); // We haven't made any changes, but commit here to avoid affecting any outer transactions.
                 return $Module->handleError( eZError::KERNEL_ACCESS_DENIED, 'kernel', array( 'AccessList' => $object->accessList( 'edit' ) ) );
+            }
         }
 
         $versionCount= $object->getVersionCount();
         $nodeID = $versionCount == 1 ? $versionObject->attribute( 'main_parent_node_id' ) : $object->attribute( 'main_node_id' );
         $versionObject->removeThis();
     }
+
+    $db->commit();
+
     $hasRedirected = false;
     if ( $http->hasSessionVariable( 'RedirectIfDiscarded' ) )
     {

--- a/kernel/content/removeeditversion.php
+++ b/kernel/content/removeeditversion.php
@@ -28,6 +28,9 @@ if ( $isConfirmed )
     if ( $object === null )
         return $Module->handleError( eZError::KERNEL_NOT_AVAILABLE, 'kernel' );
 
+    $db = eZDB::instance();
+    $db->begin();
+
     $versionObject = $object->version( $version );
     if ( is_object( $versionObject ) and
          in_array( $versionObject->attribute( 'status' ), array( eZContentObjectVersion::STATUS_DRAFT, eZContentObjectVersion::STATUS_INTERNAL_DRAFT ) ) )
@@ -46,13 +49,22 @@ if ( $isConfirmed )
                 $allowEdit = false;
 
             if ( !$allowEdit )
+            {
+                $db->rollback();
                 return $Module->handleError( eZError::KERNEL_ACCESS_DENIED, 'kernel', array( 'AccessList' => $object->accessList( 'edit' ) ) );
+            }
         }
 
         $versionCount= $object->getVersionCount();
         $nodeID = $versionCount == 1 ? $versionObject->attribute( 'main_parent_node_id' ) : $object->attribute( 'main_node_id' );
         $versionObject->removeThis();
+        $db->commit();
     }
+    else
+    {
+        $db->rollback();
+    }
+
     $hasRedirected = false;
     if ( $http->hasSessionVariable( 'RedirectIfDiscarded' ) )
     {

--- a/kernel/content/removeeditversion.php
+++ b/kernel/content/removeeditversion.php
@@ -31,14 +31,13 @@ if ( $isConfirmed )
 
     $db->begin();
 
-    $versionRes = $db->query( "SELECT * FROM ezcontentobject_version WHERE version = $version AND contentobject_id = $objectID FOR UPDATE" );
-    $versionRow = $versionRes->fetch_array(MYSQLI_ASSOC);
-    if ( !is_array( $versionRow ) )
+    $versionRows = $db->arrayQuery( "SELECT * FROM ezcontentobject_version WHERE version = $version AND contentobject_id = $objectID FOR UPDATE" );
+    if ( empty( $versionRows ) )
     {
         $db->commit(); // We haven't made any changes, but commit here to avoid affecting any outer transactions.
         return $Module->handleError( eZError::KERNEL_NOT_AVAILABLE, 'kernel' );
     }
-    $versionObject = eZContentObjectVersion::fetch( $versionRow['id'] );
+    $versionObject = eZContentObjectVersion::fetch( $versionRows[0]['id'] );
     if ( is_object( $versionObject ) and
          in_array( $versionObject->attribute( 'status' ), array( eZContentObjectVersion::STATUS_DRAFT, eZContentObjectVersion::STATUS_INTERNAL_DRAFT ) ) )
     {


### PR DESCRIPTION
> Fixes https://jira.ez.no/browse/EZP-29798
> Sub-task of https://jira.ez.no/browse/EZP-28681
> See history in obsolete shared PR https://github.com/ezsystems/ezpublish-legacy/pull/1380

Use select-for-update on object version, to ensure no one else can modify the version. Other threads return `eZError::KERNEL_NOT_AVAILABLE`.