### PR TITLE
Fix EZP-30718: Allow RerunURL to be used on hidden pages

### DIFF
--- a/kernel/layout/set.php
+++ b/kernel/layout/set.php
@@ -17,7 +17,6 @@ foreach ( $Params['UserParameters'] as $key => $param )
 
 $Result = array();
 $Result['content'] = '';
-$Result['rerun_uri'] = '/' . implode( '/', array_splice( $Params['Parameters'], 1 ) ) . $userParamString;
 
 $layoutINI = eZINI::instance( 'layout.ini' );
 $i18nINI = eZINI::instance( 'i18n.ini' );
@@ -53,6 +52,7 @@ if ( $layoutINI->hasGroup( $LayoutStyle ) )
         }
     }
 
+    $Result['rerun_uri'] = '/' . implode( '/', array_splice( $Params['Parameters'], 1 ) ) . $userParamString;
     $Module->setExitStatus( eZModule::STATUS_RERUN );
 }
 else

--- a/kernel/private/classes/ezpkernelweb.php
+++ b/kernel/private/classes/ezpkernelweb.php
@@ -843,15 +843,14 @@ class ezpKernelWeb implements ezpWebBasedKernelHandler
                 $moduleResult = $this->module->handleError( eZError::KERNEL_MODULE_DISABLED, 'kernel', array( 'check' => $moduleCheck ) );
             }
             $this->siteBasics['module-run-required'] = false;
-            if ( $this->module->exitStatus() == eZModule::STATUS_RERUN )
+            if ( isset( $moduleResult['rerun_uri'] ) )
             {
-                if ( isset( $moduleResult['rerun_uri'] ) )
-                {
-                    $this->uri = eZURI::instance( $moduleResult['rerun_uri'] );
-                    $this->siteBasics['module-run-required'] = true;
-                }
-                else
-                    eZDebug::writeError( 'No rerun URI specified, cannot continue', 'index.php' );
+                $this->uri = eZURI::instance( $moduleResult['rerun_uri'] );
+                $this->siteBasics['module-run-required'] = true;
+            }
+            else if ( $this->module->exitStatus() == eZModule::STATUS_RERUN )
+            {
+                eZDebug::writeError( 'No rerun URI specified on eZModule::STATUS_RERUN, cannot set URI', 'index.php' );
             }
 
             if ( is_array( $moduleResult ) )


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-30718

The Rerun URL instructions get trapped in the view cache (for hidden pages) because the redundant check for the module exit status can never pass once a page is cached.

The check against "rerun_uri" in the module parameters is sufficient.