### PR TITLE
eZContentObject::removeThis() does not remove assigned nodes

### DIFF
--- a/kernel/classes/ezcontentobject.php
+++ b/kernel/classes/ezcontentobject.php
@@ -1986,7 +1986,7 @@ class eZContentObject extends eZPersistentObject
                 {
                     $db = eZDB::instance();
                     $db->begin();
-                    foreach ( $additionalNodes as $additionalNode )
+                    foreach ( $nodes as $additionalNode )
                     {
                         if ( $additionalNode->attribute( 'node_id' ) != $node->attribute( 'main_node_id' ) )
                         {


### PR DESCRIPTION
Since https://github.com/ezsystems/ezpublish-legacy/commit/5651fb9c9ce8dea1105cb12f5598500218150865, the `eZContentObject::removeThis()` method uses the variable `$additionalNodes` without defining it. The consequence is that additional nodes other than the one specificed will not be removed, leading to inconsistency. Possibly to content without a main node.

* requirement
** node id is used as parameter
** used node id is the main one
* context : known context is the unpublish feature