### PR TITLE
Fix EZP-30383: Change password with "legacy_mode: false" does not properly clear the cache

### DIFF
--- a/kernel/user/ezuseroperationcollection.php
+++ b/kernel/user/ezuseroperationcollection.php
@@ -320,6 +320,8 @@ class eZUserOperationCollection
 
             // "Draft" must be in sync with the PersistentObject
             self::updateUserDraft( $user );
+			
+            eZContentCacheManager::clearContentCacheIfNeeded( $userID );
 
             return array( 'status' => true );
         }


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-30383

If you use the legacy bridge and an Administration Interface (legacy or Netgen Admin UI) that uses /user/password:

If you use "Change password" (which goes to /user/password) and then change the password, when you try to log in through a siteaccess that has "legacy_mode: false" (front-end or Netgen Admin UI) it won't work with the new password. It will work with the old password. You must clear the view cache for that user for the new password to work.

If you use "Change Information", which edits the user object and then change the user's password, this works, because it natively clears the view cache for that user.

In summary: this issue can be reproduced by 1) changing your password with the /user/password module view; 2) logging in to any siteaccess with legacy_mode:false.