### PR TITLE
EZP-29096: Do not store empty draft values in DB

### DIFF
--- a/kernel/classes/datatypes/ezuser/ezuser.php
+++ b/kernel/classes/datatypes/ezuser/ezuser.php
@@ -228,7 +228,7 @@ class eZUser extends eZPersistentObject
     /**
      * Only stores the entry if it has a Login value
      *
-     * @param null $fieldFilters
+     * @param mixed|null $fieldFilters
      */
     public function store( $fieldFilters = null )
     {

--- a/kernel/classes/datatypes/ezuser/ezuser.php
+++ b/kernel/classes/datatypes/ezuser/ezuser.php
@@ -233,7 +233,11 @@ class eZUser extends eZPersistentObject
         unset( $GLOBALS['eZUserObject_' . $userID] );
         $GLOBALS['eZUserObject_' . $userID] = $this;
         self::purgeUserCacheByUserId( $userID );
-        parent::store( $fieldFilters );
+
+        if( $this->Login )
+        {
+            parent::store( $fieldFilters );
+        }
     }
 
     function originalPassword()
@@ -307,6 +311,11 @@ class eZUser extends eZPersistentObject
         }
     }
 
+    /**
+     * @param integer $id
+     * @param bool $asObject
+     * @return eZUser|null
+     */
     static function fetch( $id, $asObject = true )
     {
         if ( !$id )

--- a/kernel/classes/datatypes/ezuser/ezuser.php
+++ b/kernel/classes/datatypes/ezuser/ezuser.php
@@ -225,7 +225,12 @@ class eZUser extends eZPersistentObject
         return new eZUser( $row );
     }
 
-    function store( $fieldFilters = null )
+    /**
+     * Only stores the entry if it has a Login value
+     *
+     * @param null $fieldFilters
+     */
+    public function store( $fieldFilters = null )
     {
         $this->Email = trim( $this->Email );
         $userID = $this->attribute( 'contentobject_id' );

--- a/kernel/classes/datatypes/ezuser/ezusertype.php
+++ b/kernel/classes/datatypes/ezuser/ezusertype.php
@@ -258,10 +258,10 @@ class eZUserType extends eZDataType
             }
 
             // saving information in the object attribute data_text field to simulate a draft
-            // only if the object version is a draft (status == 0)
+            // only if the object version is a draft
             if (
                 $user->Login &&
-                $contentObjectAttribute->attribute( 'object_version' )->attribute( 'status' ) == 0
+                $contentObjectAttribute->attribute( 'object_version' )->attribute( 'status' ) == eZContentObjectVersion::STATUS_DRAFT
             )
             {
                 $contentObjectAttribute->setAttribute( 'data_text', $this->serializeDraft( $user ) );

--- a/kernel/classes/datatypes/ezuser/ezusertype.php
+++ b/kernel/classes/datatypes/ezuser/ezusertype.php
@@ -381,7 +381,7 @@ class eZUserType extends eZDataType
         $user = eZUser::fetch( $userID );
         eZDebugSetting::writeDebug( 'kernel-user', $user, 'user' );
 
-        //Looking for a "draft" and loading it's content
+        //Looking for a "draft" and loading its content
         $serializedDraft = $contentObjectAttribute->attribute( 'data_text' );
 
         if ( !empty( $serializedDraft ) )

--- a/kernel/classes/datatypes/ezuser/ezusertype.php
+++ b/kernel/classes/datatypes/ezuser/ezusertype.php
@@ -277,10 +277,9 @@ class eZUserType extends eZDataType
         if ( !empty( $serializedDraft ) )
         {
             $user = $this->updateUserDraft( $user, $serializedDraft );
+            $user->store();
+            $contentObjectAttribute->setContent( $user );
         }
-
-        $user->store();
-        $contentObjectAttribute->setContent( $user );
     }
 
     /**

--- a/kernel/classes/datatypes/ezuser/ezusertype.php
+++ b/kernel/classes/datatypes/ezuser/ezusertype.php
@@ -335,7 +335,7 @@ class eZUserType extends eZDataType
     {
         $draft = $this->unserializeDraft( $serializedDraft );
 
-        if( $draft )
+        if ( $draft )
         {
             $user->setAttribute( 'login', $draft->login );
             $user->setAttribute( 'password_hash', $draft->password_hash );

--- a/kernel/classes/datatypes/ezuser/ezusertype.php
+++ b/kernel/classes/datatypes/ezuser/ezusertype.php
@@ -258,7 +258,10 @@ class eZUserType extends eZDataType
             }
 
             // saving information in the object attribute data_text field to simulate a draft
-            $contentObjectAttribute->setAttribute( 'data_text', $this->serializeDraft( $user ) );
+            if( $user->Login )
+            {
+                $contentObjectAttribute->setAttribute( 'data_text', $this->serializeDraft( $user ) );
+            }
         }
     }
 
@@ -360,7 +363,6 @@ class eZUserType extends eZDataType
             $GLOBALS['eZUserObject_' . $userID] = eZUser::fetch( $userID );
         }
 
-        /** @var eZUser $user */
         $user = eZUser::fetch( $userID );
         eZDebugSetting::writeDebug( 'kernel-user', $user, 'user' );
 

--- a/kernel/classes/datatypes/ezuser/ezusertype.php
+++ b/kernel/classes/datatypes/ezuser/ezusertype.php
@@ -259,7 +259,7 @@ class eZUserType extends eZDataType
 
             // saving information in the object attribute data_text field to simulate a draft
             // only if the object version is a draft (status == 0)
-            if(
+            if (
                 $user->Login &&
                 $contentObjectAttribute->attribute( 'object_version' )->attribute( 'status' ) == 0
             )

--- a/kernel/classes/datatypes/ezuser/ezusertype.php
+++ b/kernel/classes/datatypes/ezuser/ezusertype.php
@@ -258,13 +258,22 @@ class eZUserType extends eZDataType
             }
 
             // saving information in the object attribute data_text field to simulate a draft
-            if( $user->Login )
+            // only if the object version is a draft (status == 0)
+            if(
+                $user->Login &&
+                $contentObjectAttribute->attribute( 'object_version' )->attribute( 'status' ) == 0
+            )
             {
                 $contentObjectAttribute->setAttribute( 'data_text', $this->serializeDraft( $user ) );
             }
         }
     }
 
+    /**
+     * @param $contentObjectAttribute
+     * @param eZContentObject $contentObject
+     * @param $publishedNodes
+     */
     function onPublish( $contentObjectAttribute, $contentObject, $publishedNodes )
     {
         /** @var eZContentObjectAttribute $contentObjectAttribute */
@@ -279,6 +288,10 @@ class eZUserType extends eZDataType
             $user = $this->updateUserDraft( $user, $serializedDraft );
             $user->store();
             $contentObjectAttribute->setContent( $user );
+
+            // Clear draft info
+            $contentObjectAttribute->setAttribute( 'data_text', '' );
+            $contentObjectAttribute->store();
         }
     }
 
@@ -322,10 +335,13 @@ class eZUserType extends eZDataType
     {
         $draft = $this->unserializeDraft( $serializedDraft );
 
-        $user->setAttribute( 'login', $draft->login );
-        $user->setAttribute( 'password_hash', $draft->password_hash );
-        $user->setAttribute( 'email', $draft->email );
-        $user->setAttribute( 'password_hash_type', $draft->password_hash_type );
+        if( $draft )
+        {
+            $user->setAttribute( 'login', $draft->login );
+            $user->setAttribute( 'password_hash', $draft->password_hash );
+            $user->setAttribute( 'email', $draft->email );
+            $user->setAttribute( 'password_hash_type', $draft->password_hash_type );
+        }
 
         return $user;
     }
@@ -365,7 +381,7 @@ class eZUserType extends eZDataType
         $user = eZUser::fetch( $userID );
         eZDebugSetting::writeDebug( 'kernel-user', $user, 'user' );
 
-        // Looking for a "draft" and loading it's content
+        //Looking for a "draft" and loading it's content
         $serializedDraft = $contentObjectAttribute->attribute( 'data_text' );
 
         if ( !empty( $serializedDraft ) )

--- a/kernel/user/ezuseroperationcollection.php
+++ b/kernel/user/ezuseroperationcollection.php
@@ -297,7 +297,7 @@ class eZUserOperationCollection
     }
 
    /**
-     * Change user password for an existing user
+     * Change user password
      *
      * @param int $userID
      * @param string $newPassword

--- a/kernel/user/ezuseroperationcollection.php
+++ b/kernel/user/ezuseroperationcollection.php
@@ -297,7 +297,7 @@ class eZUserOperationCollection
     }
 
    /**
-     * Change user password
+     * Change user password for an existing user
      *
      * @param int $userID
      * @param string $newPassword


### PR DESCRIPTION
The issue and steps to reproduce it are described here:
https://jira.ez.no/browse/EZP-29096

Or use those steps:

* Create a new user account
* Do not fill any values in the form
* Close the browser tab
* Try to create a new user account
* You will get a transaction error

This patch will prevent the user creation to store any draft data into the DB unless the editor specified a user login.