### PR TITLE
Fix EZP-30767: Allow the developer to override the page to load on a partial URL alias path

### DIFF
--- a/kernel/classes/ezurlaliasml.php
+++ b/kernel/classes/ezurlaliasml.php
@@ -2136,7 +2136,8 @@ class eZURLAliasML extends eZPersistentObject
                 break;
 
             case 'nop':
-                $url = '/';
+                $siteINI = eZINI::instance();
+                $url = $siteINI->variable( 'URLTranslator', 'LoadOnPartialAliasPath' );
                 break;
 
             default:

--- a/settings/site.ini
+++ b/settings/site.ini
@@ -327,6 +327,11 @@ Translation=enabled
 # first part of url is defined in module.ini Modulelist, eg. 'content'
 TranslatableSystemUrls=enabled
 
+# Path to load when accessing a partial alias
+# For example, when there is a redirect from /path/one/two but the user accesses /path/one
+# By default this loads the homepage, but you can set it to load a 404 page for example
+LoadOnPartialAliasPath=/
+
 # Type of word separator for url aliases, can be one of:
 # dash - Use a dash
 # underscore - Use an underscore


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-30767

It is not desirable to load the homepage on what should otherwise be a 404 page.

To prevent a BC break, simply allow this behavior to be overridden.