### PR TITLE
Show images after used url_prefix

### DIFF
--- a/extension/ezjscore/classes/ezjscajaxcontent.php
+++ b/extension/ezjscore/classes/ezjscajaxcontent.php
@@ -478,7 +478,8 @@ class ezjscAjaxContent
                                     (string)$element, 'UTF-8'
                                 );
                             }
-                            if($key === 'url') {
+                            if( $key === 'url' )
+                            {
                                 eZURI::transformURI( $element, true );
                             }
                         }

--- a/extension/ezjscore/classes/ezjscajaxcontent.php
+++ b/extension/ezjscore/classes/ezjscajaxcontent.php
@@ -478,6 +478,9 @@ class ezjscAjaxContent
                                     (string)$element, 'UTF-8'
                                 );
                             }
+                            if($key === 'url') {
+                                eZURI::transformURI( $element, true );
+                            }
                         }
                     );
 

--- a/extension/ezoe/design/standard/javascript/ezoe/popup_utils.js
+++ b/extension/ezoe/design/standard/javascript/ezoe/popup_utils.js
@@ -843,7 +843,7 @@ var eZOEPopupUtils = {
                    {
                        tag = document.createElement("span");
                        tag.className = 'image_preview';
-                       var previewUrl = ed.settings.ez_root_url + encodeURI( n.data_map[ n.image_attributes[imageIndex] ].content[eZOEPopupUtils.settings.browseImageAlias].url )
+                       var previewUrl = encodeURI( n.data_map[ n.image_attributes[imageIndex] ].content[eZOEPopupUtils.settings.browseImageAlias].url )
                        tag.innerHTML += ' <a href="#">' + ed.getLang('preview.preview_desc')  + '<img src="' + previewUrl + '" /></a>';
                        td.appendChild( tag );
                        hasImage = true;

--- a/extension/ezoe/design/standard/templates/ezoe/tag_embed_images.tpl
+++ b/extension/ezoe/design/standard/templates/ezoe/tag_embed_images.tpl
@@ -55,7 +55,7 @@ tinyMCEPopup.onInit.add( eZOEPopupUtils.BIND( eZOEPopupUtils.init, window, {
         else
         {
            var imageAtr   = eZOEPopupUtils.embedObject['data_map'][ imageAttributes[0] ], imageSizeObj = imageAtr['content'][ args['alt'] ];
-           args['src']    = ed.settings.ez_root_url + imageSizeObj['url'];
+           args['src']    = imageSizeObj['url'];
            args['title']  = eZOEPopupUtils.safeHtml( imageAtr['alternative_text'] || eZOEPopupUtils.embedObject['name'] );
            args['width']  = imageSizeObj['width'];
            args['height'] = imageSizeObj['height'];
@@ -153,7 +153,7 @@ function loadImageSize( e, el )
     }
     else if ( attribObj[size] )
     {
-        previewImageNode.attr( 'src', eds.ez_root_url + attribObj[size]['url'] );
+        previewImageNode.attr( 'src', attribObj[size]['url'] );
         tinyMCEPopup.resizeToInnerSize();
     }
     else
@@ -165,7 +165,7 @@ function loadImageSize( e, el )
             {
                 var size = jQuery('#embed_size_source').val(), imageAttributes = eZOEPopupUtils.embedObject['image_attributes'];
                 eZOEPopupUtils.embedObject['data_map'][ imageAttributes[0] ]['content'][ size ] = data['content']['data_map'][ imageAttributes[0] ]['content'][ size ];
-                previewImageNode.attr( 'src', eds.ez_root_url + eZOEPopupUtils.embedObject['data_map'][ imageAttributes[0] ]['content'][ size ]['url'] );
+                previewImageNode.attr( 'src', eZOEPopupUtils.embedObject['data_map'][ imageAttributes[0] ]['content'][ size ]['url'] );
             }
         });
     }

--- a/extension/ezoe/ezxmltext/handlers/input/ezoexmlinput.php
+++ b/extension/ezoe/ezxmltext/handlers/input/ezoexmlinput.php
@@ -1208,7 +1208,8 @@ class eZOEXMLInput extends eZXMLInputHandler
                             if ( $content->hasAttribute( $size ) )
                             {
                                 $imageAlias  = $content->imageAlias( $size );
-                                $srcString   = $URL . '/' . $imageAlias['url'];
+                                eZURI::transformURI( $imageAlias['url'], true );
+                                $srcString   = $imageAlias['url'];
                                 $imageWidth  = $imageAlias['width'];
                                 $imageHeight = $imageAlias['height'];
                                 break;


### PR DESCRIPTION
After using AWS S3 as the source of external images, they do not appear in the rich text editor and in the modal of inserting images, this pull request will be resolved this problem.