### PR TITLE
Send unhandled exception error messages to `error_log()`.

### DIFF
--- a/lib/ezutils/classes/ezexecution.php
+++ b/lib/ezutils/classes/ezexecution.php
@@ -202,7 +202,9 @@ class eZExecution
             }
         }
 
-        eZLog::write( 'Unexpected error, the message was : ' . $e->getMessage() . ' in ' . $e->getFile() . ' on line ' . $e->getLine(), 'error.log' );
+        $msg = 'Unexpected error, the message was : ' . $e->getMessage() . ' in ' . $e->getFile() . ' on line ' . $e->getLine();
+        eZLog::write( $msg, 'error.log' );
+        error_log( $msg );
 
         eZExecution::cleanup();
         eZExecution::setCleanExit();


### PR DESCRIPTION
Before PHP 7 fatal errors was written to whatever PHP's `error_log` was set to. In PHP 7 most errors are exceptions, so eZ ends up swallowing everything, including fatal errors, in it's default exception handler and logging to its own `var/log/error.log` file. This file is, by default, is *heavily* rotated after only 250KB. This means it's very easy to lose important error messages.