### PR TITLE
EZP-29953: Do not support literal HTML in the Administration Interface

### DIFF
--- a/design/admin/templates/content/datatype/view/ezxmltags/literal.tpl
+++ b/design/admin/templates/content/datatype/view/ezxmltags/literal.tpl
@@ -1,0 +1,1 @@
+{* Do not output literal HTML in the Administration Interface *}<pre{if ne($classification|trim,'')} class="{$classification|wash}"{/if}>{$content|wash(xhtml)}</pre>


### PR DESCRIPTION
Many sites support literal HTML for front-end sites. However, we have found this to be nothing but damaging for the Administration Interface, whether that's JavaScript breaking the functionality or CSS breaking the layout. The simple fix is to disable support for the "html" literal tag class in the Administration Interface.