### PR TITLE
EZP-29279: Values of Date Field Type should be handled in UTC only

### DIFF
--- a/autoload/ezp_kernel.php
+++ b/autoload/ezp_kernel.php
@@ -486,6 +486,7 @@ return array(
       'eZTextTool'                                         => 'lib/ezutils/classes/eztexttool.php',
       'eZTextType'                                         => 'kernel/classes/datatypes/eztext/eztexttype.php',
       'eZTime'                                             => 'lib/ezlocale/classes/eztime.php',
+      'eZTimestamp'                                        => 'lib/ezutils/classes/eztimestamp.php',
       'eZTimeType'                                         => 'kernel/classes/datatypes/eztime/eztimetype.php',
       'eZTipafriendCounter'                                => 'kernel/classes/eztipafriendcounter.php',
       'eZTipafriendRequest'                                => 'kernel/classes/eztipafriendrequest.php',

--- a/kernel/classes/datatypes/ezdate/ezdatetype.php
+++ b/kernel/classes/datatypes/ezdate/ezdatetype.php
@@ -110,7 +110,7 @@ class eZDateType extends eZDataType
             {
                 $date = new eZDate();
                 $date->setMDY( $month, $day, $year );
-                $stamp = $date->timeStamp();
+                $stamp = eZTimestamp::getUtcTimestampFromLocalTimestamp( $date->timeStamp() );
             }
 
             $contentObjectAttribute->setAttribute( 'data_int', $stamp );
@@ -175,7 +175,7 @@ class eZDateType extends eZDataType
             {
                 $date = new eZDate();
                 $date->setMDY( $month, $day, $year );
-                $stamp = $date->timeStamp();
+                $stamp = eZTimestamp::getUtcTimestampFromLocalTimestamp( $date->timeStamp() );
             }
 
             $collectionAttribute->setAttribute( 'data_int', $stamp );
@@ -191,7 +191,9 @@ class eZDateType extends eZDataType
     {
         $date = new eZDate( );
         $stamp = $contentObjectAttribute->attribute( 'data_int' );
-        $date->setTimeStamp( $stamp );
+        $date->setTimeStamp(
+            eZTimestamp::getLocalTimestampFromUtcTimestamp( $stamp )
+        );
         return $date;
     }
 
@@ -344,7 +346,13 @@ class eZDateType extends eZDataType
         {
             $dom = $node->ownerDocument;
             $dateNode = $dom->createElement( 'date' );
-            $dateNode->appendChild( $dom->createTextNode( eZDateUtils::rfc1123Date( $stamp ) ) );
+            $dateNode->appendChild(
+                $dom->createTextNode(
+                    eZDateUtils::rfc1123Date(
+                        eZTimestamp::getLocalTimestampFromUtcTimestamp( $stamp )
+                    )
+                )
+            );
             $node->appendChild( $dateNode );
         }
         return $node;
@@ -355,7 +363,9 @@ class eZDateType extends eZDataType
         $dateNode = $attributeNode->getElementsByTagName( 'date' )->item( 0 );
         if ( is_object( $dateNode ) )
         {
-            $timestamp = eZDateUtils::textToDate( $dateNode->textContent );
+            $timestamp = eZTimestamp::getUtcTimestampFromLocalTimestamp(
+                eZDateUtils::textToDate( $dateNode->textContent )
+            );
             $objectAttribute->setAttribute( 'data_int', $timestamp );
         }
     }

--- a/lib/ezutils/classes/eztimestamp.php
+++ b/lib/ezutils/classes/eztimestamp.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * File containing the eZTimestamp class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ * @package lib
+ */
+
+class eZTimestamp
+{
+    /*!
+     \return a timestamp in UTC
+    */
+    public static function getUtcTimestampFromLocalTimestamp($localTimestamp) {
+        $utcTimezone = new \DateTimeZone('UTC');
+        $localTimezone = new \DateTimeZone(date_default_timezone_get());
+
+        $localDate = new \DateTime(null, $localTimezone);
+        $localDate->setTimestamp($localTimestamp);
+
+        $utcDate = new \DateTime($localDate->format('Y-m-d'), $utcTimezone);
+        return $utcDate->getTimestamp();
+    }
+
+    /*!
+     \return a timestamp in timezone defined in php.ini
+    */
+    public static function getLocalTimestampFromUtcTimestamp($utcTimestamp) {
+        $utcTimezone = new \DateTimeZone('UTC');
+        $localTimezone = new \DateTimeZone(date_default_timezone_get());
+
+        $utcDate = new \DateTime(null, $utcTimezone);
+        $utcDate->setTimestamp($utcTimestamp);
+
+        $localDate = new \DateTime($utcDate->format('Y-m-d'), $localTimezone);
+        $localTimestamp = $localDate->getTimestamp();
+
+        return $localTimestamp;
+    }
+}
+?>

--- a/lib/ezutils/classes/eztimestamp.php
+++ b/lib/ezutils/classes/eztimestamp.php
@@ -13,28 +13,28 @@ class eZTimestamp
     /*!
      \return a timestamp in UTC
     */
-    public static function getUtcTimestampFromLocalTimestamp($localTimestamp) {
-        $utcTimezone = new \DateTimeZone('UTC');
-        $localTimezone = new \DateTimeZone(date_default_timezone_get());
+    public static function getUtcTimestampFromLocalTimestamp( $localTimestamp ) {
+        $utcTimezone = new \DateTimeZone( 'UTC' );
+        $localTimezone = new \DateTimeZone( date_default_timezone_get() );
 
-        $localDate = new \DateTime(null, $localTimezone);
-        $localDate->setTimestamp($localTimestamp);
+        $localDate = new \DateTime( null, $localTimezone );
+        $localDate->setTimestamp( $localTimestamp );
 
-        $utcDate = new \DateTime($localDate->format('Y-m-d'), $utcTimezone);
+        $utcDate = new \DateTime( $localDate->format( 'Y-m-d H:i:s' ), $utcTimezone );
         return $utcDate->getTimestamp();
     }
 
     /*!
      \return a timestamp in timezone defined in php.ini
     */
-    public static function getLocalTimestampFromUtcTimestamp($utcTimestamp) {
-        $utcTimezone = new \DateTimeZone('UTC');
-        $localTimezone = new \DateTimeZone(date_default_timezone_get());
+    public static function getLocalTimestampFromUtcTimestamp( $utcTimestamp ) {
+        $utcTimezone = new \DateTimeZone( 'UTC' );
+        $localTimezone = new \DateTimeZone( date_default_timezone_get() );
 
-        $utcDate = new \DateTime(null, $utcTimezone);
-        $utcDate->setTimestamp($utcTimestamp);
+        $utcDate = new \DateTime( null, $utcTimezone );
+        $utcDate->setTimestamp( $utcTimestamp );
 
-        $localDate = new \DateTime($utcDate->format('Y-m-d'), $localTimezone);
+        $localDate = new \DateTime( $utcDate->format( 'Y-m-d H:i:s' ), $localTimezone );
         $localTimestamp = $localDate->getTimestamp();
 
         return $localTimestamp;

--- a/lib/ezutils/classes/eztimestamp.php
+++ b/lib/ezutils/classes/eztimestamp.php
@@ -19,8 +19,8 @@ class eZTimestamp
 
         $localDate = new \DateTime( null, $localTimezone );
         $localDate->setTimestamp( $localTimestamp );
-
         $utcDate = new \DateTime( $localDate->format( 'Y-m-d H:i:s' ), $utcTimezone );
+
         return $utcDate->getTimestamp();
     }
 
@@ -33,11 +33,9 @@ class eZTimestamp
 
         $utcDate = new \DateTime( null, $utcTimezone );
         $utcDate->setTimestamp( $utcTimestamp );
-
         $localDate = new \DateTime( $utcDate->format( 'Y-m-d H:i:s' ), $localTimezone );
-        $localTimestamp = $localDate->getTimestamp();
 
-        return $localTimestamp;
+        return $localDate->getTimestamp();
     }
 }
 ?>


### PR DESCRIPTION
JIRA issue: [EZP-29279](https://jira.ez.no/browse/EZP-29279)
Replaces #1384

Currently, in Legacy, the timestamp stored in the database is always midnight in the server's timezone, while in Platform it is always in UTC.
This PR modifies `eZDateType` class so timestamps are converted to UTC before being stored and are converted back to Local Timezone timestamp on retrieval.