### PR TITLE
Popup for the custom tag sub/sup fixed

### DIFF
--- a/extension/ezoe/design/standard/templates/ezoe/tag_custom.tpl
+++ b/extension/ezoe/design/standard/templates/ezoe/tag_custom.tpl
@@ -101,6 +101,11 @@ tinyMCEPopup.onInit.add( eZOEPopupUtils.BIND( eZOEPopupUtils.init, window, {
     },
     onTagGenerated:  function( el, ed, args )
     {
+        if( el === null )
+        {
+            return;
+        }
+
         // append a paragraph if user just inserted a custom tag in editor and it's the last tag
         var edBody = el.parentNode, doc = ed.getDoc(), temp = el;
         if ( edBody.nodeName !== 'BODY' )

--- a/extension/ezoe/design/standard/templates/ezoe/tag_custom.tpl
+++ b/extension/ezoe/design/standard/templates/ezoe/tag_custom.tpl
@@ -101,7 +101,7 @@ tinyMCEPopup.onInit.add( eZOEPopupUtils.BIND( eZOEPopupUtils.init, window, {
     },
     onTagGenerated:  function( el, ed, args )
     {
-        if( el === null )
+        if ( el === null )
         {
             return;
         }


### PR DESCRIPTION
The sub (subscript) and sup (superscript) tags work, but there is a UI issue.

Hitting "Ok" once adds the tag, but does not close the dialog. The dialog only closes upon clicking "Cancel."

While the dialog is open, each click of "Ok" after the first inserts the highlighted text at the beginning of the paragraph, in the sub or sup style.

Hitting "Cancel" is the only way out, which makes the necessary workflow:

Select text
Select Custom tags
Select "Sup"
Click OK
Click Cancel

**Reproduce / Testing instructions**

Select text
Select Custom tags
Select "Sup"
Click OK => Dialog remains open
Click OL => Duplicate text inserted at beginning of paragraph.

Tested with: Mac Chrome.