### PR TITLE
Fix section update on move

### DIFF
--- a/kernel/classes/ezcontentobjecttreenodeoperations.php
+++ b/kernel/classes/ezcontentobjecttreenodeoperations.php
@@ -87,8 +87,7 @@ class eZContentObjectTreeNodeOperations
                 {
 
                     eZContentObjectTreeNode::assignSectionToSubTree( $newNode->attribute( 'main_node_id' ),
-                                                                     $newParentObject->attribute( 'section_id' ),
-                                                                     $oldParentObject->attribute( 'section_id' ) );
+                                                                     $newParentObject->attribute( 'section_id' ) );
                 }
             }
 


### PR DESCRIPTION
Right now, moved content section is updated, if:

- it is the main location (https://github.com/ezsystems/ezpublish-legacy/blob/2019.03/kernel/classes/ezcontentobjecttreenodeoperations.php#L81)
- AND moved content section is not the same as new parents (https://github.com/ezsystems/ezpublish-legacy/blob/2019.03/kernel/classes/ezcontentobjecttreenodeoperations.php#L86)
- AND moved content section is the same as its old parent content section (https://github.com/ezsystems/ezpublish-legacy/blob/2019.03/kernel/classes/ezcontentobjecttreenodeoperations.php#L91)

This PR disables the last condition.