### PR TITLE
EZP-30782: allow sorting by trashed field

### DIFF
--- a/kernel/classes/ezcontentobjecttreenode.php
+++ b/kernel/classes/ezcontentobjecttreenode.php
@@ -654,7 +654,7 @@ class eZContentObjectTreeNode extends eZPersistentObject
                         } break;
                         case 'trashed':
                         {
-                            $sortingFields .= 'trashed';
+                            $sortingFields .= $treeTableName . '.trashed';
                         } break;
                         case 'attribute':
                         {

--- a/kernel/classes/ezcontentobjecttreenode.php
+++ b/kernel/classes/ezcontentobjecttreenode.php
@@ -652,6 +652,10 @@ class eZContentObjectTreeNode extends eZPersistentObject
                         {
                             $sortingFields .= 'ezcontentobject_name.name';
                         } break;
+                        case 'trashed':
+                        {
+                            $sortingFields .= 'trashed';
+                        } break;
                         case 'attribute':
                         {
                             $classAttributeID = $sortBy[2];


### PR DESCRIPTION
Hi there, 
As part of the work already merged here: https://github.com/ezsystems/ezpublish-legacy/pull/1351

This commit is to add the ability to sort by this new **trashed** field in the content/trash/ view.

**More details:**
the trash view uses the [trash_object_list](https://doc.ez.no/eZ-Publish/Technical-manual/4.x/Reference/Modules/content/Fetch-functions/trash_object_list) fetch to grab the trashed objects. In that fetch you have the ability to sort_by but unfortunately this wasn't working:
```
...
'sort_by', array( 'trashed', false() ),
...
```
The commit solve that problem.

I've also created the following Jira ticket.
https://jira.ez.no/browse/EZP-30782


Looking forward to your feedback,
Many thanks!