### PR TITLE
Travis: Drop missing 5.5 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
 # Aim to run tests on all versions of php, make sure each db is run at least once
 matrix:
   include:
-    - php: 5.5
+    - php: 5.6
       env: DB="postgresql" DB_USER="postgres"
     - php: 5.6
       env: DB="mysql" DB_USER="root"


### PR DESCRIPTION
The 5.5 builds fail as the archive no longer exists. This PR switches to 5.6 rather than dropping the build entirely, in order to keep a postgres build on 5.x.

`5.5 is not pre-installed; installing`

`Downloading archive: https://storage.googleapis.com/travis-ci-language-archives/php/binaries/ubuntu/16.04/x86_64/php-5.5.tar.bz2`

`$ curl -sSf --retry 5 -o archive.tar.bz2 $archive_url && tar xjf archive.tar.bz2 --directory /`

`curl: (22) The requested URL returned error: 404 Not Found`