### PR TITLE
EZP-30160 eZOE should work on Android

### DIFF
--- a/extension/ezoe/ezxmltext/handlers/input/ezoexmlinput.php
+++ b/extension/ezoe/ezxmltext/handlers/input/ezoexmlinput.php
@@ -184,7 +184,6 @@ class eZOEXMLInput extends eZXMLInputHandler
             // iOS 5+
             else if ( strpos( $userAgent, 'AppleWebKit' ) !== false &&
                       strpos( $userAgent, 'Mobile' ) !== false &&
-                      strpos( $userAgent, 'Android' ) === false &&//@todo: remove when Android is supported in TinyMCE
                       preg_match('/AppleWebKit\/([0-9\.]+)/i', $userAgent, $browserInfo ) )
             {
                 if ( $browserInfo[1] >= 534.46 )


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-30160

Currently eZOE doesn't show up on Android due to an issue several years ago that lead devs to just show the textarea for Android devices, but as in 2019 it should work without problems on Android devices so we can remove the line blocking for Android devices.