### PR TITLE
DFS: Cache gen. timeout check only when needed

### DIFF
--- a/kernel/private/classes/clusterfilehandlers/ezdfsfilehandler.php
+++ b/kernel/private/classes/clusterfilehandlers/ezdfsfilehandler.php
@@ -1371,6 +1371,12 @@ class eZDFSFileHandler implements eZClusterFileHandlerInterface, ezpDatabaseBase
      */
     public function checkCacheGenerationTimeout()
     {
+        if ( $this->generationStartTimestamp === false )
+        {
+            eZDebug::writeError( "Cache generation has not started, cannot check timeout", 'cluster.log' );
+            return true;
+        }
+
         eZDebugSetting::writeDebug( 'kernel-clustering', 'Checking cache generation timeout', "dfs::checkCacheGenerationTimeout( '{$this->filePath}' )" );
         return self::$dbbackend->_checkCacheGenerationTimeout( $this->filePath, $this->generationStartTimestamp );
     }

--- a/kernel/private/classes/clusterfilehandlers/ezdfsfilehandler.php
+++ b/kernel/private/classes/clusterfilehandlers/ezdfsfilehandler.php
@@ -812,7 +812,7 @@ class eZDFSFileHandler implements eZClusterFileHandlerInterface, ezpDatabaseBase
 
         // This checks if we entered timeout and got our generating file stolen
         // If this happens, we don't store our cache
-        if ( $store and $this->checkCacheGenerationTimeout() )
+        if ( $store && $this->generationStartTimestamp && $this->checkCacheGenerationTimeout() )
             $storeCache = true;
 
         $result = null;

--- a/kernel/private/classes/clusterfilehandlers/ezdfsfilehandler.php
+++ b/kernel/private/classes/clusterfilehandlers/ezdfsfilehandler.php
@@ -812,7 +812,7 @@ class eZDFSFileHandler implements eZClusterFileHandlerInterface, ezpDatabaseBase
 
         // This checks if we entered timeout and got our generating file stolen
         // If this happens, we don't store our cache
-        if ( $store && $this->generationStartTimestamp && $this->checkCacheGenerationTimeout() )
+        if ( $store and $this->checkCacheGenerationTimeout() )
             $storeCache = true;
 
         $result = null;


### PR DESCRIPTION
Only check cache generation timeout when generation has actually started, to avoid SQL error.

Calling `DFSHandler::checkCacheGenerationTimeout()` leads to an SQL error if cache generation hasn't started. In that case, the start timestamp is `false` which ends up as an empty string in the mysqli query. Fix this by not checking, when the timestamp is false. Also fixes CS.

Open questions:
- Is the fact that this happens, a symptom for a bigger problem, or is it really just a long-lived bug?
- ~Would it be more correct to fix this within `checkCacheGenerationTimeout()`?~ Done.