### PR TITLE
EZP-30416: INI settings don't support loose typing

### DIFF
--- a/settings/contentstructuremenu.ini
+++ b/settings/contentstructuremenu.ini
@@ -36,9 +36,8 @@ MaxNodes=150
 #    SortBy[]
 #    SortBy[]=name/ascending
 #    SortBy[]=published/descending
-# if set to "false" - default sorting will be implemented
-# (which is defined for each node)
-SortBy=false
+# if not set, it uses the sorting defined for each node (from the Ordering tab)
+SortBy=[]
 
 # enabled/disabled
 ToolTips=enabled

--- a/settings/contentstructuremenu.ini
+++ b/settings/contentstructuremenu.ini
@@ -36,7 +36,7 @@ MaxNodes=150
 #    SortBy[]
 #    SortBy[]=name/ascending
 #    SortBy[]=published/descending
-# if not set, it uses the sorting defined for each node (from the Ordering tab)
+# if an empty array, it uses the sorting defined for each node instead (from the Ordering tab)
 SortBy[]
 
 # enabled/disabled

--- a/settings/contentstructuremenu.ini
+++ b/settings/contentstructuremenu.ini
@@ -37,7 +37,7 @@ MaxNodes=150
 #    SortBy[]=name/ascending
 #    SortBy[]=published/descending
 # if not set, it uses the sorting defined for each node (from the Ordering tab)
-SortBy=[]
+SortBy[]
 
 # enabled/disabled
 ToolTips=enabled


### PR DESCRIPTION
Update the set definition to an empty array.
Instead of false, if not set, it uses the sorting defined for each node (from the Ordering tab).