### PR TITLE
PHP7.2 fix: Added array check before count.

### DIFF
--- a/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
+++ b/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
@@ -76,7 +76,7 @@ class eZObjectRelationListType extends eZDataType
             // If in browse mode and relations have been added using the search field
             // items are stored in the post variable
             if (
-                is_array( $http->postVariable( $postVariableName ) )
+                $http->hasPostVariable( $postVariableName )
                 && $http->postVariable( $postVariableName ) != array( "no_relation" )
                 && count( $http->postVariable( $postVariableName ) ) > 0
             )

--- a/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
+++ b/kernel/classes/datatypes/ezobjectrelationlist/ezobjectrelationlisttype.php
@@ -76,7 +76,8 @@ class eZObjectRelationListType extends eZDataType
             // If in browse mode and relations have been added using the search field
             // items are stored in the post variable
             if (
-                $http->postVariable( $postVariableName ) != array( "no_relation" )
+                is_array( $http->postVariable( $postVariableName ) )
+                && $http->postVariable( $postVariableName ) != array( "no_relation" )
                 && count( $http->postVariable( $postVariableName ) ) > 0
             )
             {


### PR DESCRIPTION
The call to get a post variable `$http->postVariable( $postVariableName )` sometimes returned `null`.
Resulting in `count(null)`, which triggers a warning.

Ref. phpdoc changelog for count: 
[https://www.php.net/manual/en/function.count.php#refsect1-function.count-changelog](https://www.php.net/manual/en/function.count.php#refsect1-function.count-changelog)