### PR TITLE
EZP-29800: Legacy transaction handling: DFS cache purge

### DIFF
--- a/kernel/private/classes/clusterfilehandlers/dfsbackends/mysqli.php
+++ b/kernel/private/classes/clusterfilehandlers/dfsbackends/mysqli.php
@@ -334,7 +334,6 @@ class eZDFSFileHandlerMySQLiBackend implements eZClusterEventNotifier
      * @see _purge
      *
      * @return bool|int false if it fails, number of affected rows otherwise
-     * @todo This method should also remove the files from disk
      */
     public function _purgeByLike( $like, $onlyExpired = false, $limit = 50, $expiry = false, $fname = false )
     {
@@ -392,11 +391,15 @@ class eZDFSFileHandlerMySQLiBackend implements eZClusterEventNotifier
             return $this->_fail( "Purging file metadata by like statement $like failed" );
         }
         $deletedDBFiles = mysqli_affected_rows( $this->db );
-        $this->dfsbackend->delete( $files );
 
-        $this->_commit( $fname );
+        if ( $this->_commit( $fname ) === true )
+        {
+            $this->dfsbackend->delete( $files );
 
-        return $deletedDBFiles;
+            return $deletedDBFiles;
+        }
+
+        return false;
     }
 
     /**
@@ -1351,6 +1354,10 @@ class eZDFSFileHandlerMySQLiBackend implements eZClusterEventNotifier
     /**
      * Stops a current transaction and commits the changes by executing a COMMIT call.
      * If the current transaction is a sub-transaction nothing is executed.
+     *
+     * Returns true if the commit was executed successfully, false if it failed, null if it wasn't executed.
+     *
+     * @return bool|null
      */
     protected function _commit( $fname = false )
     {
@@ -1360,7 +1367,11 @@ class eZDFSFileHandlerMySQLiBackend implements eZClusterEventNotifier
             $fname = "_commit";
         $this->transactionCount--;
         if ( $this->transactionCount == 0 )
-            $this->_query( "COMMIT", $fname );
+        {
+            return $this->_query("COMMIT", $fname) !== false;
+        }
+
+        return null;
     }
 
     /**

--- a/kernel/private/classes/clusterfilehandlers/dfsbackends/mysqli.php
+++ b/kernel/private/classes/clusterfilehandlers/dfsbackends/mysqli.php
@@ -392,7 +392,8 @@ class eZDFSFileHandlerMySQLiBackend implements eZClusterEventNotifier
         }
         $deletedDBFiles = mysqli_affected_rows( $this->db );
 
-        if ( $this->_commit( $fname ) === true )
+        $commitResult = $this->_commit( $fname );
+        if ( $commitResult === true || $commitResult === null )
         {
             $this->dfsbackend->delete( $files );
 


### PR DESCRIPTION
> Fixes https://jira.ez.no/browse/EZP-29800
> Sub-task of https://jira.ez.no/browse/EZP-28681
> See history in obsolete shared PR https://github.com/ezsystems/ezpublish-legacy/pull/1380

We need to know if the commit succeeded, before we can delete files.  This adds a return value to `_commit()` for that purpose.

This is problematic. What happens if the commits are recursive and `null` is returned? The files won't be deleted, but if the outer commit eventually goes through, we would want them to be. OTOH if we did delete them in the null case, and the outer commit was rolled back, we'd have the opposite problem.

Then again, it looks to me like the way purge is called, there won't be any recursive transactions here, so it's no issue in practice. The important thing is knowing if the commit failed, and not delete any files in that case. And that is covered now.