### PR TITLE
remove hardcoded sortBy to read its value either from ini or post var

### DIFF
--- a/extension/ezjscore/classes/ezjscserverfunctionsjs.php
+++ b/extension/ezjscore/classes/ezjscserverfunctionsjs.php
@@ -438,11 +438,28 @@ YUI( YUI3_config ).add('io-ez', function( Y )
         if ( self::hasPostValue( $http, 'EncodingDataMap' ) )
             $encodeParams['dataMap'] = $http->postVariable( 'EncodingDataMap' );
 
+	$ezFindIni = eZINI::instance( "ezfind.ini" );
+        if ( $ezFindIni->BlockValues[ 'SearchSettings' ] )
+        {
+            $sortBy = $ezFindIni->variable( "SearchSettings", "SortBy" );
+        }
+
+        if ( self::hasPostValue( $http, 'SortByMethod' ) )
+        {
+            $sortBy = json_decode( $http->postVariable( 'SortByMethod' ), true );
+        }
+
+        // fallback value in case $sortBy is empty or is not an array
+        if ( empty( $sortBy ) || !is_array( $sortBy ) )
+        {
+            $sortBy = array( 'published' => 'desc' );
+        }
+
         // Prepare search parameters
         $params = array( 'SearchOffset' => $searchOffset,
                          'SearchLimit' => $searchLimit,
                          'SortArray' => array( 'published', 0 ), // Legacy search engine uses SortArray
-                         'SortBy' => array( 'published' => 'desc' ) // eZ Find search method implementation uses SortBy
+                         'SortBy' => $sortBy // eZ Find search method implementation uses SortBy
         );
 
         if ( self::hasPostValue( $http, 'SearchContentClassAttributeID' ) )


### PR DESCRIPTION
Hi,

I've removed the hardcoded sort by logic here: 
`extension/ezjscore/classes/ezjscserverfunctionsjs.php`
to be able to read either ini setting or post variable.

Now we can either use an ini setting to define the sort order we want to use globally or a new POST variable through the ajax call.
If the post variable is set, it will override the ini value.

If none of the values are set or the ezfind extension is OFF, there's a fallback that sets the $sortBy variable with the same "hardcoded" value.

This PR needs to be combined with this one:
https://github.com/ezsystems/ezfind/pull/220

Thanks!