### PR TITLE
Fix: Missing ob_end_clean()

### DIFF
--- a/kernel/classes/datatypes/ezbinaryfile/plugins/ezpdfparser.php
+++ b/kernel/classes/datatypes/ezbinaryfile/plugins/ezpdfparser.php
@@ -39,6 +39,7 @@ class eZPDFParser
         // fill the buffer with the old values
         ob_start();
         print( $buffer );
+        ob_end_clean();
 
         return $metaData;
     }


### PR DESCRIPTION
Without this line in commands the output is buffered till the script is ended.