### PR TITLE
Updated instances of count() that would cause a warning in 7.2

### DIFF
--- a/kernel/classes/ezcontentobjecttreenode.php
+++ b/kernel/classes/ezcontentobjecttreenode.php
@@ -4168,7 +4168,7 @@ class eZContentObjectTreeNode extends eZPersistentObject
 
         $nodePath = null;
         $nodeDepth = 0;
-        if (((is_array($node) || $node instanceof Countable) && count($node) != 0) || $node != null) {
+        if ( is_countable( $node ) && count( $node ) != 0 ) {
             $nodePath = $node->attribute( 'path_string' );
             $nodeDepth = $node->attribute( 'depth' );
         }

--- a/kernel/classes/ezcontentobjecttreenode.php
+++ b/kernel/classes/ezcontentobjecttreenode.php
@@ -4168,12 +4168,10 @@ class eZContentObjectTreeNode extends eZPersistentObject
 
         $nodePath = null;
         $nodeDepth = 0;
-        if ( count( $node ) != 0 )
-        {
+        if (((is_array($node) || $node instanceof Countable) && count($node) != 0) || $node != null) {
             $nodePath = $node->attribute( 'path_string' );
             $nodeDepth = $node->attribute( 'depth' );
         }
-
         $childPath = $nodePath;
 
         $db = eZDB::instance();

--- a/kernel/common/ezobjectforwarder.php
+++ b/kernel/common/ezobjectforwarder.php
@@ -321,13 +321,7 @@ class eZObjectForwarder
                         $matchCount = 0;
                         foreach ( $matchItem['custom_match'] as $customMatch )
                         {
-                            $matchConditionCount = 0;
-
-                            if ($customMatch['conditions'] instanceof Countable || is_array($customMatch['conditions'])) {
-                                $matchConditionCount = count($customMatch['conditions']);
-                            } else if ($customMatch['conditions'] != null) {
-                                $matchConditionCount = 1;
-                            }
+                            $matchConditionCount = is_countable( $customMatch['conditions'] ) ? count( $customMatch['conditions'] ) : 0;
                             $code = '';
                             if ( $matchCount > 0 )
                             {

--- a/kernel/common/ezobjectforwarder.php
+++ b/kernel/common/ezobjectforwarder.php
@@ -321,7 +321,13 @@ class eZObjectForwarder
                         $matchCount = 0;
                         foreach ( $matchItem['custom_match'] as $customMatch )
                         {
-                            $matchConditionCount = count( $customMatch['conditions'] );
+                            $matchConditionCount = 0;
+                            if ($customMatch['conditions'] instanceof Countable || is_array($customMatch['conditions'])) {
+                                $matchConditionCount = count($customMatch['conditions']);
+                            }
+                            else if (!is_empty($customMatch['conditions'])) {
+                                $matchConditionCount = 1;
+                            }
                             $code = '';
                             if ( $matchCount > 0 )
                             {

--- a/kernel/common/ezobjectforwarder.php
+++ b/kernel/common/ezobjectforwarder.php
@@ -323,8 +323,10 @@ class eZObjectForwarder
                         {
                             $matchConditionCount = 0;
 
-                            if ((($customMatch['conditions'] instanceof Countable || is_array($customMatch['conditions'])) && $customMatch['conditions']) || $customMatch['conditions'] != null) {
+                            if ($customMatch['conditions'] instanceof Countable || is_array($customMatch['conditions'])) {
                                 $matchConditionCount = count($customMatch['conditions']);
+                            } else if ($emailSender != null) {
+                                $matchConditionCount = 1;
                             }
                             $code = '';
                             if ( $matchCount > 0 )

--- a/kernel/common/ezobjectforwarder.php
+++ b/kernel/common/ezobjectforwarder.php
@@ -325,7 +325,7 @@ class eZObjectForwarder
 
                             if ($customMatch['conditions'] instanceof Countable || is_array($customMatch['conditions'])) {
                                 $matchConditionCount = count($customMatch['conditions']);
-                            } else if ($emailSender != null) {
+                            } else if ($customMatch['conditions'] != null) {
                                 $matchConditionCount = 1;
                             }
                             $code = '';

--- a/kernel/common/ezobjectforwarder.php
+++ b/kernel/common/ezobjectforwarder.php
@@ -325,9 +325,6 @@ class eZObjectForwarder
                             if ($customMatch['conditions'] instanceof Countable || is_array($customMatch['conditions'])) {
                                 $matchConditionCount = count($customMatch['conditions']);
                             }
-                            else if (!is_empty($customMatch['conditions'])) {
-                                $matchConditionCount = 1;
-                            }
                             $code = '';
                             if ( $matchCount > 0 )
                             {
@@ -573,6 +570,7 @@ class eZObjectForwarder
             $newNodes[] = eZTemplateNodeTool::createCodePieceNode( "\$$designKeysName = array_pop( \$" . $designKeysName . "Stack );",
                                                                    array( 'spacing' => $acquisitionSpacing ) );
         }
+        die();
         return $newNodes;
     }
 

--- a/kernel/common/ezobjectforwarder.php
+++ b/kernel/common/ezobjectforwarder.php
@@ -573,7 +573,6 @@ class eZObjectForwarder
             $newNodes[] = eZTemplateNodeTool::createCodePieceNode( "\$$designKeysName = array_pop( \$" . $designKeysName . "Stack );",
                                                                    array( 'spacing' => $acquisitionSpacing ) );
         }
-        die();
         return $newNodes;
     }
 

--- a/kernel/common/ezobjectforwarder.php
+++ b/kernel/common/ezobjectforwarder.php
@@ -322,7 +322,8 @@ class eZObjectForwarder
                         foreach ( $matchItem['custom_match'] as $customMatch )
                         {
                             $matchConditionCount = 0;
-                            if ($customMatch['conditions'] instanceof Countable || is_array($customMatch['conditions'])) {
+
+                            if ((($customMatch['conditions'] instanceof Countable || is_array($customMatch['conditions'])) && $customMatch['conditions']) || $customMatch['conditions'] != null) {
                                 $matchConditionCount = count($customMatch['conditions']);
                             }
                             $code = '';

--- a/kernel/common/eztemplatedesignresource.php
+++ b/kernel/common/eztemplatedesignresource.php
@@ -89,7 +89,7 @@ class eZTemplateDesignResource extends eZTemplateFileResource
                     $matchConditionCount = 0;
                     if ($customMatch['conditions'] instanceof Countable || is_array($customMatch['conditions'])) {
                         $matchConditionCount = count($customMatch['conditions']);
-                    } else if ($emailSender != null) {
+                    } else if ($customMatch['conditions'] != null) {
                         $matchConditionCount = 1;
                     }
                     $code = '';

--- a/kernel/common/eztemplatedesignresource.php
+++ b/kernel/common/eztemplatedesignresource.php
@@ -90,9 +90,6 @@ class eZTemplateDesignResource extends eZTemplateFileResource
                     if ($customMatch['conditions'] instanceof Countable || is_array($customMatch['conditions'])) {
                         $matchConditionCount = count($customMatch['conditions']);
                     }
-                    else if (!is_empty($customMatch['conditions'])) {
-                        $matchConditionCount = 1;
-                    }
                     $code = '';
                     if ( $matchCount > 0 )
                     {

--- a/kernel/common/eztemplatedesignresource.php
+++ b/kernel/common/eztemplatedesignresource.php
@@ -87,7 +87,7 @@ class eZTemplateDesignResource extends eZTemplateFileResource
                 foreach ( $customMatchList as $customMatch )
                 {
                     $matchConditionCount = 0;
-                    if ($customMatch['conditions'] instanceof Countable || is_array($customMatch['conditions'])) {
+                    if ((($customMatch['conditions'] instanceof Countable || is_array($customMatch['conditions'])) && $customMatch['conditions']) || $customMatch['conditions'] != null) {
                         $matchConditionCount = count($customMatch['conditions']);
                     }
                     $code = '';

--- a/kernel/common/eztemplatedesignresource.php
+++ b/kernel/common/eztemplatedesignresource.php
@@ -87,8 +87,10 @@ class eZTemplateDesignResource extends eZTemplateFileResource
                 foreach ( $customMatchList as $customMatch )
                 {
                     $matchConditionCount = 0;
-                    if ((($customMatch['conditions'] instanceof Countable || is_array($customMatch['conditions'])) && $customMatch['conditions']) || $customMatch['conditions'] != null) {
+                    if ($customMatch['conditions'] instanceof Countable || is_array($customMatch['conditions'])) {
                         $matchConditionCount = count($customMatch['conditions']);
+                    } else if ($emailSender != null) {
+                        $matchConditionCount = 1;
                     }
                     $code = '';
                     if ( $matchCount > 0 )

--- a/kernel/common/eztemplatedesignresource.php
+++ b/kernel/common/eztemplatedesignresource.php
@@ -86,7 +86,13 @@ class eZTemplateDesignResource extends eZTemplateFileResource
                 $matchCount = 0;
                 foreach ( $customMatchList as $customMatch )
                 {
-                    $matchConditionCount = count( $customMatch['conditions'] );
+                    $matchConditionCount = 0;
+                    if ($customMatch['conditions'] instanceof Countable || is_array($customMatch['conditions'])) {
+                        $matchConditionCount = count($customMatch['conditions']);
+                    }
+                    else if (!is_empty($customMatch['conditions'])) {
+                        $matchConditionCount = 1;
+                    }
                     $code = '';
                     if ( $matchCount > 0 )
                     {

--- a/kernel/common/eztemplatedesignresource.php
+++ b/kernel/common/eztemplatedesignresource.php
@@ -86,12 +86,7 @@ class eZTemplateDesignResource extends eZTemplateFileResource
                 $matchCount = 0;
                 foreach ( $customMatchList as $customMatch )
                 {
-                    $matchConditionCount = 0;
-                    if ($customMatch['conditions'] instanceof Countable || is_array($customMatch['conditions'])) {
-                        $matchConditionCount = count($customMatch['conditions']);
-                    } else if ($customMatch['conditions'] != null) {
-                        $matchConditionCount = 1;
-                    }
+                    $matchConditionCount = is_countable( $customMatch['conditions'] ) ? count( $customMatch['conditions'] ) : 0;
                     $code = '';
                     if ( $matchCount > 0 )
                     {

--- a/lib/ezutils/classes/ezsendmailtransport.php
+++ b/lib/ezutils/classes/ezsendmailtransport.php
@@ -24,7 +24,7 @@ class eZSendmailTransport extends eZMailTransport
         $sendmailOptions = '';
         $emailFrom = $mail->sender();
         $emailSender = isset( $emailFrom['email'] ) ? $emailFrom['email'] : false;
-        if (!$emailSender || (is_array($emailSender) || $emailSender instanceof Countable && count($emailSender) <= 0) || $emailSender == null)
+        if ( !$emailSender || ( is_array($emailSender) || $emailSender instanceof Countable && count($emailSender) <= 0) || $emailSender == null )
             $emailSender = $ini->variable( 'MailSettings', 'EmailSender' );
         if ( !$emailSender )
             $emailSender = $ini->variable( 'MailSettings', 'AdminEmail' );

--- a/lib/ezutils/classes/ezsendmailtransport.php
+++ b/lib/ezutils/classes/ezsendmailtransport.php
@@ -24,7 +24,7 @@ class eZSendmailTransport extends eZMailTransport
         $sendmailOptions = '';
         $emailFrom = $mail->sender();
         $emailSender = isset( $emailFrom['email'] ) ? $emailFrom['email'] : false;
-        if ( !$emailSender || !is_string( $emailSender ) || empty( $emailSender ))
+        if (!$emailSender || (is_array($emailSender) || $emailSender instanceof Countable && count($emailSender) <= 0) || $emailSender == null)
             $emailSender = $ini->variable( 'MailSettings', 'EmailSender' );
         if ( !$emailSender )
             $emailSender = $ini->variable( 'MailSettings', 'AdminEmail' );

--- a/lib/ezutils/classes/ezsendmailtransport.php
+++ b/lib/ezutils/classes/ezsendmailtransport.php
@@ -24,7 +24,7 @@ class eZSendmailTransport extends eZMailTransport
         $sendmailOptions = '';
         $emailFrom = $mail->sender();
         $emailSender = isset( $emailFrom['email'] ) ? $emailFrom['email'] : false;
-        if ( !$emailSender || ( is_array($emailSender) || $emailSender instanceof Countable && count($emailSender) <= 0) || $emailSender == null )
+        if ( !$emailSender || ( is_countable( $emailSender ) && count( $emailSender) <= 0 ) )
             $emailSender = $ini->variable( 'MailSettings', 'EmailSender' );
         if ( !$emailSender )
             $emailSender = $ini->variable( 'MailSettings', 'AdminEmail' );


### PR DESCRIPTION
Logic updated after the following example to give a reasonable approximation of how count() worked on scalar objects previous to PHP 7.2

https://stackoverflow.com/questions/49662029/count-emitting-an-e-warning