### PR TITLE
EZP-30834: remove strtotime function from the trashed-days option

### DIFF
--- a/bin/php/trashpurge.php
+++ b/bin/php/trashpurge.php
@@ -47,7 +47,7 @@ if (
     $purgeHandler->run(
         $options['iteration-limit'] ? (int)$options['iteration-limit'] : null,
         $options['iteration-sleep'] ? (int)$options['iteration-sleep'] : null,
-        $options['trashed-days']    ? strtotime( "-{$options['trashed-days']} days" ) : null
+        $options['trashed-days']    ? (int)$options['trashed-days'] : null
     )
 )
 {


### PR DESCRIPTION
On a recent client work we noticed that the trashpurge.php wasn't working as expected.

This PR fix that issue.

Summary:          
The following line within the trashpurge.php script:
`$options['trashed-days']    ? strtotime( "-{$options['trashed-days']} days" ) : null`

Is converting the trashed days into the wrong value. 
This is because we already have the same strtotime function in here:
https://github.com/ezsystems/ezpublish-legacy/blob/2019.03/kernel/private/classes/ezscripttrashpurge.php#L88

The commit fix that issue.

More info within the Jira ticket:
JIRA ticket: https://jira.ez.no/browse/EZP-30834

Thanks!