### PR TITLE
Fix transformURI() on ignoreIndexDir & ! htmlEscape

### DIFF
--- a/lib/ezutils/classes/ezuri.php
+++ b/lib/ezutils/classes/ezuri.php
@@ -605,7 +605,7 @@ class eZURI
             $modifiedHref = eZClusterFileHandler::instance()->applyServerUri( $trimmedHref );
             if ( $modifiedHref != $trimmedHref )
             {
-                $href = $htmlEscape ? self::escapeHtmlTransformUri( $href ) : $href;
+                $href = $htmlEscape ? self::escapeHtmlTransformUri( $href ) : $modifiedHref;
                 return true;
             }
             unset( $modifiedHref );

--- a/lib/ezutils/classes/ezuri.php
+++ b/lib/ezutils/classes/ezuri.php
@@ -605,7 +605,7 @@ class eZURI
             $modifiedHref = eZClusterFileHandler::instance()->applyServerUri( $trimmedHref );
             if ( $modifiedHref != $trimmedHref )
             {
-                $href = $htmlEscape ? self::escapeHtmlTransformUri( $href ) : $modifiedHref;
+                $href = $htmlEscape ? self::escapeHtmlTransformUri( $modifiedHref ) : $modifiedHref;
                 return true;
             }
             unset( $modifiedHref );


### PR DESCRIPTION
Fix of issue introduced in 07de12622320c4648dd03d20647ac012a1411d90 `Fix EZP-23086: Image thumbnail not shown on backend if alias contains quotes` when escaping was introduced.