### PR TITLE
EZP-32018: Fixed empty ezdate field transformation

### DIFF
--- a/lib/ezutils/classes/eztimestamp.php
+++ b/lib/ezutils/classes/eztimestamp.php
@@ -15,7 +15,9 @@ class eZTimestamp
     */
     public static function getUtcTimestampFromLocalTimestamp( $localTimestamp ) {
 
-        if (!$localTimestamp) return null;
+        if (!$localTimestamp) {
+            return null;
+        }
 
         $utcTimezone = new \DateTimeZone( 'UTC' );
         $localTimezone = new \DateTimeZone( date_default_timezone_get() );
@@ -32,7 +34,9 @@ class eZTimestamp
     */
     public static function getLocalTimestampFromUtcTimestamp( $utcTimestamp ) {
 
-        if (!$utcTimestamp) return null;
+        if (!$utcTimestamp) {
+            return null;
+        }
 
         $utcTimezone = new \DateTimeZone( 'UTC' );
         $localTimezone = new \DateTimeZone( date_default_timezone_get() );

--- a/lib/ezutils/classes/eztimestamp.php
+++ b/lib/ezutils/classes/eztimestamp.php
@@ -15,7 +15,8 @@ class eZTimestamp
     */
     public static function getUtcTimestampFromLocalTimestamp( $localTimestamp ) {
 
-        if (!$localTimestamp) {
+        if ( !$localTimestamp )
+        {
             return null;
         }
 
@@ -34,7 +35,8 @@ class eZTimestamp
     */
     public static function getLocalTimestampFromUtcTimestamp( $utcTimestamp ) {
 
-        if (!$utcTimestamp) {
+        if ( !$utcTimestamp )
+        {
             return null;
         }
 

--- a/lib/ezutils/classes/eztimestamp.php
+++ b/lib/ezutils/classes/eztimestamp.php
@@ -14,6 +14,9 @@ class eZTimestamp
      \return a timestamp in UTC
     */
     public static function getUtcTimestampFromLocalTimestamp( $localTimestamp ) {
+
+        if (!$localTimestamp) return null;
+
         $utcTimezone = new \DateTimeZone( 'UTC' );
         $localTimezone = new \DateTimeZone( date_default_timezone_get() );
 
@@ -28,6 +31,9 @@ class eZTimestamp
      \return a timestamp in timezone defined in php.ini
     */
     public static function getLocalTimestampFromUtcTimestamp( $utcTimestamp ) {
+
+        if (!$utcTimestamp) return null;
+
         $utcTimezone = new \DateTimeZone( 'UTC' );
         $localTimezone = new \DateTimeZone( date_default_timezone_get() );
 


### PR DESCRIPTION
JIRA issue: [EZP-32018](https://jira.ez.no/browse/EZP-32018)

Empty field value for `ezdate` fieldtype has been handled additionally.

