### PR TITLE
Updated dbupdate scripts so they will no longer fail when there are multiple users with the same e-mail

### DIFF
--- a/update/database/mysql/5.0/dbupdate-4.7.0-to-5.0.0.sql
+++ b/update/database/mysql/5.0/dbupdate-4.7.0-to-5.0.0.sql
@@ -15,7 +15,7 @@ UPDATE ezcobj_state_group_language SET real_language_id = language_id & ~1;
 ALTER TABLE ezgeneral_digest_user_settings ADD COLUMN user_id int(11) NOT NULL default '0';
 DELETE FROM ezgeneral_digest_user_settings WHERE address NOT IN (SELECT email FROM ezuser);
 UPDATE ezgeneral_digest_user_settings SET user_id = (SELECT ezuser.contentobject_id
-           FROM ezuser WHERE ezuser.email = ezgeneral_digest_user_settings.address);
+           FROM ezuser WHERE ezuser.email = ezgeneral_digest_user_settings.address LIMIT 1);
 ALTER TABLE ezgeneral_digest_user_settings ADD UNIQUE INDEX ezgeneral_digest_user_id (user_id);
 ALTER TABLE ezgeneral_digest_user_settings DROP COLUMN address;
 ALTER TABLE ezuser ADD INDEX ezuser_login (login);

--- a/update/database/postgresql/5.0/dbupdate-4.7.0-to-5.0.0.sql
+++ b/update/database/postgresql/5.0/dbupdate-4.7.0-to-5.0.0.sql
@@ -14,7 +14,7 @@ UPDATE ezcobj_state_group_language SET real_language_id = language_id & ~1;
 ALTER TABLE ezgeneral_digest_user_settings ADD user_id integer DEFAULT 0 NOT NULL;
 DELETE FROM ezgeneral_digest_user_settings WHERE address NOT IN (SELECT email FROM ezuser);
 UPDATE ezgeneral_digest_user_settings SET user_id = (SELECT ezuser.contentobject_id
-           FROM ezuser WHERE ezuser.email = ezgeneral_digest_user_settings.address);
+           FROM ezuser WHERE ezuser.email = ezgeneral_digest_user_settings.address LIMIT 1);
 CREATE INDEX ezgeneral_digest_user_id ON ezgeneral_digest_user_settings USING btree (user_id);
 ALTER TABLE ezgeneral_digest_user_settings DROP COLUMN address;
 CREATE INDEX ezuser_login ON ezuser USING btree (login);


### PR DESCRIPTION
In some edge cases there may be more than one user returned when executing:
`SELECT ezuser.contentobject_id FROM ezuser WHERE ezuser.email = ezgeneral_digest_user_settings.address` which result in migration script failing with error:
`ERROR 1242 (21000): Subquery returns more than 1 row`

This PR fixes this, limiting the query to return a single row.